### PR TITLE
Generalize EpochConfig to enable more flexible quorum definitions

### DIFF
--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -7,40 +7,10 @@ open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 
-module LibraBFT.Abstract.BFT
-    (𝓔      : EpochConfig)(valid : ValidEpoch 𝓔)
-    (UID    : Set)
-    (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
-    (𝓥      : VoteEvidence 𝓔 UID)
-  where
+module LibraBFT.Abstract.BFT where
 
- open ValidEpoch valid
+  -- This is a utility function to make it easy to provide the bft-assumption
+  -- for the abstract EpochConfig by by assuming that at most bizF members are byzantine
+  -- and that authorsN ≥ suc (3 * bizF) and that a list of Members is a quorum if it
+  -- contains at least authorsN ∸ bizF distinct Members.
 
- open import LibraBFT.Abstract.Records 𝓔 UID _≟UID_ 𝓥
-
- -- Here we use the bft-lemma provided by a ValidEpoch to prove convenient proprties relating honest
- -- peers to quorums and pairs of quorums.
-
- lemmaB1 : (q₁ : QC)(q₂ : QC) → ∃[ a ] (a ∈QC q₁ × a ∈QC q₂ × Meta-Honest-Member 𝓔 a)
- lemmaB1 q₁ q₂
-   with bft-lemma {List-map vMember (qVotes q₁)}
-                  {List-map vMember (qVotes q₂)}
-                  (IsSorted-map⁻ vMember (qVotes q₁) (qVotes-C1 q₁))
-                  (IsSorted-map⁻ vMember (qVotes q₂) (qVotes-C1 q₂))
-                  (≤-trans (qVotes-C2 q₁)
-                    (≡⇒≤ (sym (List-length-map vMember (qVotes q₁)))))
-                  (≤-trans (qVotes-C2 q₂)
-                    (≡⇒≤ (sym (List-length-map vMember (qVotes q₂)))))
- ...| α , (α∈v1 , α∈v2 , hα) = α , Any-map sym (Any-map⁻ α∈v1)
-                                 , Any-map sym (Any-map⁻ α∈v2)
-                                 , hα
-
- -- Any QC contains at least one honest verifier
- ∃Honest∈QC : (q : QC) → ∃[ α ] (Meta-Honest-Member 𝓔 α × α ∈QC q)
- ∃Honest∈QC q
-   with IsSorted-map⁻ {_≤_ = _<Fin_} vMember (qVotes q) (qVotes-C1 q) |
-        subst (EpochConfig.QSize 𝓔 ≤_) (sym (List-length-map vMember (qVotes q))) (qVotes-C2 q)
- ...| qsorted | qsize≤
-   -- q contains an honest vote, find it using bft-lemma (use same QC twice)
-   with bft-lemma qsorted qsorted qsize≤ qsize≤
- ...| α , α∈q , _α∈q' , honα = α , honα , Any-map sym (Any-map⁻ α∈q)

--- a/LibraBFT/Abstract/Obligations/LockedRound.agda
+++ b/LibraBFT/Abstract/Obligations/LockedRound.agda
@@ -3,7 +3,7 @@ open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 
 module LibraBFT.Abstract.Obligations.LockedRound
-  (𝓔 : EpochConfig)(𝓔-valid : ValidEpoch 𝓔)
+  (𝓔 : EpochConfig)
   (UID    : Set)
   (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
   (𝓥      : VoteEvidence 𝓔 UID)
@@ -12,7 +12,7 @@ module LibraBFT.Abstract.Obligations.LockedRound
  open import LibraBFT.Abstract.Records 𝓔 UID _≟UID_ 𝓥
  open import LibraBFT.Abstract.Records.Extends 𝓔 UID _≟UID_ 𝓥
  open import LibraBFT.Abstract.RecordChain 𝓔 UID _≟UID_ 𝓥
- import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 𝓔-valid UID _≟UID_ 𝓥
+ import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 UID _≟UID_ 𝓥
    as StaticAssumptions
  open import LibraBFT.Abstract.System 𝓔 UID _≟UID_ 𝓥
 

--- a/LibraBFT/Abstract/Obligations/VotesOnce.agda
+++ b/LibraBFT/Abstract/Obligations/VotesOnce.agda
@@ -2,14 +2,14 @@ open import LibraBFT.Prelude
 open import LibraBFT.Abstract.Types
 
 module LibraBFT.Abstract.Obligations.VotesOnce
-  (𝓔 : EpochConfig)(𝓔-valid : ValidEpoch 𝓔)
+  (𝓔 : EpochConfig)
   (UID    : Set)
   (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
   (𝓥      : VoteEvidence 𝓔 UID)
   where
 
  open import LibraBFT.Abstract.Records 𝓔 UID _≟UID_ 𝓥
- import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 𝓔-valid UID _≟UID_ 𝓥
+ import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 UID _≟UID_ 𝓥
    as StaticAssumptions
  open import LibraBFT.Abstract.System 𝓔 UID _≟UID_ 𝓥
 

--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -80,8 +80,10 @@ module LibraBFT.Abstract.Properties
       → CommitRule rc' b'
       → NonInjective-≡ bId ⊎ ((B b) ∈RC rc' ⊎ (B b') ∈RC rc)
     CommitsDoNotConflict' {q} {q'} {step {r = B bb} rc b←q} {step {r = B bb'} rc' b←q'} {b} {b'} q∈sys q'∈sys cr cr'
-       with lemmaB1 q q'
-    ...| α , α∈q , α∈q' , hα
+       with bft-assumption (qVotes-C2 q) (qVotes-C2 q')
+    ...| α , α∈qmem , α∈q'mem , hα
+       with Any-sym (Any-map⁻ α∈qmem) | Any-sym (Any-map⁻ α∈q'mem)
+    ...| α∈q | α∈q'
        with ∈QC⇒AllSent {q = q} hα α∈q q∈sys | ∈QC⇒AllSent {q = q'} hα α∈q' q'∈sys
     ...| ab , ab←q , arc , ais | ab' , ab←q' , arc' , ais'
        with RecordChain-irrelevant (step arc  ab←q)  (step rc  b←q) |
@@ -116,8 +118,10 @@ module LibraBFT.Abstract.Properties
       → NonInjective-≡ bId ⊎ Σ (RecordChain (Q q')) ((B b)  ∈RC_)
                            ⊎ Σ (RecordChain (Q q))  ((B b') ∈RC_)
     CommitsDoNotConflict'' {cb} {q = q} {q'} {rcf} {rcf'} q∈sys q'∈sys crf crf'
-      with lemmaB1 q q'
-    ...| α , α∈q , α∈q' , hα
+       with bft-assumption (qVotes-C2 q) (qVotes-C2 q')
+    ...| α , α∈qmem , α∈q'mem , hα
+       with Any-sym (Any-map⁻ α∈qmem) | Any-sym (Any-map⁻ α∈q'mem)
+    ...| α∈q | α∈q'
        with ∈QC⇒AllSent {q = q} hα α∈q q∈sys | ∈QC⇒AllSent {q = q'} hα α∈q' q'∈sys
     ...| ab , ab←q , arc , ais | ab' , ab←q' , arc' , ais'
        with step arc  ab←q | step arc' ab←q'

--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -19,7 +19,7 @@ open import LibraBFT.Abstract.Types
 -- properties.
 
 module LibraBFT.Abstract.Properties
-  (𝓔 : EpochConfig)(𝓔-valid : ValidEpoch 𝓔)
+  (𝓔 : EpochConfig)
   (UID    : Set)
   (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
   (𝓥      : VoteEvidence 𝓔 UID)
@@ -28,17 +28,14 @@ module LibraBFT.Abstract.Properties
  open import LibraBFT.Abstract.Records 𝓔 UID _≟UID_ 𝓥
  open import LibraBFT.Abstract.Records.Extends 𝓔 UID _≟UID_ 𝓥
  open import LibraBFT.Abstract.RecordChain 𝓔 UID _≟UID_ 𝓥
- import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 𝓔-valid UID _≟UID_ 𝓥
+ import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 UID _≟UID_ 𝓥
    as StaticAssumptions
  open import LibraBFT.Abstract.System 𝓔 UID _≟UID_ 𝓥
 
- open import LibraBFT.Abstract.BFT 𝓔 𝓔-valid UID _≟UID_ 𝓥
-
  open EpochConfig 𝓔
- open ValidEpoch 𝓔-valid
 
- open import LibraBFT.Abstract.Obligations.VotesOnce 𝓔 𝓔-valid UID _≟UID_ 𝓥 as VO
- open import LibraBFT.Abstract.Obligations.LockedRound 𝓔 𝓔-valid UID _≟UID_ 𝓥 as LR
+ open import LibraBFT.Abstract.Obligations.VotesOnce 𝓔 UID _≟UID_ 𝓥 as VO
+ open import LibraBFT.Abstract.Obligations.LockedRound 𝓔 UID _≟UID_ 𝓥 as LR
 
  --------------------------------------------------------------------------------------------
  -- * A /ValidSysState/ is one in which both peer obligations are obeyed by honest peers * --
@@ -55,7 +52,7 @@ module LibraBFT.Abstract.Properties
  module _ {ℓ}(𝓢 : AbsSystemState ℓ) (st-valid : ValidSysState 𝓢) where
    open AbsSystemState 𝓢
    open All-InSys-props InSys
-   import LibraBFT.Abstract.RecordChain.Properties 𝓔 𝓔-valid UID _≟UID_ 𝓥 as Props
+   import LibraBFT.Abstract.RecordChain.Properties 𝓔 UID _≟UID_ 𝓥 as Props
 
    CommitsDoNotConflict : ∀{q q'}
         → {rc  : RecordChain (Q q)}  → All-InSys rc

--- a/LibraBFT/Abstract/RecordChain/Assumptions.agda
+++ b/LibraBFT/Abstract/RecordChain/Assumptions.agda
@@ -18,7 +18,7 @@ open import LibraBFT.Abstract.Types
 -- presented here can be obtained from reasoning about sent votes,
 -- which provides a much easier-to-prove interface to an implementation.
 module LibraBFT.Abstract.RecordChain.Assumptions
-    (𝓔      : EpochConfig)(valid : ValidEpoch 𝓔)
+    (𝓔      : EpochConfig)
     (UID    : Set)
     (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
     (𝓥      : VoteEvidence 𝓔 UID)
@@ -27,7 +27,6 @@ module LibraBFT.Abstract.RecordChain.Assumptions
   open import LibraBFT.Abstract.System           𝓔 UID _≟UID_ 𝓥
   open import LibraBFT.Abstract.Records          𝓔 UID _≟UID_ 𝓥
   open import LibraBFT.Abstract.Records.Extends  𝓔 UID _≟UID_ 𝓥
-  open import LibraBFT.Abstract.BFT              𝓔 valid UID _≟UID_ 𝓥
   open import LibraBFT.Abstract.RecordChain      𝓔 UID _≟UID_ 𝓥
 
   open EpochConfig 𝓔

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -18,7 +18,7 @@ open import LibraBFT.Abstract.Types
 -- separating these proofs into abstract and concrete pieces.
 
 module LibraBFT.Abstract.RecordChain.Properties
-  (𝓔      : EpochConfig)(valid : ValidEpoch 𝓔)
+  (𝓔      : EpochConfig)
   (UID    : Set)
   (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
   (𝓥      : VoteEvidence 𝓔 UID)
@@ -28,12 +28,10 @@ module LibraBFT.Abstract.RecordChain.Properties
  open import LibraBFT.Abstract.Records                 𝓔 UID _≟UID_ 𝓥
  open import LibraBFT.Abstract.Records.Extends         𝓔 UID _≟UID_ 𝓥
  open import LibraBFT.Abstract.RecordChain             𝓔 UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.BFT                     𝓔 valid UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 valid UID _≟UID_ 𝓥
+ open import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 UID _≟UID_ 𝓥
    as Assumptions
 
  open EpochConfig 𝓔
- open ValidEpoch valid
 
  module WithInvariants {ℓ}
    (InSys                 : Record → Set ℓ)

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -59,21 +59,25 @@ module LibraBFT.Abstract.RecordChain.Properties
      with b₀ ≟Block b₁
    ...| yes done = inj₂ done
    ...| no  imp
-     with lemmaB1 q₀ q₁
-   ...|  (a , (a∈q₀ , a∈q₁ , honest))
+     with bft-assumption (qVotes-C2 q₀) (qVotes-C2 q₁)
+   ...|  (a , (a∈q₀mem , a∈q₁mem , honest))
+     with Any-sym (Any-map⁻ a∈q₀mem) | Any-sym (Any-map⁻ a∈q₁mem)
+   ...| a∈q₀ | a∈q₁
       with All-lookup (qVotes-C4 q₀) (∈QC-Vote-correct q₀ a∈q₀) |
            All-lookup (qVotes-C4 q₁) (∈QC-Vote-correct q₁ a∈q₁)
    ...| a∈q₀rnd≡ | a∈q₁rnd≡
      with <-cmp (abs-vRound (∈QC-Vote q₀ a∈q₀)) (abs-vRound (∈QC-Vote q₁ a∈q₁))
-   ...| tri< va<va' _ _ = ⊥-elim (<⇒≢ (subst₂ _<_ a∈q₀rnd≡ a∈q₁rnd≡ va<va') refl)
+   ...| tri< va<va' _ _ = ⊥-elim (<⇒≢ (subst₂ _<_ a∈q₀rnd≡ a∈q₁rnd≡  va<va') refl)
    lemmaS2 {b₀} {b₁} {q₀} {q₁} ex₀ ex₁ (B←Q refl h₀) (B←Q refl h₁) refl
       | no imp
-      | (a , (a∈q₀ , a∈q₁ , honest))
+      | (a , (a∈q₀mem , a∈q₁mem , honest))
+      | a∈q₀ | a∈q₁
       | a∈q₀rnd≡ | a∈q₁rnd≡
       | tri> _ _ va'<va = ⊥-elim (<⇒≢ (subst₂ _≤_ (cong suc a∈q₁rnd≡) a∈q₀rnd≡ va'<va) refl)
    lemmaS2 {b₀} {b₁} {q₀} {q₁} ex₀ ex₁ (B←Q refl h₀) (B←Q refl h₁) hyp
       | no imp
-      |  (a , (a∈q₀ , a∈q₁ , honest))
+      | (a , (a∈q₀mem , a∈q₁mem , honest))
+      | a∈q₀ | a∈q₁
       | a∈q₀rnd≡ | a∈q₁rnd≡
       | tri≈ _ v₀≡v₁ _ =
      let v₀∈q₀ = ∈QC-Vote-correct q₀ a∈q₀
@@ -92,8 +96,11 @@ module LibraBFT.Abstract.RecordChain.Properties
            → round r₂ < getRound q'
            → NonInjective-≡ bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
    lemmaS3 {r₂} {q'} ex₀ (step rc' b←q') ex₁ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ _ b₂←q₂ c2) hyp
-     with lemmaB1 q₂ q'
-   ...| (a , (a∈q₂ , a∈q' , honest))
+     with bft-assumption (qVotes-C2 q₂) (qVotes-C2 q')
+   ...| (a , (a∈q₂mem , a∈q'mem , honest))
+        with Any-sym (Any-map⁻ a∈q₂mem) | Any-sym (Any-map⁻ a∈q'mem)
+   ...| a∈q₂ | a∈q'
+
      -- TODO-1: We have done similar reasoning on the order of votes for
      -- lemmaS2. We should factor out a predicate that analyzes the rounds
      -- of QC's and returns us a judgement about the order of the votes.
@@ -105,7 +112,8 @@ module LibraBFT.Abstract.RecordChain.Properties
      with subst₂ _<_ a∈q'rnd≡ a∈q₂rnd≡   (≤-trans va'<va₂ (≤-reflexive (sym a∈q₂rnd≡)))
    ...| res = ⊥-elim (n≮n (getRound q') (≤-trans res (≤-unstep hyp)))
    lemmaS3 {q' = q'} ex₀ (step rc' b←q') ex₁ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ P b₂←q₂ c2) hyp
-      | (a , (a∈q₂ , a∈q' , honest))
+      | (a , (a∈q₂mem , a∈q'mem , honest))
+      | a∈q₂ | a∈q'
       | a∈q'rnd≡ | a∈q₂rnd≡
       | tri≈ _ v₂≡v' _ =
      let v₂∈q₂ = ∈QC-Vote-correct q₂ a∈q₂
@@ -114,7 +122,8 @@ module LibraBFT.Abstract.RecordChain.Properties
                                         (votes-only-once a honest {q₂} {q'} ex₀ ex₁ a∈q₂ a∈q'
                                                          (trans a∈q₂rnd≡ v₂≡v'))))
    lemmaS3 {r} {q'} ex₀ (step rc' b←q') ex₁  (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ P b₂←q₂ c2) hyp
-      | (a , (a∈q₂ , a∈q' , honest))
+      | (a , (a∈q₂mem , a∈q'mem , honest))
+      | a∈q₂ | a∈q'
       | a∈q'rnd≡ | a∈q₂rnd≡
       | tri< va₂<va' _ _
      with b←q'

--- a/LibraBFT/Abstract/Records.agda
+++ b/LibraBFT/Abstract/Records.agda
@@ -73,7 +73,7 @@ module LibraBFT.Abstract.Records
      -- which guarantees distinct authors.
      qVotes-C1      : IsSorted (λ v₀ v₁ → vMember v₀ <Fin vMember v₁) qVotes
      -- Second, we it must have at least 'QuorumSize' votes, for the given epoch.
-     qVotes-C2      : QSize ≤ length qVotes
+     qVotes-C2      : IsQuorum (List-map vMember qVotes)
      -- All the votes must vote for the same blockId
      qVotes-C3      : All (λ v → vBlockUID v ≡ qCertBlockId) qVotes
      -- Likewise for rounds

--- a/LibraBFT/Abstract/Types.agda
+++ b/LibraBFT/Abstract/Types.agda
@@ -25,7 +25,7 @@ module LibraBFT.Abstract.Types where
   --
   -- The reason for the separation is that we should be able to provide
   -- an EpochConfig from a single peer state.
-  record EpochConfig : Set where
+  record EpochConfig : Set₁ where
     constructor mkEpochConfig
     field
       -- TODO-2 : This should really be a UID as Hash should not show up in the Abstract
@@ -34,11 +34,6 @@ module LibraBFT.Abstract.Types where
       genesisUID : Hash
       epochId   : EpochId
       authorsN  : ℕ
-      bizF      : ℕ
-      isBFT     : authorsN ≥ suc (3 * bizF)
-
-    QSize : ℕ
-    QSize = authorsN ∸ bizF
 
     -- The set of members of this epoch.
     Member : Set
@@ -58,6 +53,13 @@ module LibraBFT.Abstract.Types where
 
       PK-inj : ∀ {m1 m2} → getPubKey m1 ≡ getPubKey m2 → m1 ≡ m2
 
+      IsQuorum : List Member → Set
+
+      bft-assumption : ∀ {xs ys}
+                     → IsQuorum xs → IsQuorum ys
+                     → ∃[ α ] (α ∈ xs × α ∈ ys × Meta-Honest-PK (getPubKey α))
+
+
   open EpochConfig
 
   toNodeId-inj : ∀{𝓔}{x y : Member 𝓔} → toNodeId 𝓔 x ≡ toNodeId 𝓔 y → x ≡ y
@@ -65,7 +67,7 @@ module LibraBFT.Abstract.Types where
                                         (trans (cong (isMember? 𝓔) hyp)
                                                (nodeid-author-id 𝓔)))
 
-  record EpochConfigFor (eid : ℕ) : Set where
+  record EpochConfigFor (eid : ℕ) : Set₁ where
     field
      epochConfig : EpochConfig
      forEpochId  : epochId epochConfig ≡ eid
@@ -103,22 +105,6 @@ module LibraBFT.Abstract.Types where
      = trans (sym (author-nodeid-id 𝓔 RA))
              (trans (cong (toNodeId 𝓔) prf)
                     (author-nodeid-id 𝓔 RB))
-
-  -- ValidEpoch specifies a requirement for an epoch to have "enough"
-  -- honest verifiers to ensure that any pair of quorums has an honest
-  -- peer in its intersection. EpochConfig carries the information that
-  -- a peer will have immediately in its state. ValidEpoch, on the
-  -- other hand, carries information that the protocol and epoch
-  -- changes will need to guarantee.
-  record ValidEpoch (𝓔 : EpochConfig) : Set₁ where
-    field
-      bft-lemma : {xs ys : List (Member 𝓔)}
-                -- enforcing both xs and ys to be sorted lists according to
-                -- a anti-reflexive linear order ensures authors are distinct.
-                → IsSorted _<Fin_ xs → IsSorted _<Fin_ ys
-                → QSize 𝓔 ≤ length xs
-                → QSize 𝓔 ≤ length ys
-                → ∃[ α ] (α ∈ xs × α ∈ ys × Meta-Honest-Member 𝓔 α)
 
   -- The abstract model is connected to the implementaton by means of
   -- 'VoteEvidence'. The record module will be parameterized by a

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -15,7 +15,7 @@ open import LibraBFT.Yasm.Properties ConcSysParms
 
 module LibraBFT.Concrete.Obligations where
 
-  record ImplObligations : Set where
+  record ImplObligations : Set₁ where
     field
       -- Structural obligations:
       sps-cor : StepPeerState-AllValidParts

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -34,30 +34,28 @@ module LibraBFT.Concrete.Properties (impl-correct : ImplObligations) where
    open PerState st r
    open PerEpoch eid
 
-   -- For any valid epoch within said state
-   module _ (valid-𝓔 : ValidEpoch 𝓔) where
-    import LibraBFT.Abstract.Records 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as Abs
-    open import LibraBFT.Abstract.RecordChain 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
-    open import LibraBFT.Abstract.System 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
-    open import LibraBFT.Abstract.Properties 𝓔 valid-𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
+   import LibraBFT.Abstract.Records 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as Abs
+   open import LibraBFT.Abstract.RecordChain 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
+   open import LibraBFT.Abstract.System 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
+   open import LibraBFT.Abstract.Properties 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
 
-    open import LibraBFT.Abstract.Obligations.VotesOnce 𝓔 valid-𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
-    open import LibraBFT.Abstract.Obligations.LockedRound 𝓔 valid-𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
+   open import LibraBFT.Abstract.Obligations.VotesOnce 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
+   open import LibraBFT.Abstract.Obligations.LockedRound 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
 
-    validState : ValidSysState ConcSystemState
-    validState = record
-      { vss-votes-once   = VO.Proof.voo sps-cor vo₁ vo₂ st r eid valid-𝓔
-      ; vss-locked-round = LR.Proof.lrr sps-cor lr₁ st r eid valid-𝓔
-      }
+   validState : ValidSysState ConcSystemState
+   validState = record
+     { vss-votes-once   = VO.Proof.voo sps-cor vo₁ vo₂ st r eid
+     ; vss-locked-round = LR.Proof.lrr sps-cor lr₁ st r eid
+     }
 
-    open All-InSys-props (AbsSystemState.InSys ConcSystemState)
+   open All-InSys-props (AbsSystemState.InSys ConcSystemState)
 
-    -- commited blocks do not conflict.
-    S5 : ∀{q q'}
-       → {rc  : RecordChain (Abs.Q q)}  → All-InSys rc
-       → {rc' : RecordChain (Abs.Q q')} → All-InSys rc'
-       → {b b' : Abs.Block}
-       → CommitRule rc  b
-       → CommitRule rc' b'
-       → NonInjective-≡ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
-    S5 = CommitsDoNotConflict ConcSystemState validState
+   -- commited blocks do not conflict.
+   S5 : ∀{q q'}
+      → {rc  : RecordChain (Abs.Q q)}  → All-InSys rc
+      → {rc' : RecordChain (Abs.Q q')} → All-InSys rc'
+      → {b b' : Abs.Block}
+      → CommitRule rc  b
+      → CommitRule rc' b'
+      → NonInjective-≡ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
+   S5 = CommitsDoNotConflict ConcSystemState validState

--- a/LibraBFT/Concrete/Properties/LockedRound.agda
+++ b/LibraBFT/Concrete/Properties/LockedRound.agda
@@ -53,11 +53,7 @@ module LibraBFT.Concrete.Properties.LockedRound where
    open PerState st r
    open PerEpoch eid
 
-   -- TODO-4: For now we assume 𝓔 is a "ValidEpoch", but in the future we should prove that all
-   -- epochs in the system are valid. This will be dependent on how the epoch-change-transaction
-   -- mechanism is architected and consequently is left as future work.
-   module _ (valid-𝓔 : ValidEpoch 𝓔) where
-    open import LibraBFT.Abstract.Obligations.LockedRound 𝓔 valid-𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as LR
+   open import LibraBFT.Abstract.Obligations.LockedRound 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as LR
 
-    postulate  -- TODO-3: prove it
+   postulate  -- TODO-3: prove it
      lrr : LR.Type ConcSystemState

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -48,7 +48,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
  -- implementation to reason about messages sent by step-cheat, or give it something to make this
  -- case easy to eliminate.
 
- ImplObligation₁ : Set
+ ImplObligation₁ : Set₁
  ImplObligation₁ =
    ∀{e pid sndr s' outs pk}{pre : SystemState e}
    → ReachableSystemState pre
@@ -70,7 +70,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    -- Then an honest implemenation promises v and v' vote for the same blockId.
    → (v ^∙ vProposed ∙ biId) ≡ (v' ^∙ vProposed ∙ biId)
 
- ImplObligation₂ : Set
+ ImplObligation₂ : Set₁
  ImplObligation₂ =
    ∀{e pid s' outs pk}{pre : SystemState e}
    → ReachableSystemState pre
@@ -110,281 +110,277 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    open PerState st r
    open PerEpoch eid
 
-   -- TODO-4: For now we assume 𝓔 is a "ValidEpoch", but in the future we should prove that all
-   -- epochs in the system are valid. This will be dependent on how the epoch-change-transaction
-   -- mechanism is architected and consequently is left as future work.
-   module _ (valid-𝓔 : ValidEpoch 𝓔) where
-    open import LibraBFT.Abstract.Obligations.VotesOnce 𝓔 valid-𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as VO
+   open import LibraBFT.Abstract.Obligations.VotesOnce 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as VO
 
-    -- The VO proof is done by induction on the execution trace leading to 'st'. In
-    -- Agda, this is 'r : RechableSystemState st' above. We will use induction to
-    -- construct a predicate Pred'' below, which holds for every state on the trace.
+   -- The VO proof is done by induction on the execution trace leading to 'st'. In
+   -- Agda, this is 'r : RechableSystemState st' above. We will use induction to
+   -- construct a predicate Pred'' below, which holds for every state on the trace.
 
-    private
-     -- First we specify the predicate we need: it relates two votes verified
-     -- by the same public key, such that both are elements of the same message pool
-     Pred'' : PK → Vote → Vote → SentMessages → Set
-     Pred'' pk v v' pool
-       = Meta-Honest-PK pk
-       → (ver  : WithVerSig pk v)  → MsgWithSig∈ pk (ver-signature ver) pool
-       → (ver' : WithVerSig pk v') → MsgWithSig∈ pk (ver-signature ver') pool
-       → v ^∙ vEpoch ≡ v' ^∙ vEpoch
-       → v ^∙ vRound ≡ v' ^∙ vRound
-       → v ^∙ vProposedId ≡ v' ^∙ vProposedId
+   private
+    -- First we specify the predicate we need: it relates two votes verified
+    -- by the same public key, such that both are elements of the same message pool
+    Pred'' : PK → Vote → Vote → SentMessages → Set
+    Pred'' pk v v' pool
+      = Meta-Honest-PK pk
+      → (ver  : WithVerSig pk v)  → MsgWithSig∈ pk (ver-signature ver) pool
+      → (ver' : WithVerSig pk v') → MsgWithSig∈ pk (ver-signature ver') pool
+      → v ^∙ vEpoch ≡ v' ^∙ vEpoch
+      → v ^∙ vRound ≡ v' ^∙ vRound
+      → v ^∙ vProposedId ≡ v' ^∙ vProposedId
 
-     -- Usually, we want to universally quantify Pred'' over arbitrary votes and pks
-     Pred' : SentMessages → Set
-     Pred' pool = ∀{pk}{v v' : Vote} → Pred'' pk v v' pool
+    -- Usually, we want to universally quantify Pred'' over arbitrary votes and pks
+    Pred' : SentMessages → Set
+    Pred' pool = ∀{pk}{v v' : Vote} → Pred'' pk v v' pool
 
-     -- Finally, we state Pred' in terms of SystemSate
-     Pred : ∀{e} → SystemState e → Set
-     Pred = Pred' ∘ msgPool
+    -- Finally, we state Pred' in terms of SystemSate
+    Pred : ∀{e} → SystemState e → Set
+    Pred = Pred' ∘ msgPool
 
-     -------------------
-     -- * Base Case * --
-     -------------------
+    -------------------
+    -- * Base Case * --
+    -------------------
 
-     -- Pred above is trivially true for the initial state: there are no messages in the pool
-     Pred₀ : Pred initialState
-     Pred₀ _ _ ()
+    -- Pred above is trivially true for the initial state: there are no messages in the pool
+    Pred₀ : Pred initialState
+    Pred₀ _ _ ()
 
-     --------------------------------------------------
-     -- * Inductive Case: New Epochs in the System * --
-     --------------------------------------------------
+    --------------------------------------------------
+    -- * Inductive Case: New Epochs in the System * --
+    --------------------------------------------------
 
-     -- Because pushEpoch does not alter the msgPool, the proof is trivial.
-     Pred𝓔 : ∀{e}{st : SystemState e}(𝓔 : EpochConfigFor e) → Pred st → Pred (pushEpoch 𝓔 st)
-     Pred𝓔 𝓔 p = p
+    -- Because pushEpoch does not alter the msgPool, the proof is trivial.
+    Pred𝓔 : ∀{e}{st : SystemState e}(𝓔 : EpochConfigFor e) → Pred st → Pred (pushEpoch 𝓔 st)
+    Pred𝓔 𝓔 p = p
 
-     ----------------------------------------------
-     -- * Inductive Case: Transition by a Peer * --
-     ----------------------------------------------
+    ----------------------------------------------
+    -- * Inductive Case: Transition by a Peer * --
+    ----------------------------------------------
 
-     -- From this point onwards, it might be easier to read this proof starting at 'voo'
-     -- at the end of the file. Next, we provide an overview the proof.
-     --
-     -- We wish to prove that, for any two votes v and v' cast by an honest α in the message pool of
-     -- a state st, if v and v' have equal rounds and epochs, then they vote for the same block. As
-     -- we have seen above, the base case and the case for a new epoch in the system are
-     -- trivial. Next, we look at the PeerStep case.
-     --
-     -- The induction hypothesis tells us that the property holds in the pre-state.  Next, we reason
-     -- about the post-state.  We start by analyzing whether v and v' have been sent as outputs of
-     -- the PeerStep under scrutiny or were already in the pool before (captured by the PredStep
-     -- function).  There are four possibilities:
-     --
-     --   i) v and v' were aleady present in the msgPool before: use induction hypothesis.
-     --  ii) v and v' are both in the output produced by the PeerStep under scrutiny.
-     -- iii) v was present before, but v' is new.
-     --  iv) v' was present before, but v is new.
-     --
-     -- Case (i) is trivial; cases (iii) and (iv) are symmetric and reduce to an implementation
-     -- obligation (Impl-VO1) and case (ii) reduces to a different implementation obligation (Impl-VO2).
-     --
-     -- The proofs of cases (iii) and (iv) are in PredStep-wlog-ht and PredStep-wlog-ht'.  The 'ht'
-     -- suffix refers to 'Here-There' as in one vote is "here" and the other is old, or "there".  We
-     -- first analyze whether the new vote is really new or a replay; sps-cor provides us this
-     -- information.  If the new vote is, in fact, a replay of an old message, we have two old
-     -- messages and can call the induction hypothesis. If it is really new, we must rely on the
-     -- implementation obligation. But to do so, we must prove that the old vote was also sent by
-     -- the same peer.  We can see that is the case by reasoning about PK-inj and IsValidEpochMember.
-     --
-     -- Finally, the proof of case (ii) also branches on whether either of the "new" votes
-     -- are replays or are really new. In case at least one is a replay we fallback to cases (iii) and (iv)
-     -- or just call the induction hypothesis when both are replays.
-     -- When both votes are in fact new, we rely on Impl-VO2 to conclude.
-     --
-     -- In both PredSetp-wlog-ht and PredStep-wlog-hh, we must eliminate the possibility of
-     -- either vote being produced by a cheat step. This is easy because we received
-     -- a proof that the PK in question is honest, hence, it must be the case that a cheat
-     -- step is at most replaying these votes, not producing them. Producing them would
-     -- require the cheater to forge a signature. This is the purpose of the isCheat constraint.
+    -- From this point onwards, it might be easier to read this proof starting at 'voo'
+    -- at the end of the file. Next, we provide an overview the proof.
+    --
+    -- We wish to prove that, for any two votes v and v' cast by an honest α in the message pool of
+    -- a state st, if v and v' have equal rounds and epochs, then they vote for the same block. As
+    -- we have seen above, the base case and the case for a new epoch in the system are
+    -- trivial. Next, we look at the PeerStep case.
+    --
+    -- The induction hypothesis tells us that the property holds in the pre-state.  Next, we reason
+    -- about the post-state.  We start by analyzing whether v and v' have been sent as outputs of
+    -- the PeerStep under scrutiny or were already in the pool before (captured by the PredStep
+    -- function).  There are four possibilities:
+    --
+    --   i) v and v' were aleady present in the msgPool before: use induction hypothesis.
+    --  ii) v and v' are both in the output produced by the PeerStep under scrutiny.
+    -- iii) v was present before, but v' is new.
+    --  iv) v' was present before, but v is new.
+    --
+    -- Case (i) is trivial; cases (iii) and (iv) are symmetric and reduce to an implementation
+    -- obligation (Impl-VO1) and case (ii) reduces to a different implementation obligation (Impl-VO2).
+    --
+    -- The proofs of cases (iii) and (iv) are in PredStep-wlog-ht and PredStep-wlog-ht'.  The 'ht'
+    -- suffix refers to 'Here-There' as in one vote is "here" and the other is old, or "there".  We
+    -- first analyze whether the new vote is really new or a replay; sps-cor provides us this
+    -- information.  If the new vote is, in fact, a replay of an old message, we have two old
+    -- messages and can call the induction hypothesis. If it is really new, we must rely on the
+    -- implementation obligation. But to do so, we must prove that the old vote was also sent by
+    -- the same peer.  We can see that is the case by reasoning about PK-inj and IsValidEpochMember.
+    --
+    -- Finally, the proof of case (ii) also branches on whether either of the "new" votes
+    -- are replays or are really new. In case at least one is a replay we fallback to cases (iii) and (iv)
+    -- or just call the induction hypothesis when both are replays.
+    -- When both votes are in fact new, we rely on Impl-VO2 to conclude.
+    --
+    -- In both PredSetp-wlog-ht and PredStep-wlog-hh, we must eliminate the possibility of
+    -- either vote being produced by a cheat step. This is easy because we received
+    -- a proof that the PK in question is honest, hence, it must be the case that a cheat
+    -- step is at most replaying these votes, not producing them. Producing them would
+    -- require the cheater to forge a signature. This is the purpose of the isCheat constraint.
 
-     PredStep-wlog-ht' : ∀{e pid pid' s' outs pk}{pre : SystemState e}
+    PredStep-wlog-ht' : ∀{e pid pid' s' outs pk}{pre : SystemState e}
+            → ReachableSystemState pre
+            → Pred pre
+            → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) s' outs
+            → ∀{v m v' m'}
+            → v  ⊂Msg m  → m ∈ outs
+            → v' ⊂Msg m' → (pid' , m') ∈ msgPool pre
+            → WithVerSig pk v → WithVerSig pk v' → Meta-Honest-PK pk
+            → (v ^∙ vEpoch) ≡ (v' ^∙ vEpoch)
+            → (v ^∙ vProposed ∙ biRound) ≡ (v' ^∙ vProposed ∙ biRound)
+            → (v ^∙ vProposed ∙ biId) ≡ (v' ^∙ vProposed ∙ biId)
+    PredStep-wlog-ht' {pre = pre} preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈pool ver ver' hpk eids≡ r≡
+    -- (1) The first step is branching on whether 'v' above is a /new/ vote or not.
+    -- (1.1) If it's new:
+      with sps-corr preach hpk ps m∈outs v⊂m ver
+    ...| inj₁ (vValid , vNew)
+      with honestPartValid preach hpk v'⊂m' m'∈pool ver'
+    ...| v'Old , vOldValid
+      with sameHonestSig⇒sameVoteData hpk ver' (msgSigned v'Old) (sym (msgSameSig v'Old))
+    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
+    ...| inj₂ refl = Impl-VO1 preach ps hpk v⊂m m∈outs ver vNew vValid
+                       (msg⊆ v'Old) (msg∈pool v'Old)
+                       (msgSigned v'Old) eids≡ r≡
+    -- (1.1) If 'v' is not new, then there exists a msg sent with the
+    -- same signature.
+    PredStep-wlog-ht' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈pool ver ver' hpk e≡ r≡
+       | inj₂ vOld
+      with honestPartValid preach hpk v'⊂m' m'∈pool ver'
+    ...| sv' , _ = hip hpk ver vOld ver' sv' e≡ r≡
+
+    -- Here we prove a modified version of Pred'' where we assume w.l.o.g that
+    -- one vote is sent by "pstep" and another was present in the prestate.
+    PredStep-wlog-ht
+      : ∀{e pid st' outs}{pre : SystemState e}
+      → ReachableSystemState pre
+      → (pstep : StepPeer pre pid st' outs)
+      → Pred pre
+      → ∀{pk v v'}
+      -- Below is a inline expansion of "Pred'' pk v v' (msgPool (StepPeer-post pstep))",
+      -- but with the added information that one vote (v) was sent by pstep whereas the
+      -- other (v') was in the pool of the prestate.
+      → let pool = msgPool (StepPeer-post pstep)
+         in Meta-Honest-PK pk
+          → (ver  : WithVerSig pk v )(sv  : MsgWithSig∈ pk (ver-signature ver ) pool)
+          → (msgSender sv , msgWhole sv) ∈ List-map (pid ,_) outs
+          → (ver' : WithVerSig pk v')(sv' : MsgWithSig∈ pk (ver-signature ver') pool)
+          → (msgSender sv' , msgWhole sv') ∈ msgPool pre
+          → v ^∙ vEpoch ≡ v' ^∙ vEpoch
+          → v ^∙ vRound ≡ v' ^∙ vRound
+          → v ^∙ vProposedId ≡ v' ^∙ vProposedId
+    PredStep-wlog-ht preach (step-cheat fm isCheat) hip hpk ver sv (here refl) ver' sv' furtherBack' epoch≡ r≡
+      with isCheat (msg⊆ sv) (msgSigned sv)
+    ...| inj₁ abs    = ⊥-elim (hpk abs) -- The key was honest by hypothesis.
+    ...| inj₂ sentb4
+       -- the cheater replayed the message; which means the message was sent before this
+       -- step; hence, call induction hypothesis.
+      with msgSameSig sv
+    ...| refl = hip hpk ver sentb4 ver' (MsgWithSig∈-transp sv' furtherBack') epoch≡ r≡
+    PredStep-wlog-ht preach (step-honest x) hip hpk ver sv thisStep ver' sv' furtherBack' epoch≡ r≡
+      with sameHonestSig⇒sameVoteData hpk ver (msgSigned sv) (sym (msgSameSig sv))
+    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
+    ...| inj₂ refl
+      with sameHonestSig⇒sameVoteData hpk ver' (msgSigned sv') (sym (msgSameSig sv'))
+    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
+    ...| inj₂ refl
+       = PredStep-wlog-ht' preach hip x
+                 (msg⊆ sv) (Any-map (cong proj₂) (Any-map⁻ thisStep))
+                 (msg⊆ sv') furtherBack'
+                 (msgSigned sv) (msgSigned sv') hpk epoch≡ r≡
+
+    -- Analogous to PredStep-wlog-ht', but here we must reason about two messages that are in the
+    -- outputs of a step.
+    PredStep-hh' : ∀{e pid s' outs pk}{pre : SystemState e}
+            → ReachableSystemState pre → Pred pre
+            → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) s' outs
+            → ∀{v m v' m'}
+            → v  ⊂Msg m  → m  ∈ outs
+            → v' ⊂Msg m' → m' ∈ outs
+            → WithVerSig pk v → WithVerSig pk v' → Meta-Honest-PK pk
+            → (v ^∙ vEpoch) ≡ (v' ^∙ vEpoch)
+            → (v ^∙ vProposed ∙ biRound) ≡ (v' ^∙ vProposed ∙ biRound)
+            → (v ^∙ vProposed ∙ biId) ≡ (v' ^∙ vProposed ∙ biId)
+    -- Since the step is from an honest peer, we can check whether the messages are in fact
+    -- new or not.
+    PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
+      with sps-corr preach hpk ps m∈outs v⊂m ver | sps-corr preach hpk ps m'∈outs v'⊂m' ver'
+    -- (A) Both are old: call induction hypothesis
+    ...| inj₂ vOld            | inj₂ v'Old = hip hpk ver vOld ver' v'Old e≡ r≡
+
+    -- (B) One is new, one is old: use PredStep-wlog-ht'
+    PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
+       | inj₁ (vValid , vNew) | inj₂ v'Old
+      with sameHonestSig⇒sameVoteData hpk ver' (msgSigned v'Old) (sym (msgSameSig v'Old))
+    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
+    ...| inj₂ refl
+       = PredStep-wlog-ht' preach hip ps v⊂m m∈outs (msg⊆ v'Old) (msg∈pool v'Old) ver (msgSigned v'Old) hpk e≡ r≡
+
+    -- (C) One is old, one is new: use PredStep-wlog-ht'
+    PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
+       | inj₂ vOld            | inj₁ (v'Valid , v'New)
+      with sameHonestSig⇒sameVoteData hpk ver (msgSigned vOld) (sym (msgSameSig vOld))
+    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
+    ...| inj₂ refl
+       = sym (PredStep-wlog-ht' preach hip ps v'⊂m' m'∈outs (msg⊆ vOld) (msg∈pool vOld) ver' (msgSigned vOld) hpk (sym e≡) (sym r≡))
+
+    -- (D) Finally, both votes are new in this step. The proof is then trivially
+    -- forwarded to the implementation obligation.
+    PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
+       | inj₁ (vValid , vNew) | inj₁ (v'Valid , v'New)
+       = Impl-VO2 preach ps hpk v⊂m m∈outs ver vNew vValid v'⊂m' m'∈outs ver' v'New v'Valid e≡ r≡
+
+    PredStep-hh
+      : ∀{e pid st' outs}{pre : SystemState e}
+      → ReachableSystemState pre
+      → (pstep : StepPeer pre pid st' outs)
+      → Pred pre
+      → ∀{pk v v'}
+      → let pool = msgPool (StepPeer-post pstep)
+         in Meta-Honest-PK pk
+          → (ver  : WithVerSig pk v )(sv  : MsgWithSig∈ pk (ver-signature ver ) pool)
+          → (msgSender sv  , msgWhole sv)  ∈ List-map (pid ,_) outs
+          → (ver' : WithVerSig pk v')(sv' : MsgWithSig∈ pk (ver-signature ver') pool)
+          → (msgSender sv' , msgWhole sv') ∈ List-map (pid ,_) outs
+          → v ^∙ vEpoch ≡ v' ^∙ vEpoch
+          → v ^∙ vRound ≡ v' ^∙ vRound
+          → v ^∙ vProposedId ≡ v' ^∙ vProposedId
+    PredStep-hh preach (step-cheat fm isCheat) hip hpk ver sv (here refl) ver' sv' (here refl) epoch≡ r≡
+      with isCheat (msg⊆ sv) (msgSigned sv)
+    ...| inj₁ abs    = ⊥-elim (hpk abs) -- The key was honest by hypothesis.
+    ...| inj₂ sentb4
+      with isCheat (msg⊆ sv') (msgSigned sv')
+    ...| inj₁ abs     = ⊥-elim (hpk abs) -- The key was honest by hypothesis.
+    ...| inj₂ sentb4'
+      with msgSameSig sv | msgSameSig sv'
+    ...| refl | refl = hip hpk ver sentb4 ver' sentb4' epoch≡ r≡
+    PredStep-hh preach (step-honest x) hip hpk ver sv thisStep ver' sv' thisStep' epoch≡ r≡
+      with sameHonestSig⇒sameVoteData hpk ver (msgSigned sv) (sym (msgSameSig sv))
+    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
+    ...| inj₂ refl
+      with sameHonestSig⇒sameVoteData hpk ver' (msgSigned sv') (sym (msgSameSig sv'))
+    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
+    ...| inj₂ refl
+       = PredStep-hh' preach hip x
+                 (msg⊆ sv ) (Any-map (cong proj₂) (Any-map⁻ thisStep))
+                 (msg⊆ sv') (Any-map (cong proj₂) (Any-map⁻ thisStep'))
+                 (msgSigned sv) (msgSigned sv') hpk epoch≡ r≡
+
+
+    PredStep : ∀{e pid st' outs}{pre : SystemState e}
              → ReachableSystemState pre
+             → (pstep : StepPeer pre pid st' outs)
              → Pred pre
-             → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) s' outs
-             → ∀{v m v' m'}
-             → v  ⊂Msg m  → m ∈ outs
-             → v' ⊂Msg m' → (pid' , m') ∈ msgPool pre
-             → WithVerSig pk v → WithVerSig pk v' → Meta-Honest-PK pk
-             → (v ^∙ vEpoch) ≡ (v' ^∙ vEpoch)
-             → (v ^∙ vProposed ∙ biRound) ≡ (v' ^∙ vProposed ∙ biRound)
-             → (v ^∙ vProposed ∙ biId) ≡ (v' ^∙ vProposed ∙ biId)
-     PredStep-wlog-ht' {pre = pre} preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈pool ver ver' hpk eids≡ r≡
-     -- (1) The first step is branching on whether 'v' above is a /new/ vote or not.
-     -- (1.1) If it's new:
-       with sps-corr preach hpk ps m∈outs v⊂m ver
-     ...| inj₁ (vValid , vNew)
-       with honestPartValid preach hpk v'⊂m' m'∈pool ver'
-     ...| v'Old , vOldValid
-       with sameHonestSig⇒sameVoteData hpk ver' (msgSigned v'Old) (sym (msgSameSig v'Old))
-     ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-     ...| inj₂ refl = Impl-VO1 preach ps hpk v⊂m m∈outs ver vNew vValid
-                        (msg⊆ v'Old) (msg∈pool v'Old)
-                        (msgSigned v'Old) eids≡ r≡
-     -- (1.1) If 'v' is not new, then there exists a msg sent with the
-     -- same signature.
-     PredStep-wlog-ht' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈pool ver ver' hpk e≡ r≡
-        | inj₂ vOld
-       with honestPartValid preach hpk v'⊂m' m'∈pool ver'
-     ...| sv' , _ = hip hpk ver vOld ver' sv' e≡ r≡
+             → Pred (StepPeer-post pstep)
+    PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
+    -- First we check when have the votes been sent:
+      with Any-++⁻ (List-map (pid ,_) outs) {msgPool pre} (msg∈pool sv)
+         | Any-++⁻ (List-map (pid ,_) outs) {msgPool pre} (msg∈pool sv')
+    -- (A) Neither vote has been sent by the step under scrutiny: invoke inductive hypothesis
+    ...| inj₂ furtherBack | inj₂ furtherBack'
+       = hip hpk ver  (MsgWithSig∈-transp sv furtherBack)
+                 ver' (MsgWithSig∈-transp sv' furtherBack') epoch≡ r≡
+    -- (B) One vote was cast here; the other was cast in the past.
+    PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
+       | inj₁ thisStep    | inj₂ furtherBack'
+       = PredStep-wlog-ht preach pstep hip hpk ver sv thisStep ver' sv' furtherBack' epoch≡ r≡
+    -- (C) Symmetric to (B)
+    PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
+       | inj₂ furtherBack | inj₁ thisStep'
+       = sym (PredStep-wlog-ht preach pstep hip hpk ver' sv' thisStep' ver sv furtherBack (sym epoch≡) (sym r≡))
+    -- (D) Both votes were cast here
+    PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
+       | inj₁ thisStep    | inj₁ thisStep'
+       = PredStep-hh preach pstep hip hpk ver sv thisStep ver' sv' thisStep' epoch≡ r≡
 
-     -- Here we prove a modified version of Pred'' where we assume w.l.o.g that
-     -- one vote is sent by "pstep" and another was present in the prestate.
-     PredStep-wlog-ht
-       : ∀{e pid st' outs}{pre : SystemState e}
-       → ReachableSystemState pre
-       → (pstep : StepPeer pre pid st' outs)
-       → Pred pre
-       → ∀{pk v v'}
-       -- Below is a inline expansion of "Pred'' pk v v' (msgPool (StepPeer-post pstep))",
-       -- but with the added information that one vote (v) was sent by pstep whereas the
-       -- other (v') was in the pool of the prestate.
-       → let pool = msgPool (StepPeer-post pstep)
-          in Meta-Honest-PK pk
-           → (ver  : WithVerSig pk v )(sv  : MsgWithSig∈ pk (ver-signature ver ) pool)
-           → (msgSender sv , msgWhole sv) ∈ List-map (pid ,_) outs
-           → (ver' : WithVerSig pk v')(sv' : MsgWithSig∈ pk (ver-signature ver') pool)
-           → (msgSender sv' , msgWhole sv') ∈ msgPool pre
-           → v ^∙ vEpoch ≡ v' ^∙ vEpoch
-           → v ^∙ vRound ≡ v' ^∙ vRound
-           → v ^∙ vProposedId ≡ v' ^∙ vProposedId
-     PredStep-wlog-ht preach (step-cheat fm isCheat) hip hpk ver sv (here refl) ver' sv' furtherBack' epoch≡ r≡
-       with isCheat (msg⊆ sv) (msgSigned sv)
-     ...| inj₁ abs    = ⊥-elim (hpk abs) -- The key was honest by hypothesis.
-     ...| inj₂ sentb4
-        -- the cheater replayed the message; which means the message was sent before this
-        -- step; hence, call induction hypothesis.
-       with msgSameSig sv
-     ...| refl = hip hpk ver sentb4 ver' (MsgWithSig∈-transp sv' furtherBack') epoch≡ r≡
-     PredStep-wlog-ht preach (step-honest x) hip hpk ver sv thisStep ver' sv' furtherBack' epoch≡ r≡
-       with sameHonestSig⇒sameVoteData hpk ver (msgSigned sv) (sym (msgSameSig sv))
-     ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-     ...| inj₂ refl
-       with sameHonestSig⇒sameVoteData hpk ver' (msgSigned sv') (sym (msgSameSig sv'))
-     ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-     ...| inj₂ refl
-        = PredStep-wlog-ht' preach hip x
-                  (msg⊆ sv) (Any-map (cong proj₂) (Any-map⁻ thisStep))
-                  (msg⊆ sv') furtherBack'
-                  (msgSigned sv) (msgSigned sv') hpk epoch≡ r≡
-
-     -- Analogous to PredStep-wlog-ht', but here we must reason about two messages that are in the
-     -- outputs of a step.
-     PredStep-hh' : ∀{e pid s' outs pk}{pre : SystemState e}
-             → ReachableSystemState pre → Pred pre
-             → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) s' outs
-             → ∀{v m v' m'}
-             → v  ⊂Msg m  → m  ∈ outs
-             → v' ⊂Msg m' → m' ∈ outs
-             → WithVerSig pk v → WithVerSig pk v' → Meta-Honest-PK pk
-             → (v ^∙ vEpoch) ≡ (v' ^∙ vEpoch)
-             → (v ^∙ vProposed ∙ biRound) ≡ (v' ^∙ vProposed ∙ biRound)
-             → (v ^∙ vProposed ∙ biId) ≡ (v' ^∙ vProposed ∙ biId)
-     -- Since the step is from an honest peer, we can check whether the messages are in fact
-     -- new or not.
-     PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
-       with sps-corr preach hpk ps m∈outs v⊂m ver | sps-corr preach hpk ps m'∈outs v'⊂m' ver'
-     -- (A) Both are old: call induction hypothesis
-     ...| inj₂ vOld            | inj₂ v'Old = hip hpk ver vOld ver' v'Old e≡ r≡
-
-     -- (B) One is new, one is old: use PredStep-wlog-ht'
-     PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
-        | inj₁ (vValid , vNew) | inj₂ v'Old
-       with sameHonestSig⇒sameVoteData hpk ver' (msgSigned v'Old) (sym (msgSameSig v'Old))
-     ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-     ...| inj₂ refl
-        = PredStep-wlog-ht' preach hip ps v⊂m m∈outs (msg⊆ v'Old) (msg∈pool v'Old) ver (msgSigned v'Old) hpk e≡ r≡
-
-     -- (C) One is old, one is new: use PredStep-wlog-ht'
-     PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
-        | inj₂ vOld            | inj₁ (v'Valid , v'New)
-       with sameHonestSig⇒sameVoteData hpk ver (msgSigned vOld) (sym (msgSameSig vOld))
-     ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-     ...| inj₂ refl
-        = sym (PredStep-wlog-ht' preach hip ps v'⊂m' m'∈outs (msg⊆ vOld) (msg∈pool vOld) ver' (msgSigned vOld) hpk (sym e≡) (sym r≡))
-
-     -- (D) Finally, both votes are new in this step. The proof is then trivially
-     -- forwarded to the implementation obligation.
-     PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
-        | inj₁ (vValid , vNew) | inj₁ (v'Valid , v'New)
-        = Impl-VO2 preach ps hpk v⊂m m∈outs ver vNew vValid v'⊂m' m'∈outs ver' v'New v'Valid e≡ r≡
-
-     PredStep-hh
-       : ∀{e pid st' outs}{pre : SystemState e}
-       → ReachableSystemState pre
-       → (pstep : StepPeer pre pid st' outs)
-       → Pred pre
-       → ∀{pk v v'}
-       → let pool = msgPool (StepPeer-post pstep)
-          in Meta-Honest-PK pk
-           → (ver  : WithVerSig pk v )(sv  : MsgWithSig∈ pk (ver-signature ver ) pool)
-           → (msgSender sv  , msgWhole sv)  ∈ List-map (pid ,_) outs
-           → (ver' : WithVerSig pk v')(sv' : MsgWithSig∈ pk (ver-signature ver') pool)
-           → (msgSender sv' , msgWhole sv') ∈ List-map (pid ,_) outs
-           → v ^∙ vEpoch ≡ v' ^∙ vEpoch
-           → v ^∙ vRound ≡ v' ^∙ vRound
-           → v ^∙ vProposedId ≡ v' ^∙ vProposedId
-     PredStep-hh preach (step-cheat fm isCheat) hip hpk ver sv (here refl) ver' sv' (here refl) epoch≡ r≡
-       with isCheat (msg⊆ sv) (msgSigned sv)
-     ...| inj₁ abs    = ⊥-elim (hpk abs) -- The key was honest by hypothesis.
-     ...| inj₂ sentb4
-       with isCheat (msg⊆ sv') (msgSigned sv')
-     ...| inj₁ abs     = ⊥-elim (hpk abs) -- The key was honest by hypothesis.
-     ...| inj₂ sentb4'
-       with msgSameSig sv | msgSameSig sv'
-     ...| refl | refl = hip hpk ver sentb4 ver' sentb4' epoch≡ r≡
-     PredStep-hh preach (step-honest x) hip hpk ver sv thisStep ver' sv' thisStep' epoch≡ r≡
-       with sameHonestSig⇒sameVoteData hpk ver (msgSigned sv) (sym (msgSameSig sv))
-     ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-     ...| inj₂ refl
-       with sameHonestSig⇒sameVoteData hpk ver' (msgSigned sv') (sym (msgSameSig sv'))
-     ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-     ...| inj₂ refl
-        = PredStep-hh' preach hip x
-                  (msg⊆ sv ) (Any-map (cong proj₂) (Any-map⁻ thisStep))
-                  (msg⊆ sv') (Any-map (cong proj₂) (Any-map⁻ thisStep'))
-                  (msgSigned sv) (msgSigned sv') hpk epoch≡ r≡
-
-
-     PredStep : ∀{e pid st' outs}{pre : SystemState e}
-              → ReachableSystemState pre
-              → (pstep : StepPeer pre pid st' outs)
-              → Pred pre
-              → Pred (StepPeer-post pstep)
-     PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
-     -- First we check when have the votes been sent:
-       with Any-++⁻ (List-map (pid ,_) outs) {msgPool pre} (msg∈pool sv)
-          | Any-++⁻ (List-map (pid ,_) outs) {msgPool pre} (msg∈pool sv')
-     -- (A) Neither vote has been sent by the step under scrutiny: invoke inductive hypothesis
-     ...| inj₂ furtherBack | inj₂ furtherBack'
-        = hip hpk ver  (MsgWithSig∈-transp sv furtherBack)
-                  ver' (MsgWithSig∈-transp sv' furtherBack') epoch≡ r≡
-     -- (B) One vote was cast here; the other was cast in the past.
-     PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
-        | inj₁ thisStep    | inj₂ furtherBack'
-        = PredStep-wlog-ht preach pstep hip hpk ver sv thisStep ver' sv' furtherBack' epoch≡ r≡
-     -- (C) Symmetric to (B)
-     PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
-        | inj₂ furtherBack | inj₁ thisStep'
-        = sym (PredStep-wlog-ht preach pstep hip hpk ver' sv' thisStep' ver sv furtherBack (sym epoch≡) (sym r≡))
-     -- (D) Both votes were cast here
-     PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
-        | inj₁ thisStep    | inj₁ thisStep'
-        = PredStep-hh preach pstep hip hpk ver sv thisStep ver' sv' thisStep' epoch≡ r≡
-
-    voo : VO.Type ConcSystemState
-    voo hpk refl sv refl sv' round≡
-      with Step*-Step-fold Pred (λ {e} {st} _ → Pred𝓔 {e} {st}) PredStep Pred₀ r
-    ...| res
-      with vmsg≈v (vmFor sv) | vmsg≈v (vmFor sv')
-    ...| refl | refl
-       = res hpk (vmsgSigned (vmFor sv))
-                 (mkMsgWithSig∈ (nm (vmFor sv)) (cv (vmFor sv)) (cv∈nm (vmFor sv))
-                                _ (nmSentByAuth sv) (vmsgSigned (vmFor sv)) refl)
-                 (vmsgSigned (vmFor sv'))
-                 (mkMsgWithSig∈ (nm (vmFor sv')) (cv (vmFor sv')) (cv∈nm (vmFor sv'))
-                                _ (nmSentByAuth sv') (vmsgSigned (vmFor sv')) refl)
-                 (trans (vmsgEpoch (vmFor sv)) (sym (vmsgEpoch (vmFor sv'))))
-                 round≡
+   voo : VO.Type ConcSystemState
+   voo hpk refl sv refl sv' round≡
+     with Step*-Step-fold Pred (λ {e} {st} _ → Pred𝓔 {e} {st}) PredStep Pred₀ r
+   ...| res
+     with vmsg≈v (vmFor sv) | vmsg≈v (vmFor sv')
+   ...| refl | refl
+      = res hpk (vmsgSigned (vmFor sv))
+                (mkMsgWithSig∈ (nm (vmFor sv)) (cv (vmFor sv)) (cv∈nm (vmFor sv))
+                               _ (nmSentByAuth sv) (vmsgSigned (vmFor sv)) refl)
+                (vmsgSigned (vmFor sv'))
+                (mkMsgWithSig∈ (nm (vmFor sv')) (cv (vmFor sv')) (cv∈nm (vmFor sv'))
+                               _ (nmSentByAuth sv') (vmsgSigned (vmFor sv')) refl)
+                (trans (vmsgEpoch (vmFor sv)) (sym (vmsgEpoch (vmFor sv'))))
+                round≡

--- a/LibraBFT/Concrete/Records.agda
+++ b/LibraBFT/Concrete/Records.agda
@@ -96,7 +96,7 @@ module LibraBFT.Concrete.Records (𝓔 : EpochConfig) where
    ; qRound       = qc ^∙ qcVoteData ∙ vdProposed ∙ biRound
    ; qVotes       = All-reduce (α-Vote qc valid) All-self
    ; qVotes-C1    = {!!} -- this proofs will come from the KV-store module
-   ; qVotes-C2    = subst (_ ≤_) {!!} (IsValidQC.₋ivqcSizeOk valid)
+   ; qVotes-C2    = {! IsValidQC.₋ivqcIsQuorum valid!}
    ; qVotes-C3    = All-reduce⁺ (α-Vote qc valid) (λ _ → refl) All-self
    ; qVotes-C4    = All-reduce⁺ (α-Vote qc valid) (λ _ → refl) All-self
    ; qVotes-C5    = All-reduce⁺ (α-Vote qc valid) (α-Vote-evidence qc valid) All-self

--- a/LibraBFT/Impl/Consensus/Types.agda
+++ b/LibraBFT/Impl/Consensus/Types.agda
@@ -78,16 +78,7 @@ module LibraBFT.Impl.Consensus.Types where
         qsize      = epec ^∙ epValidators ∙ vvQuorumVotingPower
         bizF       = numAuthors ∸ qsize
      in (mkEpochConfig {! someHash?!}
-                (epec ^∙ epEpoch)
-                numAuthors
-                bizF
-                ok
-                {!!}
-                {!!}
-                {!!}
-                {!!}
-                {!!}
-                {!!})
+                (epec ^∙ epEpoch) numAuthors {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!})
 
   α-EC-≡ : (epec1  : EventProcessorEC)
          → (epec2  : EventProcessorEC)

--- a/LibraBFT/Impl/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochDep.agda
@@ -3,6 +3,7 @@
    Copyright (c) 2020 Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+{-# OPTIONS --allow-unsolved-metas #-}
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Hash
@@ -144,9 +145,8 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   -- cast by different authors.
   record IsValidQC (qc : QuorumCert) : Set where
     field
-      ₋ivqcSizeOk          : QSize ≤ length (qcVotes qc)
-      ₋ivqcAuthorsDistinct : allDistinct (List-map (isMember? ∘ proj₁) (qcVotes qc)) -- TODO-2: consider using the sortedBy _<_ trick; might be simpler.
       ₋ivqcVotesValid      : All (IsValidVote ∘ rebuildVote qc) (qcVotes qc)
+      ₋ivqcIsQuorum        : IsQuorum {! !}  -- TODO: extract list of abstract members using ₋ivqcVotesValid
   open IsValidQC public
 
   vqcMember : (qc : QuorumCert) → IsValidQC qc

--- a/LibraBFT/Impl/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochDep.agda
@@ -141,12 +141,13 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   ₋cveSignature : ∀{vd} → ConcreteVoteEvidence vd → Signature
   ₋cveSignature = ₋vSignature ∘ ₋cveVote
 
-  -- A valid quorum certificate is a collection of at least QSize valid votes
-  -- cast by different authors.
+  -- A valid quorum certificate contains a collection of valid votes, such that
+  -- the members represented by those votes (which exist because the votes are valid)
+  -- constitutes a quorum.
   record IsValidQC (qc : QuorumCert) : Set where
     field
       ₋ivqcVotesValid      : All (IsValidVote ∘ rebuildVote qc) (qcVotes qc)
-      ₋ivqcIsQuorum        : IsQuorum {! !}  -- TODO: extract list of abstract members using ₋ivqcVotesValid
+      ₋ivqcIsQuorum        : IsQuorum {!!}  -- TODO: extract list of abstract members using ₋ivqcVotesValid?
   open IsValidQC public
 
   vqcMember : (qc : QuorumCert) → IsValidQC qc

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -142,6 +142,13 @@ module LibraBFT.Lemmas where
  IsSorted-map⁻ f .(_ ∷ []) (x ∷ []) = [] ∷ []
  IsSorted-map⁻ f .(_ ∷ _ ∷ _) (on-∷ x ∷ (x₁ ∷ is)) = (on-∷ x) ∷ IsSorted-map⁻ f _ (x₁ ∷ is)
 
+ -- TODO-1 : Better name and/or replace with library property
+ Any-sym : ∀ {a b}{A : Set a}{B : Set b}{tgt : B}{l : List A}{f : A → B}
+         → Any (λ x → tgt ≡ f x) l
+         → Any (λ x → f x ≡ tgt) l
+ Any-sym (here x)  = here (sym x)
+ Any-sym (there x) = there (Any-sym x)
+
  Any-lookup-correct :  ∀ {a b}{A : Set a}{B : Set b}{tgt : B}{l : List A}{f : A → B}
                     → (p : Any (λ x → f x ≡ tgt) l)
                     → Any-lookup p ∈ l

--- a/LibraBFT/Yasm/AvailableEpochs.agda
+++ b/LibraBFT/Yasm/AvailableEpochs.agda
@@ -37,20 +37,20 @@ module LibraBFT.Yasm.AvailableEpochs where
  fromℕ-≤-step-natural (s≤s (s≤s prf)) = cong suc (fromℕ-≤-step-natural (s≤s prf))
 
 
- Vec-All-lookup∘tabulate : ∀{n}{A : Set}{v : Vec A n}{P : A → Set}
+ Vec-All-lookup∘tabulate : ∀{n}{A : Set}{v : Vec A n}{ℓ : Level}{P : A → Set ℓ}
                          → (f : (x : Fin n) → P (Vec-lookup v x))(i : Fin n)
                          → Vec-All.lookup {P = P} i (Vec-All.tabulate {xs = v} f) ≡ f i
  Vec-All-lookup∘tabulate {v = v₀ ∷ vs} f zero = refl
  Vec-All-lookup∘tabulate {v = v₀ ∷ vs} f (suc i) = Vec-All-lookup∘tabulate (f ∘ suc) i
 
- subst-elim : {A : Set}(P : A → Set){a₀ a₁ : A}
+ subst-elim : {A : Set}{ℓ : Level}(P : A → Set ℓ){a₀ a₁ : A}
             → (prf : a₀ ≡ a₁)(x : P a₁)
             → subst P prf (subst P (sym prf) x) ≡ x
  subst-elim _ refl x = refl
 
  -- Available epochs consist of a vector of EpochConfigs with
  -- the correct epoch ids.
- AvailableEpochs : ℕ → Set
+ AvailableEpochs : ℕ → Set₁
  AvailableEpochs = Vec-All (EpochConfigFor ∘ toℕ) ∘ Vec-allFin
 
  lookup : ∀{e} → AvailableEpochs e → (ix : Fin e) → EpochConfigFor (toℕ ix)

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -26,7 +26,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
  -- A ValidPartForPK collects the assumptions about what a /part/ in the outputs of an honest verifier
  -- satisfies: (i) the epoch field is consistent with the existent epochs and (ii) the verifier is
  -- a member of the associated epoch config, and (iii) has the given PK in that epoch.
- record ValidPartForPK {e}(𝓔s : AvailableEpochs e)(part : Part)(pk : PK) : Set where
+ record ValidPartForPK {e}(𝓔s : AvailableEpochs e)(part : Part)(pk : PK) : Set₁ where
    constructor mkValidPartForPK
    field
      vp-epoch           : part-epoch part < e
@@ -63,7 +63,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
  -- output of a 'StepPeerState' are either: (i) a valid new part (i.e., the part is valid and has
  -- not been included in a previously sent message with the same signature), or (ii) the part been
  -- included in a previously sent message with the same signature.
- StepPeerState-AllValidParts : Set
+ StepPeerState-AllValidParts : Set₁
  StepPeerState-AllValidParts = ∀{e s m part pk outs α}{𝓔s : AvailableEpochs e}{st : SystemState e}
    → (r : ReachableSystemState st)
    → Meta-Honest-PK pk
@@ -76,8 +76,8 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
    ⊎ MsgWithSig∈ pk (ver-signature ver) (msgPool st)
 
  -- A /part/ was introduced by a specific step when:
- IsValidNewPart : ∀{e e'}{pre : SystemState e}{post : SystemState e'} → Signature → PK → Step pre post → Set
- IsValidNewPart _ _ (step-epoch _) = ⊥
+ IsValidNewPart : ∀{e e'}{pre : SystemState e}{post : SystemState e'} → Signature → PK → Step pre post → Set₁
+ IsValidNewPart _ _ (step-epoch _) = Lift (ℓ+1 0ℓ) ⊥
  -- said step is a /step-peer/ and
  IsValidNewPart {pre = pre} sig pk (step-peer pstep)
     -- the part has never been seen before
@@ -100,7 +100,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
      unwind : ∀{e}{st : SystemState e}(tr : ReachableSystemState st)
             → ∀{p m σ pk} → Meta-Honest-PK pk
             → p ⊂Msg m → (σ , m) ∈ msgPool st → (ver : WithVerSig pk p)
-            → Any-Step (IsValidNewPart (ver-signature ver) pk) tr
+            → Any-Step ((IsValidNewPart (ver-signature ver) pk)) tr
      unwind (step-s tr (step-epoch _))    hpk p⊂m m∈sm sig
        = step-there (unwind tr hpk p⊂m m∈sm sig)
      unwind (step-s tr (step-peer {pid = β} {outs = outs} {pre = pre} sp)) hpk p⊂m m∈sm sig
@@ -124,6 +124,7 @@ module LibraBFT.Yasm.Properties (parms : SystemParameters) where
        with sps-avp tr hpk x m∈outs p⊂m sig
      ...| inj₂ sentb4 with unwind tr {p = msgPart sentb4} hpk (msg⊆ sentb4) (msg∈pool sentb4) (msgSigned sentb4)
      ...| res rewrite msgSameSig sentb4 = step-there res
+     
      unwind (step-s tr (step-peer {pid = β} {outs = outs} {pre = pre} sp)) {p} hpk p⊂m m∈sm sig
         | inj₁ thisStep
         | step-honest x

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -165,7 +165,7 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
  --
  -- A system consists in a partial map from PeerId to PeerState, a pool
  -- of sent messages and a number of available epochs.
- record SystemState (e : ℕ) : Set where
+ record SystemState (e : ℕ) : Set₁ where
    field
      peerStates  : Map PeerId PeerState
      msgPool     : SentMessages          -- All messages ever sent
@@ -242,7 +242,7 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
    ; msgPool    = List-map (pid ,_) outs ++ msgPool pre
    }
 
- data Step : ∀{e e'} → SystemState e → SystemState e' → Set where
+ data Step : ∀{e e'} → SystemState e → SystemState e' → Set₁ where
    step-epoch : ∀{e}{pre : SystemState e}
               → (𝓔 : EpochConfigFor e)
               -- TODO-3: Eventually, we'll condition this step to only be
@@ -273,7 +273,7 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
 
  -- * Reflexive-Transitive Closure
 
- data Step* : ∀{e e'} → SystemState e → SystemState e' → Set where
+ data Step* : ∀{e e'} → SystemState e → SystemState e' → Set₁ where
    step-0 : ∀{e}{pre : SystemState e}
           → Step* pre pre
 
@@ -282,7 +282,7 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
           → Step pre post
           → Step* fst post
 
- ReachableSystemState : ∀{e} → SystemState e → Set
+ ReachableSystemState : ∀{e} → SystemState e → Set₁
  ReachableSystemState = Step* initialState
 
  Step*-mono : ∀{e e'}{st : SystemState e}{st' : SystemState e'}
@@ -314,8 +314,8 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
  ------------------------------------------
 
  -- Type synonym to express a relation over system states;
- SystemStateRel : (∀{e e'} → SystemState e → SystemState e' → Set) → Set₁
- SystemStateRel P = ∀{e e'}{st : SystemState e}{st' : SystemState e'} → P st st' → Set
+ SystemStateRel : (∀{e e'} → SystemState e → SystemState e' → Set₁) → Set₂
+ SystemStateRel P = ∀{e e'}{st : SystemState e}{st' : SystemState e'} → P st st' → Set₁
 
  -- Just like Data.List.Any maps a predicate over elements to a predicate over lists,
  -- Any-step maps a relation over steps to a relation over steps in a trace.
@@ -332,7 +332,7 @@ module LibraBFT.Yasm.System (parms : SystemParameters) where
              → Any-Step P (step-s cont this)
 
  Any-Step-elim
-   : ∀{e₀ e₁}{st₀ : SystemState e₀}{st₁ : SystemState e₁}{P : SystemStateRel Step}{Q : Set}
+   : ∀{e₀ e₁}{st₀ : SystemState e₀}{st₁ : SystemState e₁}{P : SystemStateRel Step}{Q : Set₁}
    → {r : Step* st₀ st₁}
    → (P⇒Q : ∀{d d'}{s : SystemState d}{s' : SystemState d'}{st : Step s s'}
           → P st → Step* s' st₁ → Q)


### PR DESCRIPTION
So far, our abstract `EpochConfig` has baked in assumptions about the number of peers, maximum assumed faulty, and quorum size.  This is fundamentally a "one peer, one vote" regime, but some implementations, including LIbraBFT assign quorums differently (LibraBFT assigns Voting Power to peers, perhaps not uniformly, and requires a quorum to exceed a threshold of voting power).

This pull request generalizes `EpochConfig` so that the implementation provides an `IsQuorum` predicate on lists of members, and a property that says that, given any two such lists that both satisfy `IsQuorum`, there is an honest peer in their intersection.

Because `EpochConfig` includes a predicate on lists of members, `EpochConfig` becomes `Set₁`, which propagates around quite a bit.

There is one hole left to be filled, extracting members of votes from a `QC` in order to define `IsValidQC` in our out-of-date, partial implementation.

