### PR TITLE
Lis bft lemma pr

### DIFF
--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -329,14 +329,15 @@ module LibraBFT.Abstract.BFT
            | map-tabulate n (g ∘ f ∘ suc) id = refl
 
 
-   onHead-zero : ∀ {n} → OnHead _<Fin_ zero (List-tabulate {0ℓ} {Fin (suc n)} suc)
-
-
    tabulateSort : ∀ (n : ℕ) → IsSorted _<Fin_ (List-tabulate {0ℓ} {Fin n} id)
    tabulateSort zero = []
-   tabulateSort (suc n)
-     with tabulateSort n
-   ...| xx = onHead-zero ∷ (subst (IsSorted _<Fin_) (map-tabulate n suc id) (map-suc-sort xx))
+   tabulateSort (suc zero) = [] ∷ []
+   tabulateSort (suc (suc n)) =
+     let rec      = tabulateSort (suc n)
+         sortSuc  = map-suc-sort rec
+         map∘Tab≡ = map-tabulate (suc n) suc id
+     in (on-∷ (s≤s z≤n)) ∷ (subst (IsSorted _<Fin_) map∘Tab≡ sortSuc)
+
 
 
    members⊆ : ∀ (xs : List Member) → xs ⊆List participants

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -246,6 +246,25 @@ module LibraBFT.Abstract.BFT
      = h∉t ((trans-OnHead x₁< x<) ∷ sxs) x∈xs
 
 
+   xx : ∀ {n} {f : Fin (suc n) → ℕ}
+      → List-map f (List-tabulate suc) ≡ List-map (f ∘ suc) (List-tabulate id)
+
+
+   xxx : ∀ {n} {xs : List (Fin n)} {f : Fin n → ℕ}
+       → IsSorted _<Fin_ xs
+       → sum (List-map f xs) ≤ sum (List-map f (List-tabulate id))
+   xxx {_} {[]} {f} x = z≤n
+   xxx {n} {x₁ ∷ xs} {f} x
+     with List-tabulate {0ℓ} {Fin n} id
+   ... | [] = {!!}
+   ... | x₂ ∷ ys = {!!}
+   {- xxx {n} {[]} {f} sxs l≤n = z≤n
+   xxx {suc n} {zero ∷ []} {f} ([] ∷ sxs) l≤n rewrite +-identityʳ (f zero)
+     = m≤m+n (f zero) (sum (List-map f (List-tabulate (id ∘ suc))))
+   xxx {suc n} {zero ∷ (x ∷ xs)} {f} (on-∷ z< ∷ sxs) l≤n = {!!}
+   xxx {suc n} {suc x ∷ xs} {f} sxs l≤n = {!!} -}
+
+
    _⊆List_ : ∀ {A : Set} → List A → List A → Set
    xs ⊆List ys = All (_∈ ys) xs
 
@@ -272,7 +291,22 @@ module LibraBFT.Abstract.BFT
      = ≤-stepsˡ (f y) (sum-⊆-≤ f (x₁ ∷ sxs) sys (px ∷ aux-1 xs∈ (aux-2 (x₁ ∷ sxs) (y₁ ∷ sys) px)))
 
 
-   tabulateSort : IsSorted _<Fin_ participants
+   map-tabulate : ∀ (n : ℕ)
+                → List-map suc (List-tabulate {0ℓ} {Fin n} id) ≡ List-tabulate {0ℓ} {Fin (suc n)} suc
+
+
+   map-suc-sort : ∀ {n} {xs : List (Fin n)}
+                → IsSorted _<Fin_ xs
+                → IsSorted _<Fin_ (List-map suc xs)
+
+
+   onHead-zero : ∀ {n} → OnHead _<Fin_ zero (List-tabulate {0ℓ} {Fin (suc n)} suc)
+
+   tabulateSort : ∀ (n : ℕ) → IsSorted _<Fin_ (List-tabulate {0ℓ} {Fin n} id)
+   tabulateSort zero = []
+   tabulateSort (suc n)
+     with tabulateSort n
+   ...| xx = onHead-zero ∷ (subst (IsSorted _<Fin_) (map-tabulate n) (map-suc-sort xx))
 
 
    members⊆ : ∀ (xs : List Member) → xs ⊆List participants
