### PR TITLE
Explore how to prove first implementation obligation for fake/trivial implementation

### DIFF
--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -52,11 +52,6 @@ module LibraBFT.Abstract.Properties
        → vMember v' ≡ α → HasBeenSent v'
        → vRound v ≡ vRound v'
        → vBlockUID v ≡ vBlockUID v'
-       -- NOTE: It is interesting that this does not require the timeout signature (or even
-       -- presence/lack thereof) to be the same.  The abstract proof goes through without out it, so I
-       -- am leaving it out for now, but I'm curious what if anything could go wrong if an honest
-       -- author can send different votes for the same epoch and round that differ on timeout
-       -- signature.  Maybe something for liveness?
 
   proof : Type → StaticInv.VotesOnlyOnceRule 𝓢
   proof glob-inv α hα {q} {q'} q∈sys q'∈sys va va' VO≡

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -214,7 +214,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
      PredStep-wlog-ht' {pre = pre} preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈pool ver ver' hpk eids≡ r≡
      -- (1) The first step is branching on whether 'v' above is a /new/ vote or not.
      -- (1.1) If it's new:
-       with sps-corr pre {- preach -} hpk ps m∈outs v⊂m ver
+       with sps-corr pre preach hpk ps m∈outs v⊂m ver
      ...| inj₁ (vValid , vNew)
        with honestPartValid preach hpk v'⊂m' m'∈pool ver'
      ...| v'Old , vOldValid
@@ -285,7 +285,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
      -- Since the step is from an honest peer, we can check whether the messages are in fact
      -- new or not.
      PredStep-hh' {pre = pre} preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
-       with sps-corr pre {- preach -} hpk ps m∈outs v⊂m ver | sps-corr pre {- preach -} hpk ps m'∈outs v'⊂m' ver'
+       with sps-corr pre preach hpk ps m∈outs v⊂m ver | sps-corr pre preach hpk ps m'∈outs v'⊂m' ver'
      -- (A) Both are old: call induction hypothesis
      ...| inj₂ vOld            | inj₂ v'Old = hip hpk ver vOld ver' v'Old e≡ r≡
 

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -60,7 +60,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    -- If v is really new and valid
      -- Note that this does not directly exclude possibility of previous message with
      -- same signature, but sent by someone else.  We could prove it implies it though.
-   → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre)) → ValidPartForPK (availEpochs pre) v pk
+   → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre)) → ValidPartForPKandPeer (availEpochs pre) v pk pid
    -- And if there exists another v' that has been sent before
    → v' ⊂Msg m' → (sndr , m') ∈ (msgPool pre) → WithVerSig pk v'
    -- If v and v' share the same epoch and round
@@ -80,11 +80,11 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    -- For every vote v represented in a message output by the call
    → v  ⊂Msg m  → m ∈ outs → (sig : WithVerSig pk v)
    -- If v is really new and valid
-   → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre)) → ValidPartForPK (availEpochs pre) v pk
+   → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre)) → ValidPartForPKandPeer (availEpochs pre) v pk pid
 
    -- And if there exists another v' that is also new and valid
    → v' ⊂Msg m'  → m' ∈ outs → (sig' : WithVerSig pk v')
