### PR TITLE
(Mostly) isolate hash (a concrete notion) from Abstract namespace

### DIFF
--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -4,7 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 

--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -5,7 +5,6 @@
 -}
 {-# OPTIONS --allow-unsolved-metas #-}
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 

--- a/LibraBFT/Abstract/RecordChain.agda
+++ b/LibraBFT/Abstract/RecordChain.agda
@@ -4,7 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 
@@ -495,12 +494,12 @@ module LibraBFT.Abstract.RecordChain
  ...| eq-I = inj₂ (transp-CR rcf≈rc (commit-rule c3 prf))
 
 
- vote≡⇒QPrevHash≡ : {q q' : QC} {v v' : Vote}
-                  → v  ∈ qcVotes q
-                  → v' ∈ qcVotes q'
-                  → v ≡ v'
-                  → qCertBlockId q ≡ qCertBlockId q'
- vote≡⇒QPrevHash≡ {q} {q'} v∈q v'∈q' refl
+ vote≡⇒QPrevId≡ : {q q' : QC} {v v' : Vote}
+                → v  ∈ qcVotes q
+                → v' ∈ qcVotes q'
+                → v ≡ v'
+                → qCertBlockId q ≡ qCertBlockId q'
+ vote≡⇒QPrevId≡ {q} {q'} v∈q v'∈q' refl
      with witness v∈q (qVotes-C3 q) | witness v'∈q' (qVotes-C3 q')
  ... | refl | refl = refl
 

--- a/LibraBFT/Abstract/RecordChain/Invariants.agda
+++ b/LibraBFT/Abstract/RecordChain/Invariants.agda
@@ -4,7 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -4,7 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 
@@ -81,7 +80,7 @@ module LibraBFT.Abstract.RecordChain.Properties
       | tri≈ _ v₀≡v₁ _ =
      let v₀∈q₀ = ∈QC-Vote-correct q₀ a∈q₀
          v₁∈q₁ = ∈QC-Vote-correct q₁ a∈q₁
-         ppp   = trans h₀ (trans (vote≡⇒QPrevHash≡ {q₀} {q₁} v₀∈q₀ v₁∈q₁ (votes-only-once a honest ex₀ ex₁ a∈q₀ a∈q₁ v₀≡v₁))
+         ppp   = trans h₀ (trans (vote≡⇒QPrevId≡ {q₀} {q₁} v₀∈q₀ v₁∈q₁ (votes-only-once a honest ex₀ ex₁ a∈q₀ a∈q₁ v₀≡v₁))
                                  (sym h₁))
      in inj₁ ((b₀ , b₁) , (imp , ppp))
 

--- a/LibraBFT/Abstract/Records.agda
+++ b/LibraBFT/Abstract/Records.agda
@@ -123,8 +123,9 @@ module LibraBFT.Abstract.Records
     }
 
   -- Accessing common fields in different Records types is a nuissance; yet, Blocks,
-  -- votes and QC's all have three important common fields: author, round and prevHash.
-  -- Therefore we declare a type-class that provide "getters" for commonly used fields.
+  -- votes and QC's all have three important common fields: author, round and maybe the
+  -- ID of a previous record.  Therefore we declare a type-class that provide "getters"
+  -- for commonly used fields.
   record HasRound (A : Set) : Set where
     constructor is-librabft-record
     field
@@ -227,7 +228,7 @@ module LibraBFT.Abstract.Records
 
   -- Record unique ids carry whether the abstract id was assigned
   -- to a QC or a Block; this can be useful to avoid having to deal
-  -- with 'blockId ≟ initialAgreedHash' in order to decide whether
+  -- with 'blockId ≟ initialAgreedID' in order to decide whether
   -- a block is the genesis block or not.
   data TypedUID : Set where
     id-I   : TypedUID

--- a/LibraBFT/Abstract/Records/Extends.agda
+++ b/LibraBFT/Abstract/Records/Extends.agda
@@ -4,7 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 
@@ -22,8 +21,8 @@ module LibraBFT.Abstract.Records.Extends
   -- by the implementation to validate data received.
   --
   -- In the Abstract model, however, we are only concerned with
-  -- proving the properties; only round numbers and hashes are
-  -- actually critical to thm S5!
+  -- proving the properties; only round numbers and identifiers
+  -- for previous records are actually critical to thm S5!
   data _←_ : Record → Record → Set where
     I←B : {b : Block}
         → 0 < getRound b

--- a/LibraBFT/Abstract/Types.agda
+++ b/LibraBFT/Abstract/Types.agda
@@ -30,7 +30,7 @@ module LibraBFT.Abstract.Types where
     field
       -- TODO-2 : This should really be a UID as Hash should not show up in the Abstract namespace.
       -- This will require some refactoring of modules and reordering of module parameters.
-      initialAgreedHash : Hash
+      genesisUID : Hash
       epochId   : EpochId
       authorsN  : ℕ
       bizF      : ℕ

--- a/LibraBFT/Abstract/Types.agda
+++ b/LibraBFT/Abstract/Types.agda
@@ -28,6 +28,8 @@ module LibraBFT.Abstract.Types where
   record EpochConfig : Set where
     constructor mkEpochConfig
     field
+      -- TODO-2 : This should really be a UID as Hash should not show up in the Abstract namespace.
+      -- This will require some refactoring of modules and reordering of module parameters.
       initialAgreedHash : Hash
       epochId   : EpochId
       authorsN  : ℕ

--- a/LibraBFT/Abstract/Types.agda
+++ b/LibraBFT/Abstract/Types.agda
@@ -28,8 +28,9 @@ module LibraBFT.Abstract.Types where
   record EpochConfig : Set where
     constructor mkEpochConfig
     field
-      -- TODO-2 : This should really be a UID as Hash should not show up in the Abstract namespace.
-      -- This will require some refactoring of modules and reordering of module parameters.
+      -- TODO-2 : This should really be a UID as Hash should not show up in the Abstract
+      -- namespace.  This will require some refactoring of modules and reordering of
+      -- module parameters.
       genesisUID : Hash
       epochId   : EpochId
       authorsN  : ℕ

--- a/LibraBFT/Impl/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochDep.agda
@@ -66,13 +66,13 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   open import LibraBFT.Abstract.RecordChain     𝓔 UID _≟UID_ ConcreteVoteEvidence
 
   data VoteCoherence (v : Vote) (b : Abs.Block) : Set where
-    initial  : v ^∙ vParentId    ≡ initialAgreedHash
+    initial  : v ^∙ vParentId    ≡ genesisUID
              → v ^∙ vParentRound ≡ 0
              → Abs.bPrevQC b     ≡ nothing
              → VoteCoherence v b
 
     ¬initial : ∀{b' q}
-             → v ^∙ vParentId    ≢ initialAgreedHash
+             → v ^∙ vParentId    ≢ genesisUID
              → v ^∙ vParentRound ≢ 0
              → v ^∙ vParentId    ≡ Abs.bId b'
              → v ^∙ vParentRound ≡ Abs.bRound b'


### PR DESCRIPTION
Remove almost all mentions of Hash from abstract namespace, where we care only about an opaque `UID` type.  The type of `initialAgreeHash` (now renamed to `genesisUID`) remains `Hash`, as there is still a `TODO` to do the module parameter refactoring needed to provide a `UID` type to `LibraBFT.Abstract.Types`, enabling `genesisUID` to be of this type.