### PR TITLE
Tease SystemModel apart from LibraBFT types, move towards standard module conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Only pull requests from committers who can be verified as having signed the OCA 
 
 Please include a copyright notice consistent with other files when you introduce a new file, and edit the copyright notice of any file you change to update the list of years, separated by commas and with a comma after the last year, e.g., Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 
-It is not necessary to add your name to copyright notices because you mus sign the Oracle Contributor Agreement before we can accept your contribution.  Arguments against listing all contributors in copyright notices are at the bottom of [this Linux Foundation blog post](https://www.linuxfoundation.org/en/blog/copyright-notices-in-open-source-software-projects).  
+It is not necessary to add your name to copyright notices because you must sign the Oracle Contributor Agreement before we can accept your contribution.  Arguments against listing all contributors in copyright notices are at the bottom of [this Linux Foundation blog post](https://www.linuxfoundation.org/en/blog/copyright-notices-in-open-source-software-projects).  
 
 ### Pull request process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,12 @@ git commit --signoff
 
 Only pull requests from committers who can be verified as having signed the OCA can be accepted.
 
+### Copyright notices
+
+Please include a copyright notice consistent with other files when you introduce a new file, and edit the copyright notice of any file you change to update the list of years, separated by commas and with a comma after the last year, e.g., Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+
+It is not necessary to add your name to copyright notices because you mus sign the Oracle Contributor Agreement before we can accept your contribution.  Arguments against listing all contributors in copyright notices are at the bottom of [this Linux Foundation blog post](https://www.linuxfoundation.org/en/blog/copyright-notices-in-open-source-software-projects).  
+
 ### Pull request process
 
 1. Fork this repository

--- a/LibraBFT/Base/Types.agda
+++ b/LibraBFT/Base/Types.agda
@@ -10,6 +10,10 @@ open import LibraBFT.Base.Encode
 
 -- The ground types over which we build our abstract reasoning
 module LibraBFT.Base.Types where
+
+  NodeId : Set
+  NodeId = ℕ
+
   EpochId : Set
   EpochId = ℕ
 

--- a/LibraBFT/Base/Types.agda
+++ b/LibraBFT/Base/Types.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
@@ -10,10 +10,6 @@ open import LibraBFT.Base.Encode
 
 -- The ground types over which we build our abstract reasoning
 module LibraBFT.Base.Types where
-
-  NodeId : Set
-  NodeId = ℕ
-
   EpochId : Set
   EpochId = ℕ
 

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -1,12 +1,12 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Concrete.System.Parameters
-import LibraBFT.Concrete.Properties.VotesOnce as VO
-import LibraBFT.Concrete.Properties.LockedRound as LR
+import      LibraBFT.Concrete.Properties.VotesOnce   as VO
+import      LibraBFT.Concrete.Properties.LockedRound as LR
 open import LibraBFT.Abstract.Types
 open EpochConfig
 open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -3,11 +3,13 @@
    Copyright (c) 2020 Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+open import LibraBFT.Prelude
 open import LibraBFT.Concrete.System.Parameters
 import LibraBFT.Concrete.Properties.VotesOnce as VO
 import LibraBFT.Concrete.Properties.LockedRound as LR
-
-open import LibraBFT.Yasm.Properties ConcSysParms
+open import LibraBFT.Abstract.Types
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- This module collects in one place the obligations an
 -- implementation must meet in order to enjoy the properties

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -13,9 +13,8 @@ open import LibraBFT.Impl.Consensus.Types
 
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Concrete.Obligations
-
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- In this module, we assume that the implementation meets its
 -- obligations, and use this assumption to prove that the

--- a/LibraBFT/Concrete/Properties/LockedRound.agda
+++ b/LibraBFT/Concrete/Properties/LockedRound.agda
@@ -19,11 +19,8 @@ open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 
 open import LibraBFT.Concrete.System.Parameters
-
-open import LibraBFT.Yasm.Base
-open import LibraBFT.Yasm.AvailableEpochs using (AvailableEpochs ; lookup'; lookup'')
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- This module contains placeholders for the future analog of the
 -- corresponding VotesOnce property.  Defining the implementation

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -10,20 +10,17 @@ open import LibraBFT.Lemmas
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
 
-open import LibraBFT.Abstract.Types
+open import LibraBFT.Abstract.Types hiding (EpochConfigFor)
 open EpochConfig
 
 open import LibraBFT.Impl.NetworkMsg
-open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Consensus.Types hiding (EpochConfigFor)
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 
 open import LibraBFT.Concrete.System.Parameters
-
-open import LibraBFT.Yasm.Base
-open import LibraBFT.Yasm.AvailableEpochs using (AvailableEpochs ; lookup'; lookup'')
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- In this module, we define two "implementation obligations"
 -- (ImplObligationᵢ for i ∈ {1 , 2}), which are predicates over

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -19,11 +19,8 @@ open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 
 open import LibraBFT.Concrete.System.Parameters
-
-open import LibraBFT.Yasm.Base
-open import LibraBFT.Yasm.AvailableEpochs using (AvailableEpochs ; lookup'; lookup'')
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- This module defines an abstract system state given a reachable
 -- concrete system state.
@@ -102,7 +99,7 @@ module LibraBFT.Concrete.System (sps-corr : StepPeerState-AllValidParts) where
    open import LibraBFT.Yasm.AvailableEpochs
 
    𝓔 : EpochConfig
-   𝓔 = lookup' (availEpochs st) eid
+   𝓔 = EC-lookup (availEpochs st) eid
    open EpochConfig
 
    open import LibraBFT.Abstract.System 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
@@ -173,7 +170,7 @@ module LibraBFT.Concrete.System (sps-corr : StepPeerState-AllValidParts) where
        cv            : Vote
        cv∈nm         : cv ⊂Msg nm
        -- And contained a valid vote that, once abstracted, yeilds v.
-       vmsgMember    : Member 𝓔
+       vmsgMember    : EpochConfig.Member 𝓔
        vmsgSigned    : WithVerSig (getPubKey 𝓔 vmsgMember) cv
        vmsg≈v        : α-ValidVote 𝓔 cv vmsgMember ≡ v
        vmsgEpoch     : cv ^∙ vEpoch ≡ epochId 𝓔

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -1,15 +1,17 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-open import LibraBFT.Prelude
-open import LibraBFT.Impl.NetworkMsg
-open import LibraBFT.Impl.Consensus.Types
-open import LibraBFT.Impl.Util.Crypto
-open import LibraBFT.Yasm.Base
 open import Optics.All
+open import LibraBFT.Prelude
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.NetworkMsg
+open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
+open EpochConfig
+open import LibraBFT.Yasm.Base NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN
 
 -- In this module, we instantiate the system model with parameters to
 -- model a system using the simple implementation model we have so
@@ -18,9 +20,9 @@ open import LibraBFT.Impl.Handle sha256 sha256-cr
 -- implementation.
 
 module LibraBFT.Concrete.System.Parameters where
-
  ConcSysParms : SystemParameters
  ConcSysParms = mkSysParms
+                 NodeId
                  EventProcessor
                  NetworkMsg
                  Vote

--- a/LibraBFT/Impl/Properties.agda
+++ b/LibraBFT/Impl/Properties.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude

--- a/LibraBFT/Impl/Properties.agda
+++ b/LibraBFT/Impl/Properties.agda
@@ -7,8 +7,6 @@ open import LibraBFT.Prelude
 open import LibraBFT.Abstract.Types
 open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Concrete.System.Parameters
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
 
 -- This module collects the implementation obligations for our (fake/simple, for now)
 -- "implementation" into the structure required by Concrete.Properties.

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -11,10 +11,11 @@ open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Concrete.System.Parameters
-import      LibraBFT.Yasm.AvailableEpochs as AE
-open import LibraBFT.Yasm.Base
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
+
+open import LibraBFT.Abstract.Types
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
+
 open import LibraBFT.Concrete.Obligations
 
 -- In this module, we will prove a structural property that any new signed message produced by an
@@ -58,7 +59,7 @@ module LibraBFT.Impl.Properties.Aux where
   ...| yes msg∈ = inj₂ msg∈
   ...| no  msg∉ = inj₁ ((mkValidPartForPK      {! epoch !} -- We will need an invariant that says the epoch
                                                            -- used by a voter is "in range".
-                                               (AE.lookup'' (availEpochs st) {!!})
+                                               (EC-lookup' (availEpochs st) {!!})
                                                refl
                                                {! !}       -- The implementation will need to check that the voter is a member of
                                                            -- the epoch of the message it's sending.

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 {-# OPTIONS --allow-unsolved-metas #-}

--- a/LibraBFT/Impl/Properties/LockedRound.agda
+++ b/LibraBFT/Impl/Properties/LockedRound.agda
@@ -4,12 +4,7 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Impl.NetworkMsg
-open import LibraBFT.Concrete.System.Parameters
 import      LibraBFT.Concrete.Properties.LockedRound as LR
-
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
 
 open import LibraBFT.Concrete.Obligations
 

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -4,25 +4,7 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 {-# OPTIONS --allow-unsolved-metas #-}
-open import Optics.All
-open import LibraBFT.Lemmas
-open import LibraBFT.Prelude
-open import LibraBFT.Base.PKCS
-
-open import LibraBFT.Impl.Consensus.Types
-open import LibraBFT.Impl.NetworkMsg
-open import LibraBFT.Impl.Util.Crypto
-open import LibraBFT.Impl.Properties.Aux
-
-open import LibraBFT.Concrete.System impl-sps-avp
-open import LibraBFT.Concrete.System.Parameters
 import      LibraBFT.Concrete.Properties.VotesOnce as VO
-
-open import LibraBFT.Yasm.AvailableEpochs
-open import LibraBFT.Yasm.Base
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
-open        Structural impl-sps-avp
 
 open import LibraBFT.Concrete.Obligations
 

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 {-# OPTIONS --allow-unsolved-metas #-}

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -1,11 +1,9 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-
-open import Level using (0ℓ)
 
 -- This module incldes various Agda lemmas that are independent of the project's domain
 
@@ -41,7 +39,7 @@ module LibraBFT.Lemmas where
  ++-abs (x ∷ m) imp ()
 
 
- data All-vec {ℓ} {A : Set ℓ} (P : A → Set ℓ) : ∀ {n} → Vec {ℓ} A n → Set (Level.suc ℓ) where
+ data All-vec {ℓ} {A : Set ℓ} (P : A → Set ℓ) : ∀ {n} → Vec {ℓ} A n → Set (ℓ+1 ℓ) where
    []  : All-vec P []
    _∷_ : ∀ {x n} {xs : Vec A n} (px : P x) (pxs : All-vec P xs) → All-vec P (x ∷ xs)
 

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -1,13 +1,13 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 -- This is a selection of useful functions and definitions
 -- from the standard library that we tend to use a lot.
 module LibraBFT.Prelude where
-
   open import Level
+    using    (0ℓ; Level; Lift)
     renaming (suc to ℓ+1; zero to ℓ0; _⊔_ to _ℓ⊔_)
     public
 

--- a/LibraBFT/Yasm/AvailableEpochs.agda
+++ b/LibraBFT/Yasm/AvailableEpochs.agda
@@ -1,19 +1,24 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Abstract.Types
+import      Data.Vec.Relation.Unary.All as Vec-All
+import      Data.Fin                    as Fin
 
 -- This module defines the EpochConfigs available in the system, along
 -- with a function to add a new EpochConfig and some properties that
 -- facilitate proofs across state transitions that add an EpochConfig.
 
-module LibraBFT.Yasm.AvailableEpochs where
-
- import Data.Vec.Relation.Unary.All as Vec-All
- import Data.Fin                    as Fin
+module LibraBFT.Yasm.AvailableEpochs
+   (NodeId      : Set)
+   (ℓ-EC        : Level)
+   (EpochConfig : Set ℓ-EC)
+   (epochId     : EpochConfig → ℕ)
+   (authorsN    : EpochConfig → ℕ)
+ where
+ open import LibraBFT.Yasm.Base NodeId ℓ-EC EpochConfig epochId authorsN
 
  fin-lower-toℕ : ∀{e}(i : Fin (suc e))(prf : e ≢ toℕ i) → toℕ (Fin.lower₁ i prf) ≡ toℕ i
  fin-lower-toℕ {zero} zero prf = ⊥-elim (prf refl)
@@ -50,7 +55,7 @@ module LibraBFT.Yasm.AvailableEpochs where
 
  -- Available epochs consist of a vector of EpochConfigs with
  -- the correct epoch ids.
- AvailableEpochs : ℕ → Set₁
+ AvailableEpochs : ℕ → Set ℓ-EC
  AvailableEpochs = Vec-All (EpochConfigFor ∘ toℕ) ∘ Vec-allFin
 
  lookup : ∀{e} → AvailableEpochs e → (ix : Fin e) → EpochConfigFor (toℕ ix)

--- a/LibraBFT/Yasm/Base.agda
+++ b/LibraBFT/Yasm/Base.agda
@@ -1,22 +1,38 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Base.PKCS
 
-open import LibraBFT.Abstract.Types
-
 -- This module defines the types used to define a SystemModel.
 
-module LibraBFT.Yasm.Base where
+module LibraBFT.Yasm.Base
+  (NodeId      : Set)
+  (ℓ-EC        : Level)
+  (EpochConfig : Set ℓ-EC)
+  (epochId     : EpochConfig → ℕ)
+  (authorsN    : EpochConfig → ℕ)
+ where
+
+ EpochId : Set
+ EpochId = ℕ
+
+ Member : EpochConfig → Set
+ Member = Fin ∘ authorsN
+
+ record EpochConfigFor (eid : EpochId) : Set ℓ-EC where
+   field
+    epochConfig : EpochConfig
+    forEpochId  : epochId epochConfig ≡ eid
 
  -- Our system is configured through a value of type
  -- SystemParameters where we specify:
- record SystemParameters : Set₁ where
+ record SystemParameters : Set ((ℓ+1 0ℓ) ℓ⊔ ℓ-EC) where
   constructor mkSysParms
   field
+    PeerId    : Set
     PeerState : Set
     Msg       : Set
     Part      : Set -- Types of interest that can be represented in Msgs
@@ -31,10 +47,10 @@ module LibraBFT.Yasm.Base where
     part-epoch  : Part → EpochId
 
     -- Initializes a potentially-empty state with an EpochConfig
-    init : NodeId → EpochConfig → Maybe PeerState → PeerState × List Msg
+    init : PeerId → EpochConfig → Maybe PeerState → PeerState × List Msg
 
     -- Handles a message on a previously initialized peer.
-    handle : NodeId → Msg → PeerState → PeerState × List Msg
+    handle : PeerId → Msg → PeerState → PeerState × List Msg
 
     -- TODO-3?: So far, handlers only produce messages to be sent.
     -- It would be reasonable to generalize this to something like

--- a/LibraBFT/Yasm/Yasm.agda
+++ b/LibraBFT/Yasm/Yasm.agda
@@ -1,0 +1,26 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021 Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+open import LibraBFT.Prelude
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+import      LibraBFT.Yasm.Base as LYB
+
+-- This module provides a single import for all Yasm modules
+
+module LibraBFT.Yasm.Yasm
+   (NodeId      : Set)
+   (ℓ-EC        : Level)
+   (EpochConfig : Set ℓ-EC)
+   (epochId     : EpochConfig → EpochId)
+   (authorsN    : EpochConfig → ℕ)
+   (getPubKey   : (ec : EpochConfig) → LYB.Member NodeId ℓ-EC EpochConfig epochId authorsN ec → PK)
+   (parms       : LYB.SystemParameters NodeId ℓ-EC EpochConfig epochId authorsN)
+  where
+ open import LibraBFT.Yasm.AvailableEpochs NodeId ℓ-EC EpochConfig epochId authorsN
+             using (AvailableEpochs) renaming (lookup' to EC-lookup; lookup'' to EC-lookup')   public
+ open import LibraBFT.Yasm.Base       NodeId ℓ-EC EpochConfig epochId authorsN                 public
+ open import LibraBFT.Yasm.System     NodeId ℓ-EC EpochConfig epochId authorsN           parms public
+ open import LibraBFT.Yasm.Properties NodeId ℓ-EC EpochConfig epochId authorsN getPubKey parms public

--- a/STYLE.md
+++ b/STYLE.md
@@ -3,7 +3,27 @@
 ## Coding style conventions
 We are not aware of any official Agda "style guide" or similar; please let us know if you know of one.  Otherwise, please try to be consistent with style used in the repo so far and/or contribute here by helping to establish more detailed guidance.
 
-Please ensure that there are no trailing spaces before creating a pull request; [this script](./Scripts/remove-trailing-whitespace.sh) is useful for this purpose.
+We will maintain style-related conventions here; please try to adhere to them where possible before creating a pull request.
+
+- *Trailing spaces*: ensure that there are none; [this script](./Scripts/remove-trailing-whitespace.sh) is useful for this purpose.
+- *Module structure*: ensure that each module follows this structure and order:
+  - Pragmas, if any
+  - Copyright notice
+  - Imports
+     - In general, list all imports in the earliest place possible.  For example, the top of file should include all imports required by the file's modules except those that must be imported within the module due to a dependence on module parameters or a requirement to open public.
+     - To the extent possible, group related imports together in order.  List common imports such as `LibraBFT.Prelude`, `LibraBFT.Lemmas` and `LimraBFT.Base.Types` first.
+     - When a module must be imported in order to define the module parameters *and* must be imported within the module, if necessary, limit the first import with `using` or using a module qualifier; this helps to avoid conflicts with subset imports within the module.
+  - Comment with overview of the module
+  - Module definition
+- *Syntax conventions*
+  -  Example `with` abstraction (note alignment and no space between `...` and `|`)
+
+    ```
+      Example : ExampleSignature
+      Example x y
+         with ExampleValue
+      ...| ExampleName = ...
+    ```
 
 ## Assumptions, warnings and overrides
 Ultimately, we aim for a clean proof with all assumptions well justified and minimal warnings and overrides thereof.  While this repo is "work in progress", it is natural that we don't always keep everything perfect in this regard.

--- a/STYLE.md
+++ b/STYLE.md
@@ -7,11 +7,11 @@ We will maintain style-related conventions here; please try to adhere to them wh
 
 - *Trailing spaces*: ensure that there are none; [this script](./Scripts/remove-trailing-whitespace.sh) is useful for this purpose.
 - *Module structure*: ensure that each module follows this structure and order:
-  - Pragmas, if any
   - Copyright notice
+  - Pragmas, if any
   - Imports
      - In general, list all imports in the earliest place possible.  For example, the top of file should include all imports required by the file's modules except those that must be imported within the module due to a dependence on module parameters or a requirement to open public.
-     - To the extent possible, group related imports together in order.  List common imports such as `LibraBFT.Prelude`, `LibraBFT.Lemmas` and `LimraBFT.Base.Types` first.
+     - To the extent possible, group related imports together in order.  List common imports such as `LibraBFT.Prelude`, `LibraBFT.Lemmas` and `LibraBFT.Base.Types` first.
      - When a module must be imported in order to define the module parameters *and* must be imported within the module, if necessary, limit the first import with `using` or using a module qualifier; this helps to avoid conflicts with subset imports within the module.
   - Comment with overview of the module
   - Module definition


### PR DESCRIPTION
During development, we used the `EpochConfig` type from `LibraBFT.Abstract` in the system model (`Yasm`).  This was an abstraction violation because the system model should be independent of any particular application.  Similarly, we assumed `NodeId` was `ℕ` (as in our fake implementation).

This pull request abstracts out only the necessary parts of `EpochConfig` for the system model and parameterizes the system model by a `PeerId` type.

It also includes some updates to the Style and Contributing guides to try to move towards some conventions for module organization.