### PR TITLE
Only require LockedRoundRule for contiguous 3-chain, eliminate TERMINATING

### DIFF
--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -110,7 +110,7 @@ module LibraBFT.Abstract.Properties
       qc←b      : Q qc ← B (veBlock votesForB)
       rc        : RecordChain (Q qc)
       n         : ℕ
-      is-2chain : 𝕂-chain Simple (2 + n) rc
+      is-2chain : 𝕂-chain Contig (2 + n) rc
   open Cand-3-chain-vote public
 
   -- Returns the round of the head of the candidate 3-chain. In the diagram
@@ -157,8 +157,8 @@ module LibraBFT.Abstract.Properties
            (λ vp → Cand-3-chain-head-round c2 ≤ round (vpParent vp))
 
   private
-   make-cand-3-chain : ∀{n R α q}{rc : RecordChain (Q q)}
-                     → (c3 : 𝕂-chain R (3 + n) rc)
+   make-cand-3-chain : ∀{n α q}{rc : RecordChain (Q q)}
+                     → (c3 : 𝕂-chain Contig (3 + n) rc)
                      → (v  : α ∈QC q)
                      → Cand-3-chain-vote (∈QC-Vote q v)
    make-cand-3-chain {q = q} (s-chain {suc (suc n)} {rc = rc} {b = b} ext₀@(Q←B h0 refl) _ ext₁@(B←Q h1 refl) c2) v
@@ -170,14 +170,14 @@ module LibraBFT.Abstract.Properties
                 ; qc←b = ext₀
                 ; rc = rc
                 ; n  = n
-                ; is-2chain = 𝕂-chain-to-Simple c2
+                ; is-2chain = c2
                 }
 
    -- It is important that the make-cand-3-chain lemma doesn't change the head of
    -- the 3-chain/cand-2-chain.
    make-cand-3-chain-lemma
-     : ∀{n R α q}{rc : RecordChain (Q q)}
-     → (c3 : 𝕂-chain R (3 + n) rc)
+     : ∀{n α q}{rc : RecordChain (Q q)}
+     → (c3 : 𝕂-chain Contig (3 + n) rc)
      → (v  : α ∈QC q)
      → NonInjective-≡ bId ⊎ kchainBlock (suc zero) (is-2chain (make-cand-3-chain c3 v)) ≡ kchainBlock (suc (suc zero)) c3
    make-cand-3-chain-lemma {q = q} c3@(s-chain {suc (suc n)} {rc = rc} {b = b} ext₀@(Q←B h0 refl) _ ext₁@(B←Q h1 refl) c2) v

--- a/LibraBFT/Abstract/RecordChain/Invariants.agda
+++ b/LibraBFT/Abstract/RecordChain/Invariants.agda
@@ -102,11 +102,11 @@ module LibraBFT.Abstract.RecordChain.Invariants
    -- checks have been performed and we can infer this information solely
    -- by seeing α has knowledge of the 2-chain in Fig2 above.
    --
-   LockedRoundRule : Set (ℓ+1 ℓ0 ℓ⊔ ℓ)
+   LockedRoundRule : Set ℓ
    LockedRoundRule
-     = ∀{R}(α : Member)(hpk : Meta-Honest-Member 𝓔 α)
+     = ∀(α : Member)(hpk : Meta-Honest-Member 𝓔 α)
      → ∀{q q'}(q∈𝓢 : InSys (Q q))(q'∈𝓢 : InSys (Q q'))
-     → {rc : RecordChain (Q q)}{n : ℕ}(c3 : 𝕂-chain R (3 + n) rc)
+     → {rc : RecordChain (Q q)}{n : ℕ}(c3 : 𝕂-chain Contig (3 + n) rc)
      → (vα : α ∈QC q) -- α knows of the 2-chain because it voted on the tail of the 3-chain!
      → (rc' : RecordChain (Q q'))
      → (vα' : α ∈QC q')

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -87,14 +87,14 @@ module LibraBFT.Abstract.RecordChain.Properties
    ----------------
    -- Lemma S3
 
-   lemmaS3 : ∀{P r₂}{rc : RecordChain r₂}
+   lemmaS3 : ∀{r₂}{rc : RecordChain r₂}
            → InSys r₂
-           → (c3 : 𝕂-chain P 3 rc)        -- This is B₀ ← C₀ ← B₁ ← C₁ ← B₂ ← C₂ in S3
+           → (c3 : 𝕂-chain Contig 3 rc)        -- This is B₀ ← C₀ ← B₁ ← C₁ ← B₂ ← C₂ in S3
            → {q' : QC} → InSys (Q q')
            → (certB : RecordChain (Q q')) -- Immediately before a (Q q), we have the certified block (B b), which is the 'B' in S3
            → round r₂ < getRound q'
            → NonInjective-≡ bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound certB)
-   lemmaS3 {r} {r₂} ex₀ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ _ b₂←q₂ c2) {q'} ex₁ (step certB b←q') hyp
+   lemmaS3 {r₂} ex₀ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ _ b₂←q₂ c2) {q'} ex₁ (step certB b←q') hyp
      with lemmaB1 q₂ q'
    ...| (a , (a∈q₂ , a∈q' , honest))
      -- TODO-1: We have done similar reasoning on the order of votes for
@@ -107,7 +107,7 @@ module LibraBFT.Abstract.RecordChain.Properties
    ...| tri> _ _ va'<va₂
      with subst₂ _<_ a∈q'rnd≡ a∈q₂rnd≡   (≤-trans va'<va₂ (≤-reflexive (sym a∈q₂rnd≡)))
    ...| res = ⊥-elim (n≮n (getRound q') (≤-trans res (≤-unstep hyp)))
-   lemmaS3 {r} ex₀ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ P b₂←q₂ c2) {q'} ex₁ (step certB b←q') hyp
+   lemmaS3 ex₀ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ P b₂←q₂ c2) {q'} ex₁ (step certB b←q') hyp
       | (a , (a∈q₂ , a∈q' , honest))
       | a∈q'rnd≡ | a∈q₂rnd≡
       | tri≈ _ v₂≡v' _ =

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -208,12 +208,6 @@ module LibraBFT.Abstract.RecordChain.Properties
    ...| inj₁ hb   = inj₁ hb
    ...| inj₂ res' = inj₂ (there (B←Q refl x₀) res')
 
-   -- TODO-2: Eliminate the need for the TERMINATING pragma here.  The
-   -- problem is that propS4 invokes itself recursively with an argument
-   -- (ls3) that is returned from lemmaS3, and Agda doesn't know that this
-   -- argument, which is an inequality on round numbers, is "smaller" than
-   -- the original argument "hyp".
-   {-# TERMINATING #-}
    propS4 : ∀{q}
           → {rc : RecordChain (Q q)}
           → All-InSys 𝓢 rc


### PR DESCRIPTION
Our abstract `LockedRoundRule` (similar to the corresponding aspects of HotStuff and LibraBDT papers) imposes a condition on peers that is stronger than necessary.  In particular, the risk that this rule is designed to avoid is if a block is committed, we must ensure that a conflicting block is not also committed.  The first block is committed only if the 3-chain mentioned in the condition has contiguous rounds, but this was not stated.  This pull request fixes that.

By weakening the constraint, we demonstrate that a wider range of implementations is possible.  It is unclear whether it would be advantageous to modify existing implementations to take advantage of the weaker requirement, but it is worth knowing that we can do so without compromising correctness.

We also eliminate a TERMINATING pragma that is no necessary (perhaps upgrading Agda eliminated the need for it?)