@@ -281,7 +315,7 @@ module LibraBFT.Abstract.BFT
    votingPower≤N : ∀ {xs : List Member} → IsSorted _<Fin_ xs
                    → CombinedPower xs ≤ N
    votingPower≤N {xs} sxs rewrite totalVotPower
-     = sum-⊆-≤ votPower sxs tabulateSort (members⊆ xs)
+     = sum-⊆-≤ votPower sxs (tabulateSort authorsN) (members⊆ xs)
 
 
    union-votPower : ∀ {xs ys : List Member}

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -339,8 +339,9 @@ module LibraBFT.Abstract.BFT
      in (on-∷ (s≤s z≤n)) ∷ (subst (IsSorted _<Fin_) map∘Tab≡ sortSuc)
 
 
-
    members⊆ : ∀ (xs : List Member) → xs ⊆List participants
+   members⊆ [] = []
+   members⊆ (x ∷ xs) = Any-tabulate⁺ x refl ∷ (members⊆ xs)
 
 
    votingPower≤N : ∀ {xs : List Member} → IsSorted _<Fin_ xs

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -312,11 +312,12 @@ module LibraBFT.Abstract.BFT
        in ≤-stepsˡ (f y) (sum-⊆-≤ f (x₁ ∷ sxs) sys (px ∷ xs∈ys))
 
 
-
-
    map-suc-sort : ∀ {n} {xs : List (Fin n)}
                 → IsSorted _<Fin_ xs
                 → IsSorted _<Fin_ (List-map suc xs)
+   map-suc-sort [] = []
+   map-suc-sort (x ∷ []) = [] ∷ []
+   map-suc-sort (on-∷ x< ∷ (x₁ ∷ sxs)) = (on-∷ (s≤s x<)) ∷ (map-suc-sort (x₁ ∷ sxs))
 
 
    map-tabulate : ∀  {A B : Set} (n : ℕ) (g : A → B) (f : Fin n → A)

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -312,8 +312,6 @@ module LibraBFT.Abstract.BFT
        in ≤-stepsˡ (f y) (sum-⊆-≤ f (x₁ ∷ sxs) sys (px ∷ xs∈ys))
 
 
-   map-tabulate : ∀ (n : ℕ)
-                → List-map suc (List-tabulate {0ℓ} {Fin n} id) ≡ List-tabulate {0ℓ} {Fin (suc n)} suc
 
 
    map-suc-sort : ∀ {n} {xs : List (Fin n)}
@@ -321,13 +319,23 @@ module LibraBFT.Abstract.BFT
                 → IsSorted _<Fin_ (List-map suc xs)
 
 
+   map-tabulate : ∀  {A B : Set} (n : ℕ) (g : A → B) (f : Fin n → A)
+                  → List-map g (List-tabulate f) ≡ List-tabulate (g ∘ f)
+   map-tabulate zero    _ _ = refl
+   map-tabulate (suc n) g f
+     rewrite sym (map-tabulate n (f ∘ suc) id)
+           | sym (List-map-compose  {g = g} {f = f ∘ suc} (List-tabulate id))
+           | map-tabulate n (g ∘ f ∘ suc) id = refl
+
+
    onHead-zero : ∀ {n} → OnHead _<Fin_ zero (List-tabulate {0ℓ} {Fin (suc n)} suc)
+
 
    tabulateSort : ∀ (n : ℕ) → IsSorted _<Fin_ (List-tabulate {0ℓ} {Fin n} id)
    tabulateSort zero = []
    tabulateSort (suc n)
      with tabulateSort n
-   ...| xx = onHead-zero ∷ (subst (IsSorted _<Fin_) (map-tabulate n) (map-suc-sort xx))
+   ...| xx = onHead-zero ∷ (subst (IsSorted _<Fin_) (map-tabulate n suc id) (map-suc-sort xx))
 
 
    members⊆ : ∀ (xs : List Member) → xs ⊆List participants

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -534,32 +534,37 @@ module LibraBFT.Abstract.BFT
 
    span-dis : ∀ {xs dis : List Member}
             → span Meta-dishonest? xs ≡ (dis , [])