-   → ¬ (MsgWithSig∈ pk (ver-signature sig') (msgPool pre)) → ValidPartForPK (availEpochs pre) v' pk
+   → ¬ (MsgWithSig∈ pk (ver-signature sig') (msgPool pre)) → ValidPartForPKandPeer (availEpochs pre) v' pk pid
 
    -- If v and v' share the same epoch and round
    → (v ^∙ vEpoch) ≡ (v' ^∙ vEpoch)

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -214,7 +214,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
      PredStep-wlog-ht' {pre = pre} preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈pool ver ver' hpk eids≡ r≡
      -- (1) The first step is branching on whether 'v' above is a /new/ vote or not.
      -- (1.1) If it's new:
-       with sps-corr preach hpk ps m∈outs v⊂m ver
+       with sps-corr pre {- preach -} hpk ps m∈outs v⊂m ver
      ...| inj₁ (vValid , vNew)
        with honestPartValid preach hpk v'⊂m' m'∈pool ver'
      ...| v'Old , vOldValid
@@ -284,8 +284,8 @@ module LibraBFT.Concrete.Properties.VotesOnce where
              → (v ^∙ vProposed ∙ biId) ≡ (v' ^∙ vProposed ∙ biId)
      -- Since the step is from an honest peer, we can check whether the messages are in fact
      -- new or not.
-     PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
-       with sps-corr preach hpk ps m∈outs v⊂m ver | sps-corr preach hpk ps m'∈outs v'⊂m' ver'
+     PredStep-hh' {pre = pre} preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
+       with sps-corr pre {- preach -} hpk ps m∈outs v⊂m ver | sps-corr pre {- preach -} hpk ps m'∈outs v'⊂m' ver'
      -- (A) Both are old: call induction hypothesis
      ...| inj₂ vOld            | inj₂ v'Old = hip hpk ver vOld ver' v'Old e≡ r≡
 

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -26,7 +26,7 @@ module LibraBFT.Impl.Handle
   (hash-cr : ∀{x y} → hash x ≡ hash y → Collision hash x y ⊎ x ≡ y)
   where
 
- open import LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor hash hash-cr
+ open import LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor hash hash-cr public
  open import LibraBFT.Impl.NetworkMsg
 
  postulate

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -51,7 +51,7 @@ module LibraBFT.Impl.Properties.Aux where
                                   -- previously with the same signature.
   ...| withVoteSIHighCC x = {!!}
 
-  impl-sps-avp {pk = pk} {α = α} {st = st} preach hpk (step-msg {sndr , P pm} m∈pool ps≡ eff) m∈outs v⊂m ver
+  impl-sps-avp {pk = pk} {α = α} st hpk (step-msg {sndr , P pm} m∈pool ps≡ eff) m∈outs v⊂m ver
      | here refl
      | vote∈vm {v} {si}
      with MsgWithSig∈? {pk} {ver-signature ver} {msgPool st}

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -30,11 +30,11 @@ module LibraBFT.Impl.Properties.Aux where
 
   impl-sps-avp : StepPeerState-AllValidParts
   -- In our fake/simple implementation, init and handling V and C msgs do not send any messages
-  impl-sps-avp _ hpk (step-init ix eff) m∈outs part⊂m ver        rewrite (cong proj₂ eff) = ⊥-elim (¬Any[] m∈outs)
-  impl-sps-avp _ hpk (step-msg {sndr , V vm} _ _ eff) m∈outs _ _ rewrite (cong proj₂ eff) = ⊥-elim (¬Any[] m∈outs)
-  impl-sps-avp _ hpk (step-msg {sndr , C cm} _ _ eff) m∈outs _ _ rewrite (cong proj₂ eff) = ⊥-elim (¬Any[] m∈outs)
+  impl-sps-avp _ _ hpk (step-init ix eff) m∈outs part⊂m ver        rewrite (cong proj₂ eff) = ⊥-elim (¬Any[] m∈outs)
+  impl-sps-avp _ _ hpk (step-msg {sndr , V vm} _ _ eff) m∈outs _ _ rewrite (cong proj₂ eff) = ⊥-elim (¬Any[] m∈outs)
+  impl-sps-avp _ _ hpk (step-msg {sndr , C cm} _ _ eff) m∈outs _ _ rewrite (cong proj₂ eff) = ⊥-elim (¬Any[] m∈outs)
   -- These aren't true yet, because processProposalMsgM sends fake votes that don't follow the rules for ValidPartForPK
-  impl-sps-avp preach hpk (step-msg {sndr , P pm} m∈pool ps≡ eff) m∈outs v⊂m ver
+  impl-sps-avp st preach hpk (step-msg {sndr , P pm} m∈pool ps≡ eff) m∈outs v⊂m ver
      with m∈outs
      -- Handler sends at most one vote, so it can't be "there"
   ...| there {xs = xs} imp rewrite proj₂ (∷-injective (cong proj₂ eff)) = ⊥-elim (¬Any[] imp)
@@ -51,7 +51,7 @@ module LibraBFT.Impl.Properties.Aux where
                                   -- previously with the same signature.
   ...| withVoteSIHighCC x = {!!}
 
-  impl-sps-avp {pk = pk} {α = α} st hpk (step-msg {sndr , P pm} m∈pool ps≡ eff) m∈outs v⊂m ver
+  impl-sps-avp {pk = pk} {α = α} st preach hpk (step-msg {sndr , P pm} m∈pool ps≡ eff) m∈outs v⊂m ver
      | here refl
      | vote∈vm {v} {si}
      with MsgWithSig∈? {pk} {ver-signature ver} {msgPool st}

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -62,5 +62,5 @@ module LibraBFT.Impl.Properties.Aux where
                                                refl
                                                {! !}       -- The implementation will need to check that the voter is a member of
                                                            -- the epoch of the message it's sending.
-                                               refl)
+                                               refl , {!!})
                         , msg∉)

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -197,11 +197,11 @@ module LibraBFT.Impl.Properties.VotesOnce where
   ...| inj₂ sentb4 = ⊥-elim (¬sentb4 sentb4)
   ...| inj₁ ((vpk'' , sender) , _) rewrite msgSameSig mws = WhatWeWant-transp* www step*
 
-  vo₁-unwind2 : VO.ImplObligation₁
+  vo₁ : VO.ImplObligation₁
   -- Initialization doesn't send any messages at all so far.  In future it may send messages, but
   -- probably not containing Votes?
-  vo₁-unwind2 r (step-init _ eff) _ _ m∈outs _ _ _ _ _ _ _ _ rewrite cong proj₂ eff = ⊥-elim (¬Any[] m∈outs)
-  vo₁-unwind2 {e} {pk = pk} {pre = pre} r sm@(step-msg {s = ps} {s' = ps'} _ ps≡ _) {v' = v'} hpk v⊂m m∈outs sig ¬sentb4 (vpb , refl) v'⊂m' m'∈pool sig' eIds≡ rnds≡
+  vo₁ r (step-init _ eff) _ _ m∈outs _ _ _ _ _ _ _ _ rewrite cong proj₂ eff = ⊥-elim (¬Any[] m∈outs)
+  vo₁ {e} {pk = pk} {pre = pre} r sm@(step-msg {s = ps} {s' = ps'} _ ps≡ _) {v' = v'} hpk v⊂m m∈outs sig ¬sentb4 (vpb , refl) v'⊂m' m'∈pool sig' eIds≡ rnds≡
      -- Use unwind to find the step that first sent the signature for v', then Any-Step-elim to
      -- prove that going from the post state of that step to pre results in a state in which the
      -- round of v' is at most the last voted round recorded in the peerState of pid (the peer that
@@ -231,5 +231,5 @@ module LibraBFT.Impl.Properties.VotesOnce where
   -- TODO-1: this may be overly complicated now that rnd≡ is an equality
   ...| refl rewrite rnds≡ = ⊥-elim (<⇒≢ (≤-reflexive suclvr≡v'rnd) (≤-antisym (<⇒≤ (≤-reflexive suclvr≡v'rnd)) v'rnd≤lvr))
 
---   postulate  -- TODO : prove
---     vo₂ : VO.ImplObligation₂
+  postulate  -- TODO : prove
+    vo₂ : VO.ImplObligation₂

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -128,8 +128,15 @@ module LibraBFT.Impl.Properties.VotesOnce where
                      → (theStep : Step pre post)
                      → WhatWeWant pk sig pre
                      → WhatWeWant pk sig post
-  WhatWeWant-transp {e} {pre = pre} {post} (step-epoch ec) (mkWhatWeWant origE origSt mws vpk origSndr refl ij lvr) = mkWhatWeWant origE origSt mws (ValidPartForPK-stable-epoch ec vpk) origSndr {!!} ij lvr
-  WhatWeWant-transp {pre = pre} {post} (step-peer sps) (mkWhatWeWant origE origSt mws vpk origSndr refl ij lvr) = mkWhatWeWant origE origSt mws vpk origSndr refl {!!} {!!} 
+  WhatWeWant-transp {e} {pre = pre} {post} (step-epoch ec) (mkWhatWeWant origE origSt mws vpk origSndr refl ij lvr) =
+    mkWhatWeWant origE origSt mws (ValidPartForPK-stable-epoch ec vpk) origSndr (epochPreservestoNodeId vpk) ij lvr
+  WhatWeWant-transp {pre = pre} {post} sp@(step-peer {pid = pid} {st'} sps) (mkWhatWeWant origE origSt mws vpk origSndr xxx ij lvr)
+     with origSndr ≟ℕ pid
+  ...| no diff rewrite Map-set-target-≢ {k = pid} {k' = origSndr} {mv = st'} {m = peerStates pre} diff =
+               mkWhatWeWant origE origSt mws vpk origSndr xxx ij lvr
+  ...| yes same = mkWhatWeWant origE origSt mws vpk origSndr xxx
+                               (initializedStableStep sp ij)
+                               (≤-trans lvr {! !})  -- I think I can do this one.  Famous last words?
   
   WhatWeWant-transp* : ∀ {e e' pk sig} {start : SystemState e}{final : SystemState e'}
                      → WhatWeWant pk sig start

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -92,7 +92,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
   -- Initialization doesn't send any messages at all so far.  In future it may send messages, but
   -- probably not containing Votes?
   vo₁-unwind2 r (step-init _ eff) _ _ m∈outs _ _ _ _ _ _ _ _ rewrite cong proj₂ eff = ⊥-elim (¬Any[] m∈outs)
-  vo₁-unwind2 {e} {pid} {pk = pk} {pre = pre} r (step-msg {s = ps} m∈pool ps≡ xx) {v' = v'} {m' = m'} hpk v⊂m m∈outs sig ¬sentb4 vpb v'⊂m' m'∈pool sig' eIds≡ rnds≡
+  vo₁-unwind2 {e} {pid} {pk = pk} {pre = pre} r (step-msg {s = ps} m∈pool ps≡ xx) {v' = v'} {m' = m'} hpk v⊂m m∈outs sig ¬sentb4 (vpb , pid≡) v'⊂m' m'∈pool sig' eIds≡ rnds≡
      with Any-Step-elim (whatWeWant {v' = v'} {pk})
                         (Any-Step-⇒ (λ _ ivnp → isValidNewPart⇒fSE ivnp)
                                     (unwind r hpk v'⊂m' m'∈pool sig'))

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -60,12 +60,12 @@ module LibraBFT.Impl.Properties.VotesOnce where
   firstSendEstablishes : Vote → PK → SystemStateRel Step
   firstSendEstablishes _ _ (step-epoch _) = ⊥ 
   firstSendEstablishes _ _ (step-peer (step-cheat _ _)) = ⊥
-  firstSendEstablishes v' pk {e} {.e} sysStep@(step-peer {pid = pid} {pre = pre} pstep@(step-honest {st = pst} {outs} _)) =
+  firstSendEstablishes v' pk {e} {.e} sysStep@(step-peer {pid = pid'} {pre = pre} pstep@(step-honest {st = pst} {outs} _)) =
     let post = StepPeer-post pstep
-     in Map-lookup pid (peerStates post) ≡ just pst
+     in Map-lookup pid' (peerStates post) ≡ just pst
       × Σ (IsValidNewPart (₋vSignature v') pk sysStep)
           λ ivnp → let (_ , (_ , vpb)) = ivnp
-                    in ( EpochConfig.toNodeId (vp-ec vpb) (vp-member vpb) ≡ pid)
+                    in ( EpochConfig.toNodeId (vp-ec vpb) (vp-member vpb) ≡ pid')
                        × ∃[ v ] ( v ^∙ vEpoch < e
                                 × v ^∙ vRound ≤ (₋epEC pst) ^∙ epLastVotedRound
                                 × Σ (WithVerSig pk v)

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -79,6 +79,8 @@ module LibraBFT.Impl.Properties.VotesOnce where
                      → IsValidNewPart (₋vSignature v') pk theStep
                      → firstSendEstablishes v' pk theStep
 
+    -- We will use impl-sps-avp to establish the first conjunct of firstsendestablishes; it no
+    -- longer needs to know its pre-state is reachable, which is inconvenient to know here.
     whatWeWant : ∀ {e e' e'' v' pk}{pre : SystemState e} {post : SystemState e'}{final : SystemState e''} {theStep : Step pre post}
                → firstSendEstablishes v' pk theStep
                → Step* post final

--- a/LibraBFT/Impl/Util/Crypto.agda
+++ b/LibraBFT/Impl/Util/Crypto.agda
@@ -92,9 +92,11 @@ module LibraBFT.Impl.Util.Crypto where
   ...| inj₂ _     | inj₁ hb   = inj₁ hb
   ...| inj₂ prop≡ | inj₂ par≡ = inj₂ (VoteData-η prop≡ par≡)
 
+  lIHashes : LedgerInfo → List HashValue
+  lIHashes (mkLedgerInfo ci cdh) = hashBI ci ∷ cdh ∷ []
+
   hashLI : LedgerInfo → HashValue
-  hashLI (mkLedgerInfo commitInfo consensusDataHash) =
-    hash-concat (hashBI commitInfo ∷ consensusDataHash ∷ [])
+  hashLI = hash-concat ∘ lIHashes
 
   hashLI-inj : ∀ {li1 li2} → hashLI li1 ≡ hashLI li2 → NonInjective-≡ sha256 ⊎ li1 ≡ li2
   hashLI-inj {mkLedgerInfo ci1 cd1} {mkLedgerInfo ci2 cd2} prf

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -210,3 +210,9 @@ module LibraBFT.Lemmas where
  to-witness-isJust-≡ {aMB = just a'} {a} {prf}
     with to-witness-lemma (isJust {aMB = just a'} {a} prf) refl
  ...| xxx = just-injective (trans (sym xxx) prf)
+
+ to-witness-known-value : ∀ {ℓ}{A : Set ℓ} {aMB a}
+                        → (ij : Is-just {ℓ} {A} aMB)
+                        → aMB ≡ just a
+                        → a ≡ to-witness ij
+ to-witness-known-value (just x) refl = refl

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -36,6 +36,9 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
      vp-key             : getPubKey vp-ec vp-member ≡ pk
  open ValidPartForPK public
 
+ ValidPartForPKandPeer : ∀ {e}(𝓔s : AvailableEpochs e)(part : Part)(pk : PK) (pid : PeerId) → Set
+ ValidPartForPKandPeer 𝓔s part pk pid = Σ (ValidPartForPK 𝓔s part pk) λ vp → EpochConfig.toNodeId (vp-ec vp) (vp-member vp) ≡ pid
+
  -- A valid part remains valid when new epochs are added
  ValidPartForPK-stable-epoch : ∀{e part pk}{𝓔s : AvailableEpochs e}(𝓔 : EpochConfigFor e)
                           → ValidPartForPK 𝓔s part pk
@@ -85,7 +88,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
                                  -- NOTE: this doesn't DIRECTLY imply that nobody else has sent a
                                  -- message with the same signature just that the author of the part
                                  -- hasn't.
-   → (ValidPartForPK 𝓔s part pk × ¬ (MsgWithSig∈ pk (ver-signature ver) (msgPool st)))
+   → (ValidPartForPKandPeer 𝓔s part pk α × ¬ (MsgWithSig∈ pk (ver-signature ver) (msgPool st)))
    ⊎ MsgWithSig∈ pk (ver-signature ver) (msgPool st)
 
  -- A /part/ was introduced by a specific step when:
@@ -143,7 +146,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
         | (m , refl , m∈outs)
         | inj₁ (valid-part , notBefore) =
                step-here tr (notBefore , MsgWithSig∈-++ˡ (mkMsgWithSig∈ _ _ p⊂m β thisStep sig refl)
-                                       , valid-part)
+                                       , proj₁ valid-part)
 
      -- Unwind is inconvenient to use by itself because we have to do
      -- induction on Any-Step-elim. The 'honestPartValid' property below
@@ -200,7 +203,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
         | inj₁ thisStep
         | step-honest x
        with Any-satisfied-∈ (Any-map⁻ thisStep)
-     ...| (m , refl , m∈outs) = ⊎-map proj₁ MsgWithSig∈-++ʳ (sps-avp st hpk x m∈outs p⊆m sig)
+     ...| (m , refl , m∈outs) = ⊎-map (proj₁ ∘ proj₁) MsgWithSig∈-++ʳ (sps-avp st hpk x m∈outs p⊆m sig)
 
      -- The ext-unforgeability' property can be collapsed in a single clause.
 
@@ -260,7 +263,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
         with Any-satisfied-∈ (Any-map⁻ thisStep)
      ...| (m' , refl , m∈outs)
         with sps-avp preach hpk sps m∈outs (msg⊆ mws) (msgSigned mws)
-     ...| inj₁ (vpbα₀ , _) = mws , vpbα₀
+     ...| inj₁ (vpbα₀ , _) = mws , proj₁ vpbα₀
      ...| inj₂ mws'
         with msgWithSigSentByAuthor preach hpk mws'
      ...| mws'' , vpb'' rewrite sym (msgSameSig mws) = MsgWithSig∈-++ʳ mws'' , vpb''

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -80,8 +80,11 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
  -- not been included in a previously sent message with the same signature), or (ii) the part been
  -- included in a previously sent message with the same signature.
  StepPeerState-AllValidParts : Set
- StepPeerState-AllValidParts = ∀{e s m part pk outs α}{𝓔s : AvailableEpochs e}{st : SystemState e}
-   → (r : ReachableSystemState st)
+ StepPeerState-AllValidParts = ∀{e s m part pk outs α}{𝓔s : AvailableEpochs e}
+   → (st : SystemState e)
+   --  → (r : ReachableSystemState st) -- TODO-3 (or not!) It's a pain to feed this parameter, and
+                                       -- typical implementations will not need to know that the
+                                       -- state is reachable to know that they obey these rules.
    → Meta-Honest-PK pk
    → StepPeerState α 𝓔s (msgPool st) (Map-lookup α (peerStates st)) s outs
    → m ∈ outs → part ⊂Msg m → (ver : WithVerSig pk part)
@@ -137,7 +140,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
         | step-honest x
        with Any-satisfied-∈ (Any-map⁻ thisStep)
      ...| (m , refl , m∈outs)
-       with sps-avp tr hpk x m∈outs p⊂m sig
+       with sps-avp pre {- tr -} hpk x m∈outs p⊂m sig
      ...| inj₂ sentb4 with unwind tr {p = msgPart sentb4} hpk (msg⊆ sentb4) (msg∈pool sentb4) (msgSigned sentb4)
      ...| res rewrite msgSameSig sentb4 = step-there res
      unwind (step-s tr (step-peer {pid = β} {outs = outs} {pre = pre} sp)) {p} hpk p⊂m m∈sm sig
@@ -203,7 +206,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
         | inj₁ thisStep
         | step-honest x
        with Any-satisfied-∈ (Any-map⁻ thisStep)
-     ...| (m , refl , m∈outs) = ⊎-map (proj₁ ∘ proj₁) MsgWithSig∈-++ʳ (sps-avp st hpk x m∈outs p⊆m sig)
+     ...| (m , refl , m∈outs) = ⊎-map (proj₁ ∘ proj₁) MsgWithSig∈-++ʳ (sps-avp pre {- st -} hpk x m∈outs p⊆m sig)
 
      -- The ext-unforgeability' property can be collapsed in a single clause.
 
@@ -262,7 +265,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
         | inj₁ thisStep
         with Any-satisfied-∈ (Any-map⁻ thisStep)
      ...| (m' , refl , m∈outs)
-        with sps-avp preach hpk sps m∈outs (msg⊆ mws) (msgSigned mws)
+        with sps-avp pre {- preach -} hpk sps m∈outs (msg⊆ mws) (msgSigned mws)
      ...| inj₁ (vpbα₀ , _) = mws , proj₁ vpbα₀
      ...| inj₂ mws'
         with msgWithSigSentByAuthor preach hpk mws'

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -52,17 +52,17 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
    }
 
  postulate -- TODO-1: prove
-   samePKandEpoch⇒sameEC : ∀ {e p1 p2 pk}{𝓔s : AvailableEpochs e}
-                         → (vp1 : ValidPartForPK 𝓔s p1 pk)
-                         → (vp2 : ValidPartForPK 𝓔s p2 pk)
-                         → part-epoch p1 ≡ part-epoch p2
-                         → vp-ec vp2 ≡ vp-ec vp1
+   sameEpoch⇒sameEC : ∀ {e p1 p2 pk}{𝓔s : AvailableEpochs e}
+                    → (vp1 : ValidPartForPK 𝓔s p1 pk)
+                    → (vp2 : ValidPartForPK 𝓔s p2 pk)
+                    → part-epoch p1 ≡ part-epoch p2
+                    → vp-ec vp2 ≡ vp-ec vp1
 
-   samePKandEpoch⇒sameMember : ∀ {e p1 p2 pk}{𝓔s : AvailableEpochs e}
-                           → (vp1 : ValidPartForPK 𝓔s p1 pk)
-                           → (vp2 : ValidPartForPK 𝓔s p2 pk)
-                           → (e≡ : part-epoch p1 ≡ part-epoch p2)
-                           → vp-member vp1 ≡ cast (cong authorsN (samePKandEpoch⇒sameEC vp1 vp2 e≡)) (vp-member vp2)
+   sameEC⇒sameMember : ∀ {e p1 p2 pk}{𝓔s : AvailableEpochs e}
+                     → (vp1 : ValidPartForPK 𝓔s p1 pk)
+                     → (vp2 : ValidPartForPK 𝓔s p2 pk)
+                     → (ecs≡ : vp-ec vp2 ≡ vp-ec vp1)
+                     → toℕ (vp-member vp1) ≡ toℕ (vp-member vp2)
 
  -- A valid part remains valid
  ValidPartForPK-stable : ∀{e e'}{st : SystemState e}{st' : SystemState e'}

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -95,7 +95,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
 
      -- We can unwind the state and highlight the step where a part was
      -- originally sent. This 'unwind' function combined with Any-Step-elim
-     -- enables a powerful form of reasoning. The 'honestVoteEpoch' below
+     -- enables a powerful form of reasoning. The 'honestPartValid' below
      -- exemplifies this well.
      unwind : ∀{e}{st : SystemState e}(tr : ReachableSystemState st)
             → ∀{p m σ pk} → Meta-Honest-PK pk

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -51,6 +51,21 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
    ; vp-key             = vpk
    }
 
+ VPfPK-stable-ec-stable : ∀{e part pk}{𝓔s : AvailableEpochs e}(𝓔 : EpochConfigFor e)
+                          → (vpk : ValidPartForPK 𝓔s part pk)
+                          → vp-ec vpk ≡ vp-ec (ValidPartForPK-stable-epoch 𝓔 vpk)
+ VPfPK-stable-ec-stable _ (mkValidPartForPK _ ec refl _ _) = refl
+ postulate
+   epochPreservestoNodeId : ∀ {e part pk ec}{𝓔s : AvailableEpochs e}
+      → (vpk : ValidPartForPK 𝓔s part pk)
+      → EpochConfig.toNodeId (vp-ec vpk) (vp-member vpk) ≡
+        EpochConfig.toNodeId (vp-ec (ValidPartForPK-stable-epoch ec vpk)) (vp-member (ValidPartForPK-stable-epoch ec vpk))
+
+ VPfPK-stable-member-stable : ∀{e part pk}{𝓔s : AvailableEpochs e}(𝓔 : EpochConfigFor e)
+                          → (vpk : ValidPartForPK 𝓔s part pk)
+                          → toℕ (vp-member (ValidPartForPK-stable-epoch 𝓔 vpk)) ≡ toℕ (vp-member vpk)
+ VPfPK-stable-member-stable _ (mkValidPartForPK _ _ refl mem _) = refl
+
  postulate -- TODO-1: prove
    sameEpoch⇒sameEC : ∀ {e p1 p2 pk}{𝓔s : AvailableEpochs e}
                     → (vp1 : ValidPartForPK 𝓔s p1 pk)

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -48,6 +48,19 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
    ; vp-key             = vpk
    }
 
+ postulate -- TODO-1: prove
+   samePKandEpoch⇒sameEC : ∀ {e p1 p2 pk}{𝓔s : AvailableEpochs e}
+                         → (vp1 : ValidPartForPK 𝓔s p1 pk)
+                         → (vp2 : ValidPartForPK 𝓔s p2 pk)
+                         → part-epoch p1 ≡ part-epoch p2
+                         → vp-ec vp2 ≡ vp-ec vp1
+
+   samePKandEpoch⇒sameMember : ∀ {e p1 p2 pk}{𝓔s : AvailableEpochs e}
+                           → (vp1 : ValidPartForPK 𝓔s p1 pk)
+                           → (vp2 : ValidPartForPK 𝓔s p2 pk)
+                           → (e≡ : part-epoch p1 ≡ part-epoch p2)
+                           → vp-member vp1 ≡ cast (cong authorsN (samePKandEpoch⇒sameEC vp1 vp2 e≡)) (vp-member vp2)
+
  -- A valid part remains valid
  ValidPartForPK-stable : ∀{e e'}{st : SystemState e}{st' : SystemState e'}
                     → Step* st st' → ∀{part pk}

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -331,6 +331,14 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
              → (prf  : Any-Step P cont)
              → Any-Step P (step-s cont this)
 
+ Any-Step-⇒ : ∀ {P Q : SystemStateRel Step}
+            → (∀ {e e'}{pre : SystemState e}{post : SystemState e'} → (x : Step pre post) → P {e} {e'} x → Q {e} {e'} x)
+            → ∀ {e e' fst lst} {tr : Step* {e} {e'} fst lst}
+            → Any-Step P tr
+            → Any-Step Q tr
+ Any-Step-⇒ p⇒q (step-here cont {this} prf) = step-here cont (p⇒q this prf)
+ Any-Step-⇒ p⇒q (step-there anyStep) = step-there (Any-Step-⇒ p⇒q anyStep)
+
  Any-Step-elim
    : ∀{e₀ e₁}{st₀ : SystemState e₀}{st₁ : SystemState e₁}{P : SystemStateRel Step}{Q : Set}
    → {r : Step* st₀ st₁}

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -282,6 +282,11 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
           → Step pre post
           → Step* fst post
 
+ postulate
+   initializedStableStep : ∀ {e e'} {pre : SystemState e} {post : SystemState e'} {pid}
+                         → (theStep : Step pre post)
+                         → Is-just (Map-lookup pid (peerStates pre))
+                         → Is-just (Map-lookup pid (peerStates post))
  ReachableSystemState : ∀{e} → SystemState e → Set
  ReachableSystemState = Step* initialState
 

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -267,6 +267,11 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
                        → m ∈ (ml ++ sm)
                        → m ∈ ml
 
+   cheatStepDNMPeerStates : ∀{e pid st' outs}{pre : SystemState e}
+                          → (theStep : StepPeer pre pid st' outs)
+                          → isCheat theStep
+                          → peerStates (StepPeer-post theStep) ≡ peerStates pre
+
  step-epoch-does-not-send : ∀ {e} (pre : SystemState e) (𝓔 : EpochConfigFor e)
                             → msgPool (pushEpoch 𝓔 pre) ≡ msgPool pre
  step-epoch-does-not-send _ _ = refl
@@ -282,11 +287,6 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
           → Step pre post
           → Step* fst post
 
- postulate
-   initializedStableStep : ∀ {e e'} {pre : SystemState e} {post : SystemState e'} {pid}
-                         → (theStep : Step pre post)
-                         → Is-just (Map-lookup pid (peerStates pre))
-                         → Is-just (Map-lookup pid (peerStates post))
  ReachableSystemState : ∀{e} → SystemState e → Set
  ReachableSystemState = Step* initialState
 

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -203,15 +203,15 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
    -- of the actual EpochConfig for the epoch being initialized.  Later, we
    -- may move to a more general scheme, enabled by assuming a function
    -- 'render : InitPackage -> EpochConfig'.
-   step-init : ∀{ms s' out}(ix : Fin e)
-             → (s' , out) ≡ init pid (AE.lookup' 𝓔s ix) ms
-             → StepPeerState pid 𝓔s pool ms s' out
+   step-init : ∀{ms s' outs}(ix : Fin e)
+             → (s' , outs) ≡ init pid (AE.lookup' 𝓔s ix) ms
+             → StepPeerState pid 𝓔s pool ms s' outs
 
    -- The peer processes a message in the pool
-   step-msg  : ∀{m ms s s' out}
+   step-msg  : ∀{m ms s s' outs}
              → m ∈ pool
-             → ms ≡ just s → (s' , out) ≡ handle pid (proj₂ m) s
-             → StepPeerState pid 𝓔s pool ms s' out
+             → ms ≡ just s → (s' , outs) ≡ handle pid (proj₂ m) s
+             → StepPeerState pid 𝓔s pool ms s' outs
 
  -- The pre-state of the suplied PeerId is related to the post-state and list of output messages iff:
  data StepPeer {e}(pre : SystemState e) : PeerId → Maybe PeerState → List Msg → Set where


### PR DESCRIPTION
Note: This pull request is really to enable discussion and interaction; maybe we'll decide to merge it or go in a different direction.

We explore how to prove ` VO.ImplObligation₁` using `unwind` and `Any-Step-elim`, aided by a new `Any-Step-⇒` that allows us to establish properties of the first transition to send a given signature.

We have made some progress, which has helped to highlight some challenges to discuss, and also to give a sense of what's more painful than it should be, so we can think about how to streamline before moving on to harder properties and/or a more realistic implementation.

A few postulates have been used and not yet proved.  Most are about the implementation handler and are hopefully straightforward.  However, I struggled trying to prove`epochPreservestoNodeId`, which seems like it should be straightforward; would appreciate input from Agda experts).  Apropos of nothing, hi @VictorCMiraldo :-).