### PR TITLE
For consistency with paper, minor refactor and remove unneeded names

### DIFF
--- a/LibraBFT/Abstract/RecordChain/Assumptions.agda
+++ b/LibraBFT/Abstract/RecordChain/Assumptions.agda
@@ -30,6 +30,7 @@ module LibraBFT.Abstract.RecordChain.Assumptions
   open import LibraBFT.Abstract.RecordChain      𝓔 UID _≟UID_ 𝓥
 
   open EpochConfig 𝓔
+  open WithEpochConfig 𝓔
 
   module _ {ℓ}(InSys : Record → Set ℓ) where
 
@@ -38,7 +39,7 @@ module LibraBFT.Abstract.RecordChain.Assumptions
    VotesOnlyOnceRule : Set ℓ
    VotesOnlyOnceRule
       -- Given an honest α
-      = (α : Member) → (hpk : Meta-Honest-Member 𝓔 α)
+      = (α : Member) → Meta-Honest-Member α
       -- For all system states where q and q' exist,
       → ∀{q q'} → (q∈𝓢 : InSys (Q q)) → (q'∈𝓢 : InSys (Q q'))
       -- such that α voted for q and q'; if α says it's the same vote, then it's the same vote.
@@ -101,7 +102,7 @@ module LibraBFT.Abstract.RecordChain.Assumptions
    --
    LockedRoundRule : Set ℓ
    LockedRoundRule
-     = ∀(α : Member)(hpk : Meta-Honest-Member 𝓔 α)
+     = ∀(α : Member) → Meta-Honest-Member α
      → ∀{q q'}(q∈𝓢 : InSys (Q q))(q'∈𝓢 : InSys (Q q'))
      → {rc : RecordChain (Q q)}{n : ℕ}(c3 : 𝕂-chain Contig (3 + n) rc)
      → (vα : α ∈QC q) -- α knows of the 2-chain because it voted on the tail of the 3-chain!

--- a/LibraBFT/Abstract/System.agda
+++ b/LibraBFT/Abstract/System.agda
@@ -43,6 +43,8 @@ module LibraBFT.Abstract.System
     All-InSys-step hyp ext r here = r
     All-InSys-step hyp ext r (there .ext r∈rc) = hyp r∈rc
 
+  open WithEpochConfig 𝓔
+
   -- We say an InSys predicate is /Complete/ when we can construct a record chain
   -- from any vote by an honest participant. This essentially says that whenever
   -- an honest participant casts a vote, they have checked that the voted-for
@@ -51,7 +53,7 @@ module LibraBFT.Abstract.System
   -- require only a short suffix of a RecordChain.
   Complete : ∀{ℓ} → (Record → Set ℓ) → Set ℓ
   Complete ∈sys = ∀{α q}
-                → Meta-Honest-Member 𝓔 α
+                → Meta-Honest-Member α
                 → α ∈QC q
                 → ∈sys (Q q)
                 → ∃[ b ] ( Σ (RecordChain (B b)) All-InSys

--- a/LibraBFT/Abstract/Types.agda
+++ b/LibraBFT/Abstract/Types.agda
@@ -78,9 +78,11 @@ module LibraBFT.Abstract.Types where
               → EpochConfig.Member 𝓔'
   MemberSubst refl = id
 
-  -- A member of an epoch is considered "honest" iff its public key is honest.
-  Meta-Honest-Member : (𝓔 : EpochConfig) → Member 𝓔 → Set
-  Meta-Honest-Member 𝓔 α = Meta-Honest-PK (getPubKey 𝓔 α)
+  module WithEpochConfig (𝓔 : EpochConfig) where
+
+    -- A member of an epoch is considered "honest" iff its public key is honest.
+    Meta-Honest-Member : Member 𝓔 → Set
+    Meta-Honest-Member α = Meta-Honest-PK (getPubKey 𝓔 α)
 
   -- Naturally, if two witnesses that two authors belong
   -- in the epoch are the same, then the authors are also the same.

--- a/LibraBFT/Concrete/Intermediate.agda
+++ b/LibraBFT/Concrete/Intermediate.agda
@@ -30,6 +30,8 @@ module LibraBFT.Concrete.Intermediate
 
    open import LibraBFT.Abstract.Records         𝓔 UID _≟UID_ 𝓥
 
+   open WithEpochConfig 𝓔
+
    -- Since the invariants we want to specify (votes-once and locked-round-rule),
    -- are predicates over a /System State/, we must factor out the necessary
    -- functionality.
@@ -46,5 +48,5 @@ module LibraBFT.Concrete.Intermediate
 
        -- Such that, the votes that belong to honest participants inside a
        -- QC that exists in the system must have been sent
-       ∈QC⇒HasBeenSent : ∀{q α} → InSys (Q q) → Meta-Honest-Member 𝓔 α
+       ∈QC⇒HasBeenSent : ∀{q α} → InSys (Q q) → Meta-Honest-Member α
                        → (va : α ∈QC q) → HasBeenSent (∈QC-Vote q va)

--- a/LibraBFT/Concrete/Obligations/LockedRound.agda
+++ b/LibraBFT/Concrete/Obligations/LockedRound.agda
@@ -27,6 +27,7 @@ module LibraBFT.Concrete.Obligations.LockedRound
 
  module _ {ℓ}(𝓢 : IntermediateSystemState ℓ) where
   open IntermediateSystemState 𝓢
+  open WithEpochConfig 𝓔
 
  -- The LockedRound rule is a little more involved to be expressed in terms
  -- of /HasBeenSent/: it needs two additional pieces which are introduced
@@ -95,7 +96,7 @@ module LibraBFT.Concrete.Obligations.LockedRound
   -- Given two votes by an honest author α:
   Type : Set ℓ
   Type = ∀{α v v'}
-       → Meta-Honest-Member 𝓔 α
+       → Meta-Honest-Member α
        → vMember v  ≡ α → HasBeenSent v
        → vMember v' ≡ α → HasBeenSent v'
        -- If v is a vote on a candidate 3-chain, that is, is a vote on a block

--- a/LibraBFT/Concrete/Obligations/VotesOnce.agda
+++ b/LibraBFT/Concrete/Obligations/VotesOnce.agda
@@ -24,10 +24,11 @@ module LibraBFT.Concrete.Obligations.VotesOnce
 
  module _ {ℓ}(𝓢 : IntermediateSystemState ℓ) where
   open IntermediateSystemState 𝓢
+  open WithEpochConfig 𝓔
 
   Type : Set ℓ
   Type = ∀{α v v'}
-       → Meta-Honest-Member 𝓔 α
+       → Meta-Honest-Member α
        → vMember v  ≡ α → HasBeenSent v
        → vMember v' ≡ α → HasBeenSent v'
        → vRound v ≡ vRound v'

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -201,9 +201,11 @@ module LibraBFT.Concrete.System (sps-corr : StepPeerState-AllValidParts) where
        nmInOuts : nm vmFor ∈ outs
    open ∃VoteMsgInFor public
 
+   open WithEpochConfig 𝓔
+
    ∈QC⇒sent : ∀{e} {st : SystemState e} {q α}
             → Abs.Q q α-Sent (msgPool st)
-            → Meta-Honest-Member 𝓔 α
+            → Meta-Honest-Member α
             → (vα : α Abs.∈QC q)
             → ∃VoteMsgSentFor (msgPool st) (Abs.∈QC-Vote q vα)
 


### PR DESCRIPTION
Enable opening an inner module to avoid specifying the `EpochConfig` explicitly for `Meta-Honest-Member`. This is to enable consistency with the paper without cluttering the paper with the `EpochConfig`.

Signed-off-by: Mark Moir <mark.moir@oracle.com>