-            → length xs ≡ length (List-filter Meta-dishonest? xs)
+            → List-filter Meta-dishonest? xs ≡ xs
+{-
    span-dis {[]} {dis} eq = refl
    span-dis {x ∷ xs} {dis} eq
      with Meta-dishonest? x | eq
    ...| no ¬dis  | ()
    ...| yes prf  | _
      with span Meta-dishonest? xs | inspect (span Meta-dishonest?) xs
-   ...| fst , [] | [ eq₁ ] = cong suc (span-dis {xs} eq₁)
+   ...| fst , [] | [ eq₁ ] = cong suc (span-dis {xs} eq₁) -}
 
 
    -- TODO-1 : An alternative to prove this lemma would be:
-   -- - First use the library lemma length-filter to prove that
-   --   length (List-filter Meta-dishonest? xs) ≤ length xs.
-   -- - Then prove that if length (List-filter Meta-dishonest? xs) < length xs
-   --   then ∃[ α ] (α ∈ xs × Meta-Honest-PK (getPubKey α)).
-   -- - Otherwise, if length (List-filter Meta-dishonest? xs ≡ )length xs we
+   -- - First prove that
+   --   CombinedPower (List-filter Meta-dishonest? xs) ≤ CombinedPower xs.
+   -- - Then prove that:
+   --   - If CombinedPower (List-filter Meta-dishonest? xs) ≤ CombinedPower xs
+   --     then ∃[ α ] (α ∈ xs × Meta-Honest-PK (getPubKey α)).
+   --   - If CombinedPower (List-filter Meta-dishonest? xs ≡ CombinedPower xs we
    --   get a contradiction using the bft assumption (as we have now).
    find-honest : ∀ {xs : List Member}
                → IsSorted _<Fin_ xs
                → bizF + 1 ≤ CombinedPower xs
                → ∃[ α ] (α ∈ xs × Meta-Honest-PK (getPubKey α))
-   find-honest {xs} sxs biz< = {!!}
-   {-  with span Meta-dishonest? xs | inspect (span Meta-dishonest?) xs
-   ...| dis , [] | [ eq ] rewrite +-comm bizF 1
-                                 | span-dis {xs} eq = ⊥-elim (<⇒≱ biz< {!!}) --(bft-assumption sxs))
-   ...| dis , x ∷ hon | [ eq ] = x , (span-hon eq) -}
+   find-honest {xs} sxs biz<
+     with span Meta-dishonest? xs | inspect (span Meta-dishonest?) xs
+   ...| dis , [] | [ eq ]
+        rewrite +-comm bizF 1
+          = let bft     = bft-assumption sxs
+                xsVot≤f = subst (_≤ bizF) (cong CombinedPower (span-dis {xs} eq)) bft
+            in ⊥-elim (<⇒≱ biz< xsVot≤f)
+   ...| dis , x ∷ hon | [ eq ] = x , (span-hon eq)
 
 
    bft-lemma : {xs ys : List Member}

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -97,7 +97,7 @@ module LibraBFT.Abstract.BFT
    ...| tri> ¬a ¬b c = slist
 
 
-   trans-OnHead : ∀ {xs : List Member} {y x : Member}
+   trans-OnHead : ∀ {n} {xs : List (Fin n)} {y x : Fin n}
                 → OnHead _<Fin_ y xs
                 → x <Fin y
                 → OnHead _<Fin_ x xs
@@ -240,9 +240,9 @@ module LibraBFT.Abstract.BFT
    union-length-UpLim sxs sys = sorted-length (union-sorted sxs sys)
 
 
-   h∉t : ∀ {xs : List Member} {x} → IsSorted _<Fin_ (x ∷ xs) → x ∉ xs
-   h∉t {x₁ ∷ xs} {x} (on-∷ x< ∷ sxs) (here refl) = ⊥-elim (<⇒≢ x< refl)
-   h∉t {x₁ ∷ xs} {x} (on-∷ x< ∷ (x₁< ∷ sxs)) (there x∈xs)
+   h∉t : ∀ {n} {xs : List (Fin n)} {x} → IsSorted _<Fin_ (x ∷ xs) → x ∉ xs
+   h∉t {_} {x₁ ∷ xs} {x} (on-∷ x< ∷ sxs) (here refl) = ⊥-elim (<⇒≢ x< refl)
+   h∉t {_} {x₁ ∷ xs} {x} (on-∷ x< ∷ (x₁< ∷ sxs)) (there x∈xs)
      = h∉t ((trans-OnHead x₁< x<) ∷ sxs) x∈xs
 
    y∉⇒All≢ : ∀ {n} {xs : List (Fin n)} {x y} → y ∉ (x ∷ xs)
@@ -254,6 +254,16 @@ module LibraBFT.Abstract.BFT
      with x ≟Fin y
    ...| yes x≡y = ⊥-elim (y∉ (here (sym x≡y)))
    ...| no  x≢y = x≢y , y∉xs
+
+
+   ≤-head : ∀ {n} {xs : List (Fin n)} {x y}
+          → y ∈ (x ∷ xs) → IsSorted _<Fin_ (x ∷ xs)
+          → x ≤Fin y
+   ≤-head {_} {xs} {x} {x} (here refl) sxs = ≤-refl
+   ≤-head {_} {x₁ ∷ []} {x} {x₁} (there (here refl)) (on-∷ x< ∷ sxs) = <⇒≤ x<
+   ≤-head {_} {x₁ ∷ x₂ ∷ xs} {x} {y} (there y∈) (on-∷ x<x₁ ∷ sxs)
+     = ≤-trans (<⇒≤ x<x₁) (≤-head y∈ sxs)
+
 
 
    _⊆List_ : ∀ {A : Set} → List A → List A → Set
@@ -282,7 +292,10 @@ module LibraBFT.Abstract.BFT
                → IsSorted _<Fin_ (x ∷ xs) → IsSorted _<Fin_ (y ∷ ys)
                → x ∈ ys
                → y ∉ xs
-   sort→∈-disj = {!!}
+   sort→∈-disj {ys = y₁ ∷ ys} (x< ∷ sxs) (on-∷ y<y₁ ∷ sys) x∈ys y∈xs
+     = let y₁≤x = ≤-head x∈ys sys
+           y<x  = <-transˡ y<y₁ y₁≤x
+       in h∉t (trans-OnHead x< y<x ∷ sxs) y∈xs
 
 
    sum-⊆-≤ : ∀ {xs ys : List Member} (f : Member → ℕ)
@@ -384,13 +397,6 @@ module LibraBFT.Abstract.BFT
    ...| inj₁ y∈xs = ⊥-elim (y∉xs y∈xs)
    ...| inj₂ y∈ys = ⊥-elim (y∉ys y∈ys)
 
-
-   ≤-head : ∀ {xs : List Member} {x y}
-                   → y ∈ (x ∷ xs) → IsSorted _<Fin_ (x ∷ xs)
-                   → x ≤Fin y
-   ≤-head {xs} {x} {x} (here refl) sxs = ≤-refl
-   ≤-head {x₁ ∷ []} {x} {x₁} (there (here refl)) (on-∷ x< ∷ sxs) = <⇒≤ x<
-   ≤-head {x₁ ∷ x₂ ∷ xs} {x} {y} (there y∈) (on-∷ x<x₁ ∷ sxs) = ≤-trans (<⇒≤ x<x₁) (≤-head y∈ sxs)
 
 
    unionElemLength-∈ : ∀ {xs : List Member} {x} → x ∈ xs → IsSorted _<Fin_ xs

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -495,11 +495,14 @@ module LibraBFT.Abstract.BFT
                  → QSize ≤ CombinedPower ys
                  → CombinedPower (xs ++ ys) ∸ N ≤ CombinedPower (intersect xs ys)
                  → bizF + 1 ≤ CombinedPower (intersect xs ys)
-   quorumInt>biz xs ys q≤x q≤y ≤int = {!!}
-   {-  let p₁ = ≤-trans (∸-monoˡ-≤ authorsN (+-mono-≤ q≤x q≤y)) ≤int
-         p₂ = subst (_≤ length (intersect xs ys)) (simpExp₁ authorsN bizF) p₁
-         p₃ = ≤-trans (∸-monoˡ-≤ (2 * bizF) isBFT) p₂
-     in subst (_≤ length (intersect xs ys)) (simpExp₂ bizF) p₃
+   quorumInt>biz xs ys q≤x q≤y ≤int
+     rewrite map-++-commute votPower xs ys
+           | sum-++-commute (List-map votPower xs) (List-map votPower ys)
+           = let powInt = CombinedPower (intersect xs ys)
+                 p₁     = ≤-trans (∸-monoˡ-≤ N (+-mono-≤ q≤x q≤y)) ≤int
+                 p₂     = subst (_≤ powInt) (simpExp₁ N bizF) p₁
+                 p₃     = ≤-trans (∸-monoˡ-≤ (2 * bizF) isBFT) p₂
+             in subst (_≤ powInt) (simpExp₂ bizF) p₃
        where  simpExp₁ : ∀ (x y : ℕ) → (x ∸ y) + (x ∸ y) ∸ x ≡ x ∸ (2 * y)
               simpExp₁ x y rewrite sym (*-identityʳ (x ∸ y))
                                  | sym (*-distribˡ-+ (x ∸ y) 1 1)
@@ -514,7 +517,7 @@ module LibraBFT.Abstract.BFT
               simpExp₂ : ∀ (x : ℕ) → suc (3 * x) ∸ 2 * x ≡ x + 1
               simpExp₂ x rewrite +-∸-assoc 1 (*-monoˡ-≤ x {2} {3} (s≤s (s≤s z≤n)))
                                | sym (*-distribʳ-∸ x 3 2)
-                               | sym (+-suc x 0) = refl -}
+                               | sym (+-suc x 0) = refl
 
 
    span-hon : ∀ {xs dis hon : List Member} {x : Member}

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -217,3 +217,14 @@ module LibraBFT.Lemmas where
  to-witness-isJust-≡ {aMB = just a'} {a} {prf}
     with to-witness-lemma (isJust {aMB = just a'} {a} prf) refl
  ...| xxx = just-injective (trans (sym xxx) prf)
+
+
+ ∸-suc-≤ : ∀ (x w : ℕ) → suc x ∸ w ≤ suc (x ∸ w)
+ ∸-suc-≤ x zero = ≤-refl
+ ∸-suc-≤ zero (suc w) rewrite 0∸n≡0 w = z≤n
+ ∸-suc-≤ (suc x) (suc w) = ∸-suc-≤ x w
+
+ m∸n≤o⇒m∸o≤n : ∀ (x z w : ℕ) → x ∸ z ≤ w → x ∸ w ≤ z
+ m∸n≤o⇒m∸o≤n x zero w p≤ rewrite m≤n⇒m∸n≡0 p≤ = z≤n
+ m∸n≤o⇒m∸o≤n zero (suc z) w p≤ rewrite 0∸n≡0 w = z≤n
+ m∸n≤o⇒m∸o≤n (suc x) (suc z) w p≤ = ≤-trans (∸-suc-≤ x w) (s≤s (m∸n≤o⇒m∸o≤n x z w p≤))

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -142,6 +142,38 @@ module LibraBFT.Lemmas where
  IsSorted-map⁻ f .(_ ∷ []) (x ∷ []) = [] ∷ []
  IsSorted-map⁻ f .(_ ∷ _ ∷ _) (on-∷ x ∷ (x₁ ∷ is)) = (on-∷ x) ∷ IsSorted-map⁻ f _ (x₁ ∷ is)
 
+
+ transOnHead : ∀ {A} {l : List A} {y x : A} {_<_ : A → A → Set}
+              → Transitive _<_
+              → OnHead _<_ y l
+              → x < y
+              → OnHead _<_ x l
+ transOnHead _ [] _ = []
+ transOnHead trans (on-∷ y<f) x<y = on-∷ (trans x<y y<f)
+
+ ++-OnHead : ∀ {A} {xs ys : List A} {y : A} {_<_ : A → A → Set}
+           → OnHead _<_ y xs
+           → OnHead _<_ y ys
+           → OnHead _<_ y (xs ++ ys)
+ ++-OnHead []         y<y₁ = y<y₁
+ ++-OnHead (on-∷ y<x) _    = on-∷ y<x
+
+ h∉t : ∀ {A} {t : List A} {h : A} {_<_ : A → A → Set}
+     → Irreflexive _<_ _≡_ → Transitive _<_
+     → IsSorted _<_ (h ∷ t)
+     → h ∉ t
+ h∉t irfl trans (on-∷ h< ∷ sxs) (here refl) = ⊥-elim (irfl h< refl)
+ h∉t irfl trans (on-∷ h< ∷ (x₁< ∷ sxs)) (there h∈t)
+   = h∉t irfl trans ((transOnHead trans x₁< h<) ∷ sxs) h∈t
+
+ ≤-head : ∀ {A} {l : List A} {x y : A} {_<_ : A → A → Set} {_≤_ : A → A → Set}
+        → Reflexive _≤_ → Trans _<_ _≤_ _≤_
+        → y ∈ (x ∷ l) → IsSorted _<_ (x ∷ l)
+        → _≤_ x y
+ ≤-head ref≤ trans (here refl) _ = ref≤
+ ≤-head ref≤ trans (there y∈) (on-∷ x<x₁ ∷ sl) = trans x<x₁ (≤-head ref≤ trans y∈ sl)
+
+
  -- TODO-1 : Better name and/or replace with library property
  Any-sym : ∀ {a b}{A : Set a}{B : Set b}{tgt : B}{l : List A}{f : A → B}
          → Any (λ x → tgt ≡ f x) l

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -138,7 +138,7 @@ module LibraBFT.Prelude where
 
   open import Data.Fin.Properties
     using (toℕ-injective)
-    renaming (<-cmp to Fin-<-cmp; <-trans to Fin-<-trans)
+    renaming (<-cmp to Fin-<-cmp; <⇒≢ to <⇒≢Fin)
     public
 
   open import Relation.Binary.PropositionalEquality

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -36,7 +36,7 @@ module LibraBFT.Prelude where
 
   open import Data.List.Properties
     renaming (≡-dec to List-≡-dec; length-map to List-length-map; map-compose to List-map-compose)
-    using (∷-injective; length-++; map-++-commute; sum-++-commute)
+    using (∷-injective; length-++; map-++-commute; sum-++-commute; map-tabulate)
     public
 
   open import Data.List.Relation.Unary.Any

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -47,14 +47,15 @@ module LibraBFT.Prelude where
 
   open import Data.List.Relation.Unary.Any.Properties
     using    (¬Any[])
-    renaming ( map⁺      to Any-map⁺
-             ; map⁻      to Any-map⁻
-             ; concat⁺   to Any-concat⁺
-             ; concat⁻   to Any-concat⁻
-             ; ++⁻       to Any-++⁻
-             ; ++⁺ʳ      to Any-++ʳ
-             ; ++⁺ˡ      to Any-++ˡ
+    renaming ( map⁺       to Any-map⁺
+             ; map⁻       to Any-map⁻
+             ; concat⁺    to Any-concat⁺
+             ; concat⁻    to Any-concat⁻
+             ; ++⁻        to Any-++⁻
+             ; ++⁺ʳ       to Any-++ʳ
+             ; ++⁺ˡ       to Any-++ˡ
              ; singleton⁻ to Any-singleton⁻
+             ; tabulate⁺  to Any-tabulate⁺
              )
     public
 

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -29,13 +29,14 @@ module LibraBFT.Prelude where
     public
 
   open import Data.List
-    renaming (map to List-map ; filter to List-filter ; lookup to List-lookup)
+    renaming (map to List-map ; filter to List-filter ; lookup to List-lookup;
+              tabulate to List-tabulate)
     hiding (fromMaybe; [_])
     public
 
   open import Data.List.Properties
     renaming (≡-dec to List-≡-dec; length-map to List-length-map)
-    using (∷-injective; length-++)
+    using (∷-injective; length-++; map-++-commute; sum-++-commute)
     public
 
   open import Data.List.Relation.Unary.Any

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -35,7 +35,7 @@ module LibraBFT.Prelude where
     public
 
   open import Data.List.Properties
-    renaming (≡-dec to List-≡-dec; length-map to List-length-map)
+    renaming (≡-dec to List-≡-dec; length-map to List-length-map; map-compose to List-map-compose)
     using (∷-injective; length-++; map-++-commute; sum-++-commute)
     public
 


### PR DESCRIPTION
Proved the bft-lemma for a set of nodes of that can have different voting power. The module receives as module parameter a function `votPower` that returns for each member its voting power.  The (inner) module also receives as arguments proof that that the combined power of all nodes is `N` and the combined voting power of the byzantine nodes has a threshold of `bizF`. 

The bft-lemma (at the end of the file) receives two lists of distinct members (enforced by the type `IsSorted _<Fin_`) such that, for each list, the combined voting power of all members in that list is at least than `N - bizF` (representing the quorum size). 

This work can be used as a utility for a possible implementation of LibraBFT. 