### PR TITLE
Parameterize Abstract.* by `NodeId` and `UID` types, various refactoring and streamlining of imports

### DIFF
--- a/LibraBFT/Abstract/Abstract.agda
+++ b/LibraBFT/Abstract/Abstract.agda
@@ -5,7 +5,7 @@
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Abstract.Types.EpochConfig
-open WithAbsVote
+open        WithAbsVote
 
 -- This module provides a convenient way for modules in other namespaces to import
 -- everything from Abstract.

--- a/LibraBFT/Abstract/Abstract.agda
+++ b/LibraBFT/Abstract/Abstract.agda
@@ -1,0 +1,26 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+open import LibraBFT.Prelude
+open import LibraBFT.Abstract.Types.EpochConfig
+open import LibraBFT.Abstract.Types
+
+-- This module provides a convenient way for modules in other namespaces to import
+-- everything from Abstract.
+
+module LibraBFT.Abstract.Abstract
+  (UID    : Set)
+  (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
+  (NodeId : Set)
+  (𝓔  : EpochConfig UID NodeId)
+  (𝓥  : VoteEvidence UID NodeId 𝓔)
+  where
+    open import LibraBFT.Abstract.Types                   UID        NodeId 𝓔    public
+    open import LibraBFT.Abstract.RecordChain             UID _≟UID_ NodeId 𝓔 𝓥 public
+    open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥  public
+    open import LibraBFT.Abstract.Records                 UID _≟UID_ NodeId 𝓔 𝓥 public
+    open import LibraBFT.Abstract.Records.Extends         UID _≟UID_ NodeId 𝓔 𝓥 public
+    open import LibraBFT.Abstract.Properties              UID _≟UID_ NodeId 𝓔 𝓥 public
+    open import LibraBFT.Abstract.System                  UID _≟UID_ NodeId 𝓔 𝓥 public

--- a/LibraBFT/Abstract/Abstract.agda
+++ b/LibraBFT/Abstract/Abstract.agda
@@ -5,7 +5,7 @@
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Abstract.Types.EpochConfig
-open import LibraBFT.Abstract.Types
+open WithAbsVote
 
 -- This module provides a convenient way for modules in other namespaces to import
 -- everything from Abstract.
@@ -19,7 +19,7 @@ module LibraBFT.Abstract.Abstract
   where
     open import LibraBFT.Abstract.Types                   UID        NodeId 𝓔    public
     open import LibraBFT.Abstract.RecordChain             UID _≟UID_ NodeId 𝓔 𝓥 public
-    open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥  public
+    open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥 public
     open import LibraBFT.Abstract.Records                 UID _≟UID_ NodeId 𝓔 𝓥 public
     open import LibraBFT.Abstract.Records.Extends         UID _≟UID_ NodeId 𝓔 𝓥 public
     open import LibraBFT.Abstract.Properties              UID _≟UID_ NodeId 𝓔 𝓥 public

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -1,32 +1,31 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
-open import LibraBFT.Abstract.Types
 open import LibraBFT.Base.PKCS
 
-  -- This module provides a utility function to make it easy to
-  -- provide the bft-lemma for implementations in which the
-  -- participants can have different voting power.
+-- This module provides a utility function to make it easy to
+-- provide the bft-lemma for implementations in which the
+-- participants can have different voting power.
 
-  -- The module is parametrized with the number of participants -
-  -- `authorsN`, and with a function - `votPower` - that assigns to
-  -- each participant its voting power. The parameter `N` corresponds
-  -- to the total voting power of all participants, as required by the
-  -- parameter `totalVotPower` in the inner module. These
-  -- implementations should assume a fixed unknown subset of malicious
-  -- nodes - Byzantine - but should also assume a security threshold
-  -- `bizF`, such that N > 3 * bizF, which should be provided in
-  -- parameter `isBFT`.  Finally, the `bft-assumption` states that the
-  -- combined voting power of Byzantine nodes must not exceed the
-  -- security threshold `bizF`.
+-- The module is parametrized with the number of participants -
+-- `authorsN`, and with a function - `votPower` - that assigns to
+-- each participant its voting power. The parameter `N` corresponds
+-- to the total voting power of all participants, as required by the
+-- parameter `totalVotPower` in the inner module. These
+-- implementations should assume a fixed unknown subset of malicious
+-- nodes - Byzantine - but should also assume a security threshold
+-- `bizF`, such that N > 3 * bizF, which should be provided in
+-- parameter `isBFT`.  Finally, the `bft-assumption` states that the
+-- combined voting power of Byzantine nodes must not exceed the
+-- security threshold `bizF`.
 
-  -- The bft-lemma is the last lemma in this file and proves that in
-  -- the intersection of any quorums, whose combined voting power is
-  -- greater or equal than `N - bizF`, there is an honest Member.
+-- The bft-lemma is the last lemma in this file and proves that in
+-- the intersection of any quorums, whose combined voting power is
+-- greater or equal than `N - bizF`, there is an honest Member.
 
 module LibraBFT.Abstract.BFT
   (authorsN      : ℕ)
@@ -35,10 +34,7 @@ module LibraBFT.Abstract.BFT
   (bizF          : ℕ)
   (isBFT         : totalVotPower ≥ suc (3 * bizF))
   (getPubKey     : Fin authorsN → PK)
-
-
  where
-
 
  -- The set of members of this epoch.
  Member : Set

--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -6,6 +6,7 @@
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
+open import LibraBFT.Abstract.Types.EpochConfig
 
 -- For each desired property (VotesOnce and LockedRoundRule), we have a
 -- module containing a Type that defines a property that an implementation
@@ -18,29 +19,29 @@ open import LibraBFT.Abstract.Types
 -- properties.
 
 module LibraBFT.Abstract.Properties
-  (𝓔 : EpochConfig)
   (UID    : Set)
   (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
-  (𝓥      : VoteEvidence 𝓔 UID)
+  (NodeId : Set)
+  (𝓔  : EpochConfig UID NodeId)
+  (𝓥  : VoteEvidence UID NodeId 𝓔)
   where
 
- open import LibraBFT.Abstract.Records 𝓔 UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.Records.Extends 𝓔 UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.RecordChain 𝓔 UID _≟UID_ 𝓥
- import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 UID _≟UID_ 𝓥
-   as StaticAssumptions
- open import LibraBFT.Abstract.System 𝓔 UID _≟UID_ 𝓥
+ open import LibraBFT.Abstract.Records                 UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.Records.Extends         UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.RecordChain             UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.System                  UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.RecordChain.Properties  UID _≟UID_ NodeId 𝓔 𝓥
 
  open EpochConfig 𝓔
 
  module WithAssumptions {ℓ}
    (InSys                 : Record → Set ℓ)
-   (votes-only-once       : StaticAssumptions.VotesOnlyOnceRule InSys)
-   (locked-round-rule     : StaticAssumptions.LockedRoundRule   InSys)
+   (votes-only-once       : VotesOnlyOnceRule InSys)
+   (locked-round-rule     : LockedRoundRule   InSys)
   where
 
    open All-InSys-props InSys
-   import LibraBFT.Abstract.RecordChain.Properties 𝓔 UID _≟UID_ 𝓥 as Props
 
    CommitsDoNotConflict : ∀{q q'}
         → {rc  : RecordChain (Q q)}  → All-InSys rc
@@ -49,7 +50,7 @@ module LibraBFT.Abstract.Properties
         → CommitRule rc  b
         → CommitRule rc' b'
         → NonInjective-≡ bId ⊎ ((B b) ∈RC rc' ⊎ (B b') ∈RC rc)
-   CommitsDoNotConflict = Props.WithInvariants.thmS5 InSys votes-only-once locked-round-rule
+   CommitsDoNotConflict = WithInvariants.thmS5 InSys votes-only-once locked-round-rule
 
    -- When we are dealing with a /Complete/ InSys predicate, we can go a few steps
    -- further and prove that commits do not conflict even if we have only partial

--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -7,6 +7,7 @@ open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 open import LibraBFT.Abstract.Types.EpochConfig
+open WithAbsVote
 
 -- For each desired property (VotesOnce and LockedRoundRule), we have a
 -- module containing a Type that defines a property that an implementation

--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -7,7 +7,7 @@ open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 open import LibraBFT.Abstract.Types.EpochConfig
-open WithAbsVote
+open        WithAbsVote
 
 -- For each desired property (VotesOnce and LockedRoundRule), we have a
 -- module containing a Type that defines a property that an implementation
@@ -33,8 +33,7 @@ module LibraBFT.Abstract.Properties
  open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥
  open import LibraBFT.Abstract.System                  UID _≟UID_ NodeId 𝓔 𝓥
  open import LibraBFT.Abstract.RecordChain.Properties  UID _≟UID_ NodeId 𝓔 𝓥
-
- open EpochConfig 𝓔
+ open        EpochConfig 𝓔
 
  module WithAssumptions {ℓ}
    (InSys                 : Record → Set ℓ)

--- a/LibraBFT/Abstract/RecordChain.agda
+++ b/LibraBFT/Abstract/RecordChain.agda
@@ -6,8 +6,8 @@
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Base.Types
-open import LibraBFT.Abstract.Types
 open import LibraBFT.Abstract.Types.EpochConfig
+open WithAbsVote
 
 -- This module defines RecordChains and related types and utility definitions
 

--- a/LibraBFT/Abstract/RecordChain.agda
+++ b/LibraBFT/Abstract/RecordChain.agda
@@ -1,21 +1,28 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
+open import LibraBFT.Base.Types
 open import LibraBFT.Abstract.Types
+open import LibraBFT.Abstract.Types.EpochConfig
+
+-- This module defines RecordChains and related types and utility definitions
 
 module LibraBFT.Abstract.RecordChain
-  (𝓔      : EpochConfig)
   (UID    : Set)
   (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
-  (𝓥      : VoteEvidence 𝓔 UID)
-    where
+  (NodeId : Set)
+  (𝓔      : EpochConfig UID NodeId)
+  (𝓥      : VoteEvidence UID NodeId 𝓔)
+  where
 
- open import LibraBFT.Abstract.Records          𝓔 UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.Records.Extends  𝓔 UID _≟UID_ 𝓥
+ open import LibraBFT.Abstract.Records         UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.Records.Extends UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.Types           UID        NodeId
+ open EpochConfig 𝓔
 
  -- One way of looking at a 'RecordChain r' is as a path from the epoch's
  -- initial record (I) to r.  For generality, we express this in two steps.

--- a/LibraBFT/Abstract/RecordChain.agda
+++ b/LibraBFT/Abstract/RecordChain.agda
@@ -7,7 +7,7 @@ open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Base.Types
 open import LibraBFT.Abstract.Types.EpochConfig
-open WithAbsVote
+open        WithAbsVote
 
 -- This module defines RecordChains and related types and utility definitions
 
@@ -18,11 +18,10 @@ module LibraBFT.Abstract.RecordChain
   (𝓔      : EpochConfig UID NodeId)
   (𝓥      : VoteEvidence UID NodeId 𝓔)
   where
-
  open import LibraBFT.Abstract.Records         UID _≟UID_ NodeId 𝓔 𝓥
  open import LibraBFT.Abstract.Records.Extends UID _≟UID_ NodeId 𝓔 𝓥
  open import LibraBFT.Abstract.Types           UID        NodeId
- open EpochConfig 𝓔
+ open        EpochConfig 𝓔
 
  -- One way of looking at a 'RecordChain r' is as a path from the epoch's
  -- initial record (I) to r.  For generality, we express this in two steps.

--- a/LibraBFT/Abstract/RecordChain/Assumptions.agda
+++ b/LibraBFT/Abstract/RecordChain/Assumptions.agda
@@ -1,11 +1,12 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021 Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
-open import LibraBFT.Abstract.Types
+open import LibraBFT.Abstract.Types using (VoteEvidence)
+open import LibraBFT.Abstract.Types.EpochConfig
 
 -- Here we establish the properties necessary to achieve consensus
 -- just like we see them on paper: stating facts about the state of
@@ -17,20 +18,22 @@ open import LibraBFT.Abstract.Types
 -- The module 'LibraBFT.Abstract.Properties' proves that the invariants
 -- presented here can be obtained from reasoning about sent votes,
 -- which provides a much easier-to-prove interface to an implementation.
+
 module LibraBFT.Abstract.RecordChain.Assumptions
-    (𝓔      : EpochConfig)
     (UID    : Set)
     (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
-    (𝓥      : VoteEvidence 𝓔 UID)
+    (NodeId : Set)
+    (𝓔      : EpochConfig UID NodeId)
+    (𝓥      : VoteEvidence UID NodeId 𝓔)
   where
 
-  open import LibraBFT.Abstract.System           𝓔 UID _≟UID_ 𝓥
-  open import LibraBFT.Abstract.Records          𝓔 UID _≟UID_ 𝓥
-  open import LibraBFT.Abstract.Records.Extends  𝓔 UID _≟UID_ 𝓥
-  open import LibraBFT.Abstract.RecordChain      𝓔 UID _≟UID_ 𝓥
+  open import LibraBFT.Abstract.Types           UID        NodeId 𝓔
+  open import LibraBFT.Abstract.System          UID _≟UID_ NodeId 𝓔 𝓥
+  open import LibraBFT.Abstract.Records         UID _≟UID_ NodeId 𝓔 𝓥
+  open import LibraBFT.Abstract.Records.Extends UID _≟UID_ NodeId 𝓔 𝓥
+  open import LibraBFT.Abstract.RecordChain     UID _≟UID_ NodeId 𝓔 𝓥
 
   open EpochConfig 𝓔
-  open WithEpochConfig 𝓔
 
   module _ {ℓ}(InSys : Record → Set ℓ) where
 

--- a/LibraBFT/Abstract/RecordChain/Assumptions.agda
+++ b/LibraBFT/Abstract/RecordChain/Assumptions.agda
@@ -5,8 +5,8 @@
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
-open import LibraBFT.Abstract.Types using (VoteEvidence)
 open import LibraBFT.Abstract.Types.EpochConfig
+open WithAbsVote
 
 -- Here we establish the properties necessary to achieve consensus
 -- just like we see them on paper: stating facts about the state of

--- a/LibraBFT/Abstract/RecordChain/Assumptions.agda
+++ b/LibraBFT/Abstract/RecordChain/Assumptions.agda
@@ -6,7 +6,7 @@
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types.EpochConfig
-open WithAbsVote
+open        WithAbsVote
 
 -- Here we establish the properties necessary to achieve consensus
 -- just like we see them on paper: stating facts about the state of
@@ -32,8 +32,7 @@ module LibraBFT.Abstract.RecordChain.Assumptions
   open import LibraBFT.Abstract.Records         UID _≟UID_ NodeId 𝓔 𝓥
   open import LibraBFT.Abstract.Records.Extends UID _≟UID_ NodeId 𝓔 𝓥
   open import LibraBFT.Abstract.RecordChain     UID _≟UID_ NodeId 𝓔 𝓥
-
-  open EpochConfig 𝓔
+  open        EpochConfig 𝓔
 
   module _ {ℓ}(InSys : Record → Set ℓ) where
 

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -7,6 +7,7 @@ open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 open import LibraBFT.Abstract.Types.EpochConfig
+open WithAbsVote
 
 -- This module contains properties about RecordChains, culminating in
 -- theorem S5, which is the main per-epoch correctness condition.  The

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -1,11 +1,12 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
+open import LibraBFT.Abstract.Types.EpochConfig
 
 -- This module contains properties about RecordChains, culminating in
 -- theorem S5, which is the main per-epoch correctness condition.  The
@@ -18,25 +19,26 @@ open import LibraBFT.Abstract.Types
 -- separating these proofs into abstract and concrete pieces.
 
 module LibraBFT.Abstract.RecordChain.Properties
-  (𝓔      : EpochConfig)
   (UID    : Set)
   (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
-  (𝓥      : VoteEvidence 𝓔 UID)
-   where
+  (NodeId : Set)
+  (𝓔      : EpochConfig UID NodeId)
+  (𝓥      : VoteEvidence UID NodeId 𝓔)
+  where
 
- open import LibraBFT.Abstract.System                  𝓔 UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.Records                 𝓔 UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.Records.Extends         𝓔 UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.RecordChain             𝓔 UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 UID _≟UID_ 𝓥
-   as Assumptions
+ open import LibraBFT.Abstract.Types                   UID        NodeId 𝓔
+ open import LibraBFT.Abstract.System                  UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.Records                 UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.Records.Extends         UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.RecordChain             UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥
 
  open EpochConfig 𝓔
 
  module WithInvariants {ℓ}
    (InSys                 : Record → Set ℓ)
-   (votes-only-once       : Assumptions.VotesOnlyOnceRule InSys)
-   (locked-round-rule     : Assumptions.LockedRoundRule   InSys)
+   (votes-only-once       : VotesOnlyOnceRule InSys)
+   (locked-round-rule     : LockedRoundRule   InSys)
   where
 
    open All-InSys-props InSys

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -7,7 +7,7 @@ open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 open import LibraBFT.Abstract.Types.EpochConfig
-open WithAbsVote
+open        WithAbsVote
 
 -- This module contains properties about RecordChains, culminating in
 -- theorem S5, which is the main per-epoch correctness condition.  The
@@ -26,22 +26,19 @@ module LibraBFT.Abstract.RecordChain.Properties
   (𝓔      : EpochConfig UID NodeId)
   (𝓥      : VoteEvidence UID NodeId 𝓔)
   where
-
  open import LibraBFT.Abstract.Types                   UID        NodeId 𝓔
  open import LibraBFT.Abstract.System                  UID _≟UID_ NodeId 𝓔 𝓥
  open import LibraBFT.Abstract.Records                 UID _≟UID_ NodeId 𝓔 𝓥
  open import LibraBFT.Abstract.Records.Extends         UID _≟UID_ NodeId 𝓔 𝓥
  open import LibraBFT.Abstract.RecordChain             UID _≟UID_ NodeId 𝓔 𝓥
  open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥
-
- open EpochConfig 𝓔
+ open        EpochConfig 𝓔
 
  module WithInvariants {ℓ}
    (InSys                 : Record → Set ℓ)
    (votes-only-once       : VotesOnlyOnceRule InSys)
    (locked-round-rule     : LockedRoundRule   InSys)
-  where
-
+   where
    open All-InSys-props InSys
 
    ----------------------

--- a/LibraBFT/Abstract/Records.agda
+++ b/LibraBFT/Abstract/Records.agda
@@ -6,8 +6,8 @@
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Base.Types
-open import LibraBFT.Abstract.Types using (VoteEvidence)
 open import LibraBFT.Abstract.Types.EpochConfig
+open WithAbsVote
 
 -- This module defines abstract records (the initial or "genesis" record, blocks, and quorum
 -- certificates), along with related definitions and properties.
@@ -46,7 +46,7 @@ module LibraBFT.Abstract.Records
   -- to the correct parameters; This helps in defining
   -- and manipulating the 𝓥 vote evidence predicate.
   Vote : Set
-  Vote = AbsVoteData 𝓔
+  Vote = AbsVoteData UID NodeId 𝓔
 
   vRound      : Vote → Round
   vRound      = abs-vRound

--- a/LibraBFT/Abstract/Records.agda
+++ b/LibraBFT/Abstract/Records.agda
@@ -1,22 +1,26 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
-open import LibraBFT.Abstract.Types
+open import LibraBFT.Base.Types
+open import LibraBFT.Abstract.Types using (VoteEvidence)
+open import LibraBFT.Abstract.Types.EpochConfig
 
 -- This module defines abstract records (the initial or "genesis" record, blocks, and quorum
 -- certificates), along with related definitions and properties.
 
 module LibraBFT.Abstract.Records
-    (𝓔      : EpochConfig)
     (UID    : Set)
     (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁)) -- Needed to prove ≟Block and ≈?QC
-    (𝓥      : VoteEvidence 𝓔 UID)
+    (NodeId : Set)
+    (𝓔 : EpochConfig UID NodeId)
+    (𝓥 : VoteEvidence UID NodeId 𝓔)
  where
 
+  open import LibraBFT.Abstract.Types UID NodeId
   open EpochConfig 𝓔
 
   -- Abstract blocks do /not/ need to carry the state hash. Since the
@@ -42,7 +46,7 @@ module LibraBFT.Abstract.Records
   -- to the correct parameters; This helps in defining
   -- and manipulating the 𝓥 vote evidence predicate.
   Vote : Set
-  Vote = AbsVoteData 𝓔 UID
+  Vote = AbsVoteData 𝓔
 
   vRound      : Vote → Round
   vRound      = abs-vRound

--- a/LibraBFT/Abstract/Records.agda
+++ b/LibraBFT/Abstract/Records.agda
@@ -7,7 +7,7 @@ open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Base.Types
 open import LibraBFT.Abstract.Types.EpochConfig
-open WithAbsVote
+open        WithAbsVote
 
 -- This module defines abstract records (the initial or "genesis" record, blocks, and quorum
 -- certificates), along with related definitions and properties.
@@ -18,10 +18,9 @@ module LibraBFT.Abstract.Records
     (NodeId : Set)
     (𝓔 : EpochConfig UID NodeId)
     (𝓥 : VoteEvidence UID NodeId 𝓔)
- where
-
+    where
   open import LibraBFT.Abstract.Types UID NodeId
-  open EpochConfig 𝓔
+  open        EpochConfig 𝓔
 
   -- Abstract blocks do /not/ need to carry the state hash. Since the
   -- state hash of a concrete block is supposed to be hashed in the

--- a/LibraBFT/Abstract/Records/Extends.agda
+++ b/LibraBFT/Abstract/Records/Extends.agda
@@ -1,20 +1,26 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
+open import LibraBFT.Abstract.Types.EpochConfig
+
+-- This module defines the notion of one Record r "extending" another
+-- Record r' (denoted r' ← r), ensuring rules about rounds and that r
+-- correctly identifies r'
 
 module LibraBFT.Abstract.Records.Extends
-    (𝓔      : EpochConfig)
     (UID    : Set)
     (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
-    (𝓥      : VoteEvidence 𝓔 UID)
- where
+    (NodeId : Set)
+    (𝓔      : EpochConfig UID NodeId)
+    (𝓥     : VoteEvidence UID NodeId 𝓔)
+  where
 
-  open import LibraBFT.Abstract.Records 𝓔 UID _≟UID_ 𝓥
+  open import LibraBFT.Abstract.Records UID _≟UID_ NodeId 𝓔 𝓥
 
   -- Most of the conditions in section 4.2 of the paper (see
   -- LibraBFT.Abstract.RecordChain.Properties) would be checked

--- a/LibraBFT/Abstract/Records/Extends.agda
+++ b/LibraBFT/Abstract/Records/Extends.agda
@@ -7,6 +7,7 @@ open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Abstract.Types
 open import LibraBFT.Abstract.Types.EpochConfig
+open WithAbsVote
 
 -- This module defines the notion of one Record r "extending" another
 -- Record r' (denoted r' ← r), ensuring rules about rounds and that r

--- a/LibraBFT/Abstract/System.agda
+++ b/LibraBFT/Abstract/System.agda
@@ -4,7 +4,8 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Abstract.Types
+open import LibraBFT.Abstract.Types using (VoteEvidence)
+open import LibraBFT.Abstract.Types.EpochConfig
 
 -- This module defines and abstract view if a system, encompassing only a predicate for Records,
 -- another for Votes and a proof that, if a Vote is included in a QC in the system, then and
@@ -15,15 +16,17 @@ open import LibraBFT.Abstract.Types
 -- require only a short suffix of a RecordChain.
 
 module LibraBFT.Abstract.System
-    (𝓔      : EpochConfig)
     (UID    : Set)
     (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
-    (𝓥      : VoteEvidence 𝓔 UID)
-   where
+    (NodeId : Set)
+    (𝓔 : EpochConfig UID NodeId)
+    (𝓥 : VoteEvidence UID NodeId 𝓔)
+  where
 
-  open import LibraBFT.Abstract.Records         𝓔 UID _≟UID_ 𝓥
-  open import LibraBFT.Abstract.Records.Extends 𝓔 UID _≟UID_ 𝓥
-  open import LibraBFT.Abstract.RecordChain     𝓔 UID _≟UID_ 𝓥
+  open import LibraBFT.Abstract.Types           UID        NodeId 𝓔
+  open import LibraBFT.Abstract.Records         UID _≟UID_ NodeId 𝓔 𝓥
+  open import LibraBFT.Abstract.Records.Extends UID _≟UID_ NodeId 𝓔 𝓥
+  open import LibraBFT.Abstract.RecordChain     UID _≟UID_ NodeId 𝓔 𝓥
 
   module All-InSys-props {ℓ}(InSys : Record → Set ℓ) where
 
@@ -42,8 +45,6 @@ module LibraBFT.Abstract.System
                    → All-InSys (step rc ext)
     All-InSys-step hyp ext r here = r
     All-InSys-step hyp ext r (there .ext r∈rc) = hyp r∈rc
-
-  open WithEpochConfig 𝓔
 
   -- We say an InSys predicate is /Complete/ when we can construct a record chain
   -- from any vote by an honest participant. This essentially says that whenever

--- a/LibraBFT/Abstract/System.agda
+++ b/LibraBFT/Abstract/System.agda
@@ -4,8 +4,8 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Abstract.Types using (VoteEvidence)
 open import LibraBFT.Abstract.Types.EpochConfig
+open WithAbsVote
 
 -- This module defines and abstract view if a system, encompassing only a predicate for Records,
 -- another for Votes and a proof that, if a Vote is included in a QC in the system, then and

--- a/LibraBFT/Abstract/Types.agda
+++ b/LibraBFT/Abstract/Types.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021 Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
@@ -9,7 +9,6 @@ open import LibraBFT.Lemmas
 -- with the necessary module parameters (PK and MetaHonestPK)
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
-
 open import LibraBFT.Abstract.Types.EpochConfig
 
 -- This module brings in the base types used through libra

--- a/LibraBFT/Abstract/Types.agda
+++ b/LibraBFT/Abstract/Types.agda
@@ -48,30 +48,3 @@ module LibraBFT.Abstract.Types
      = trans (sym (author-nodeid-id RA))
              (trans (cong toNodeId prf)
                     (author-nodeid-id RB))
-
-  -- The abstract model is connected to the implementaton by means of
-  -- 'VoteEvidence'. The record module will be parameterized by a
-  -- v of type 'VoteEvidence 𝓔 UID'; this v will provide evidence
-  -- that a given author voted for a given block (identified by the UID)
-  -- on the specified round.
-  --
-  -- When it comes time to instantiate the v above concretely, it will
-  -- be something that states that we have a signature from the specified
-  -- author voting for the specified block.
-  record AbsVoteData : Set where
-    constructor mkAbsVoteData
-    field
-      abs-vRound     : Round
-      abs-vMember    : EpochConfig.Member 𝓔
-      abs-vBlockUID  : UID
-  open AbsVoteData public
-
-  AbsVoteData-η : ∀ {r1 r2 : Round} {m1 m2 : Member} {b1 b2 : UID}
-                → r1 ≡ r2
-                → m1 ≡ m2
-                → b1 ≡ b2
-                → mkAbsVoteData r1 m1 b1 ≡ mkAbsVoteData r2 m2 b2
-  AbsVoteData-η refl refl refl = refl
-
-  VoteEvidence : Set₁
-  VoteEvidence = AbsVoteData → Set

--- a/LibraBFT/Abstract/Types.agda
+++ b/LibraBFT/Abstract/Types.agda
@@ -18,7 +18,6 @@ module LibraBFT.Abstract.Types
   (NodeId : Set)
   (𝓔      : EpochConfig UID NodeId)
   where
-
   open EpochConfig 𝓔
 
   -- A member of an epoch is considered "honest" iff its public key is honest.

--- a/LibraBFT/Abstract/Types.agda
+++ b/LibraBFT/Abstract/Types.agda
@@ -5,111 +5,50 @@
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
--- TODO-2: The following import should be eliminated; see comment on
--- genesisUID below.
-open import LibraBFT.Hash
 -- TODO-2: The following import should be eliminated and replaced
 -- with the necessary module parameters (PK and MetaHonestPK)
 open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig
 
 -- This module brings in the base types used through libra
 -- and those necessary for the abstract model.
-module LibraBFT.Abstract.Types where
+module LibraBFT.Abstract.Types
+  (UID    : Set)
+  (NodeId : Set)
+  (𝓔      : EpochConfig UID NodeId)
+  where
 
-  open import LibraBFT.Base.Types public
+  open EpochConfig 𝓔
 
-  -- Simple way to flag meta-information without having it getting
-  -- in the way.
-  Meta : ∀{ℓ} → Set ℓ → Set ℓ
-  Meta x = x
-
-  -- An epoch-configuration carries only simple data about the epoch; the complicated
-  -- parts will be provided by the System, defined below.
-  --
-  -- The reason for the separation is that we should be able to provide
-  -- an EpochConfig from a single peer state.
-  record EpochConfig : Set₁ where
-    constructor mkEpochConfig
-    field
-      -- TODO-2 : This should really be a UID as Hash should not show up in the Abstract
-      -- namespace.  This will require some refactoring of modules and reordering of
-      -- module parameters.
-      genesisUID : Hash
-      epochId   : EpochId
-      authorsN  : ℕ
-
-    -- The set of members of this epoch.
-    Member : Set
-    Member = Fin authorsN
-
-    -- There is a partial isomorphism between NodeIds and the
-    -- authors participating in this epoch.
-    field
-      toNodeId  : Member → NodeId
-      isMember? : NodeId → Maybe Member
-
-      nodeid-author-id : ∀{α}     → isMember? (toNodeId α) ≡ just α
-      author-nodeid-id : ∀{nid α} → isMember? nid ≡ just α
-                                  → toNodeId α ≡ nid
-
-      getPubKey : Member → PK
-
-      PK-inj : ∀ {m1 m2} → getPubKey m1 ≡ getPubKey m2 → m1 ≡ m2
-
-      IsQuorum : List Member → Set
-
-      bft-assumption : ∀ {xs ys}
-                     → IsQuorum xs → IsQuorum ys
-                     → ∃[ α ] (α ∈ xs × α ∈ ys × Meta-Honest-PK (getPubKey α))
-
-
-  open EpochConfig
-
-  toNodeId-inj : ∀{𝓔}{x y : Member 𝓔} → toNodeId 𝓔 x ≡ toNodeId 𝓔 y → x ≡ y
-  toNodeId-inj {𝓔} hyp = just-injective (trans (sym (nodeid-author-id 𝓔))
-                                        (trans (cong (isMember? 𝓔) hyp)
-                                               (nodeid-author-id 𝓔)))
-
-  record EpochConfigFor (eid : ℕ) : Set₁ where
-    field
-     epochConfig : EpochConfig
-     forEpochId  : epochId epochConfig ≡ eid
-
-  MemberSubst : ∀ {𝓔} {𝓔'}
-              → 𝓔' ≡ 𝓔
-              → EpochConfig.Member 𝓔
-              → EpochConfig.Member 𝓔'
-  MemberSubst refl = id
-
-  module WithEpochConfig (𝓔 : EpochConfig) where
-
-    -- A member of an epoch is considered "honest" iff its public key is honest.
-    Meta-Honest-Member : Member 𝓔 → Set
-    Meta-Honest-Member α = Meta-Honest-PK (getPubKey 𝓔 α)
+  -- A member of an epoch is considered "honest" iff its public key is honest.
+  Meta-Honest-Member : EpochConfig.Member 𝓔 → Set
+  Meta-Honest-Member α = Meta-Honest-PK (getPubKey α)
 
   -- Naturally, if two witnesses that two authors belong
   -- in the epoch are the same, then the authors are also the same.
   --
   -- This proof is very Galois-like, because of the way we structured
   -- our partial isos. It's actually pretty nice! :)
-  member≡⇒author≡ : ∀{α β}{𝓔 : EpochConfig}
-                  → (authorα : Is-just (isMember? 𝓔 α))
-                  → (authorβ : Is-just (isMember? 𝓔 β))
+  member≡⇒author≡ : ∀{α β}
+                  → (authorα : Is-just (isMember? α))
+                  → (authorβ : Is-just (isMember? β))
                   → to-witness authorα ≡ to-witness authorβ
                   → α ≡ β
-  member≡⇒author≡ {α} {β} {𝓔} a b prf
-    with isMember? 𝓔 α | inspect (isMember? 𝓔) α
+  member≡⇒author≡ {α} {β} a b prf
+    with isMember? α | inspect isMember? α
   ...| nothing | [ _ ] = ⊥-elim (maybe-any-⊥ a)
-  member≡⇒author≡ {α} {β} {𝓔} (just _) b prf
+  member≡⇒author≡ {α} {β} (just _) b prf
      | just ra | [ RA ]
-    with isMember? 𝓔 β | inspect (isMember? 𝓔) β
+    with isMember? β | inspect isMember? β
   ...| nothing | [ _ ] = ⊥-elim (maybe-any-⊥ b)
-  member≡⇒author≡ {α} {β} {𝓔} (just _) (just _) prf
+  member≡⇒author≡ {α} {β} (just _) (just _) prf
      | just ra | [ RA ]
      | just rb | [ RB ]
-     = trans (sym (author-nodeid-id 𝓔 RA))
-             (trans (cong (toNodeId 𝓔) prf)
-                    (author-nodeid-id 𝓔 RB))
+     = trans (sym (author-nodeid-id RA))
+             (trans (cong toNodeId prf)
+                    (author-nodeid-id RB))
 
   -- The abstract model is connected to the implementaton by means of
   -- 'VoteEvidence'. The record module will be parameterized by a
@@ -120,7 +59,7 @@ module LibraBFT.Abstract.Types where
   -- When it comes time to instantiate the v above concretely, it will
   -- be something that states that we have a signature from the specified
   -- author voting for the specified block.
-  record AbsVoteData (𝓔 : EpochConfig)(UID : Set) : Set where
+  record AbsVoteData : Set where
     constructor mkAbsVoteData
     field
       abs-vRound     : Round
@@ -128,12 +67,12 @@ module LibraBFT.Abstract.Types where
       abs-vBlockUID  : UID
   open AbsVoteData public
 
-  AbsVoteData-η : ∀ {𝓔} {UID : Set} {r1 r2 : Round} {m1 m2 : EpochConfig.Member 𝓔} {b1 b2 : UID}
+  AbsVoteData-η : ∀ {r1 r2 : Round} {m1 m2 : Member} {b1 b2 : UID}
                 → r1 ≡ r2
                 → m1 ≡ m2
                 → b1 ≡ b2
-                → mkAbsVoteData {𝓔} {UID} r1 m1 b1 ≡ mkAbsVoteData r2 m2 b2
+                → mkAbsVoteData r1 m1 b1 ≡ mkAbsVoteData r2 m2 b2
   AbsVoteData-η refl refl refl = refl
 
-  VoteEvidence : EpochConfig → Set → Set₁
-  VoteEvidence 𝓔 UID = AbsVoteData 𝓔 UID → Set
+  VoteEvidence : Set₁
+  VoteEvidence = AbsVoteData → Set

--- a/LibraBFT/Abstract/Types/EpochConfig.agda
+++ b/LibraBFT/Abstract/Types/EpochConfig.agda
@@ -60,3 +60,31 @@ module LibraBFT.Abstract.Types.EpochConfig
     field
      epochConfig : EpochConfig
      forEpochId  : epochId epochConfig ≡ eid
+
+  module WithAbsVote (𝓔 : EpochConfig) where
+    -- The abstract model is connected to the implementaton by means of
+    -- 'VoteEvidence'. The record module will be parameterized by a
+    -- v of type 'VoteEvidence 𝓔 UID'; this v will provide evidence
+    -- that a given author voted for a given block (identified by the UID)
+    -- on the specified round.
+    --
+    -- When it comes time to instantiate the v above concretely, it will
+    -- be something that states that we have a signature from the specified
+    -- author voting for the specified block.
+    record AbsVoteData : Set where
+      constructor mkAbsVoteData
+      field
+        abs-vRound     : Round
+        abs-vMember    : EpochConfig.Member 𝓔
+        abs-vBlockUID  : UID
+    open AbsVoteData public
+
+    AbsVoteData-η : ∀ {r1 r2 : Round} {m1 m2 : EpochConfig.Member 𝓔} {b1 b2 : UID}
+                  → r1 ≡ r2
+                  → m1 ≡ m2
+                  → b1 ≡ b2
+                  → mkAbsVoteData r1 m1 b1 ≡ mkAbsVoteData r2 m2 b2
+    AbsVoteData-η refl refl refl = refl
+
+    VoteEvidence : Set₁
+    VoteEvidence = AbsVoteData → Set

--- a/LibraBFT/Abstract/Types/EpochConfig.agda
+++ b/LibraBFT/Abstract/Types/EpochConfig.agda
@@ -1,0 +1,62 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2020 Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+open import LibraBFT.Prelude
+open import LibraBFT.Lemmas
+-- TODO-2: The following import should be eliminated and replaced
+-- with the necessary module parameters (PK and MetaHonestPK)
+open import LibraBFT.Base.PKCS
+
+-- This module brings in the base types used through libra
+-- and those necessary for the abstract model.
+module LibraBFT.Abstract.Types.EpochConfig
+  (UID    : Set)
+  (NodeId : Set)
+  where
+
+  open import LibraBFT.Base.Types
+
+  -- An epoch-configuration carries only simple data about the epoch; the complicated
+  -- parts will be provided by the System, defined below.
+  --
+  -- The reason for the separation is that we should be able to provide
+  -- an EpochConfig from a single peer state.
+  record EpochConfig : Set₁ where
+    constructor mkEpochConfig
+    field
+      genesisUID : UID
+      epochId   : EpochId
+      authorsN  : ℕ
+
+    -- The set of members of this epoch.
+    Member : Set
+    Member = Fin authorsN
+
+    -- There is a partial isomorphism between NodeIds and the
+    -- authors participating in this epoch.
+    field
+      toNodeId  : Member → NodeId
+      isMember? : NodeId → Maybe Member
+
+      nodeid-author-id : ∀{α}     → isMember? (toNodeId α) ≡ just α
+      author-nodeid-id : ∀{nid α} → isMember? nid ≡ just α
+                                  → toNodeId α ≡ nid
+
+      getPubKey : Member → PK
+
+      PK-inj : ∀ {m1 m2} → getPubKey m1 ≡ getPubKey m2 → m1 ≡ m2
+
+      IsQuorum : List Member → Set
+
+      bft-assumption : ∀ {xs ys}
+                     → IsQuorum xs → IsQuorum ys
+                     → ∃[ α ] (α ∈ xs × α ∈ ys × Meta-Honest-PK (getPubKey α))
+
+  open EpochConfig
+
+  record EpochConfigFor (eid : ℕ) : Set₁ where
+    field
+     epochConfig : EpochConfig
+     forEpochId  : epochId epochConfig ≡ eid

--- a/LibraBFT/Abstract/Types/EpochConfig.agda
+++ b/LibraBFT/Abstract/Types/EpochConfig.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude

--- a/LibraBFT/Base/PKCS.agda
+++ b/LibraBFT/Base/PKCS.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Lemmas

--- a/LibraBFT/Base/Types.agda
+++ b/LibraBFT/Base/Types.agda
@@ -8,13 +8,22 @@ open import LibraBFT.Hash
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Encode
 
--- The ground types over which we build our abstract reasoning
+-- The ground types that are common across Abstract, Concrete and Impl
+-- and some utility types
 module LibraBFT.Base.Types where
   EpochId : Set
   EpochId = ℕ
 
   Round : Set
   Round = ℕ
+
+  -- This was intended to be a simple way to flag meta-information without having it
+  -- getting in the way.  It's important to ensure that an implementation does not
+  -- use various information, such as who is honest.  However, we found this got in
+  -- the way too much during development, so for now we get a similar effect by using
+  -- a naming convention and enforcement via grep and eyeballs.  Maybe one day...
+  Meta : ∀{ℓ} → Set ℓ → Set ℓ
+  Meta x = x
 
   -- An EPRound is a 'compound round'; that is,
   -- is a round coupled with an epoch id.  As most of our

--- a/LibraBFT/Concrete/Intermediate.agda
+++ b/LibraBFT/Concrete/Intermediate.agda
@@ -20,15 +20,14 @@
 
 open import LibraBFT.Prelude
 open import LibraBFT.Impl.Base.Types
-open import LibraBFT.Abstract.Types             UID NodeId using (VoteEvidence)
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open WithAbsVote
 
 module LibraBFT.Concrete.Intermediate
     (𝓔 : EpochConfig)
     (𝓥 : VoteEvidence 𝓔)
    where
-   open import LibraBFT.Abstract.Types   UID        NodeId 𝓔
-   open import LibraBFT.Abstract.Records UID _≟UID_ NodeId 𝓔 𝓥
+   open import LibraBFT.Abstract.Abstract UID _≟UID_ NodeId 𝓔 𝓥
 
    -- Since the invariants we want to specify (votes-once and locked-round-rule),
    -- are predicates over a /System State/, we must factor out the necessary

--- a/LibraBFT/Concrete/Intermediate.agda
+++ b/LibraBFT/Concrete/Intermediate.agda
@@ -3,9 +3,6 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-open import LibraBFT.Prelude
-open import LibraBFT.Abstract.Types
-
 -- This module defines an intermediate (between an implementation and Abstract) notion
 -- of a system state.  The goal is to enable proving for a particular implementation
 -- the properties required to provide to Abstract.Properties in order to get the high
@@ -21,16 +18,17 @@ open import LibraBFT.Abstract.Types
 -- be provided as module parameters to LibraBFT.Concrete (including IsValidVote and
 -- α-ValidVote)
 
+open import LibraBFT.Prelude
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Abstract.Types             UID NodeId using (VoteEvidence)
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+
 module LibraBFT.Concrete.Intermediate
-    (𝓔      : EpochConfig)
-    (UID    : Set)
-    (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
-    (𝓥      : VoteEvidence 𝓔 UID)
+    (𝓔 : EpochConfig)
+    (𝓥 : VoteEvidence 𝓔)
    where
-
-   open import LibraBFT.Abstract.Records         𝓔 UID _≟UID_ 𝓥
-
-   open WithEpochConfig 𝓔
+   open import LibraBFT.Abstract.Types   UID        NodeId 𝓔
+   open import LibraBFT.Abstract.Records UID _≟UID_ NodeId 𝓔 𝓥
 
    -- Since the invariants we want to specify (votes-once and locked-round-rule),
    -- are predicates over a /System State/, we must factor out the necessary

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -8,7 +8,6 @@ import LibraBFT.Concrete.Properties.VotesOnce as VO
 import LibraBFT.Concrete.Properties.LockedRound as LR
 
 open import LibraBFT.Impl.Base.Types
-open import LibraBFT.Abstract.Types             UID NodeId
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open EpochConfig
 

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -7,9 +7,8 @@ open import LibraBFT.Prelude
 open import LibraBFT.Concrete.System.Parameters
 import      LibraBFT.Concrete.Properties.VotesOnce   as VO
 import      LibraBFT.Concrete.Properties.LockedRound as LR
-open import LibraBFT.Abstract.Types
 open import LibraBFT.Impl.Consensus.Types hiding (EpochConfigFor)
-open EpochConfig
+open        EpochConfig
 open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- This module collects in one place the obligations an

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -1,20 +1,25 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-open import LibraBFT.Concrete.System.Parameters
+open import LibraBFT.Prelude
 import LibraBFT.Concrete.Properties.VotesOnce as VO
 import LibraBFT.Concrete.Properties.LockedRound as LR
 
-open import LibraBFT.Yasm.Properties ConcSysParms
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Abstract.Types             UID NodeId
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open EpochConfig
+
+open import LibraBFT.Concrete.System.Parameters
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- This module collects in one place the obligations an
 -- implementation must meet in order to enjoy the properties
 -- proved in Abstract.Properties.
 
 module LibraBFT.Concrete.Obligations where
-
   record ImplObligations : Set₁ where
     field
       -- Structural obligations:

--- a/LibraBFT/Concrete/Obligations/LockedRound.agda
+++ b/LibraBFT/Concrete/Obligations/LockedRound.agda
@@ -8,7 +8,7 @@ open import LibraBFT.Lemmas
 open import LibraBFT.Base.Types
 open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
-open WithAbsVote
+open        WithAbsVote
 
 module LibraBFT.Concrete.Obligations.LockedRound
   (𝓔 : EpochConfig)

--- a/LibraBFT/Concrete/Obligations/LockedRound.agda
+++ b/LibraBFT/Concrete/Obligations/LockedRound.agda
@@ -5,21 +5,22 @@
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
-open import LibraBFT.Abstract.Types
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open import LibraBFT.Abstract.Types UID NodeId using (VoteEvidence)
 
 module LibraBFT.Concrete.Obligations.LockedRound
   (𝓔 : EpochConfig)
-  (UID    : Set)
-  (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
-  (𝓥      : VoteEvidence 𝓔 UID)
+  (𝓥 : VoteEvidence 𝓔)
   where
+ open import LibraBFT.Abstract.Records                 UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.Records.Extends         UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.RecordChain             UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.Types                   UID        NodeId 𝓔
+ open import LibraBFT.Concrete.Intermediate                              𝓔 𝓥
 
- open import LibraBFT.Abstract.Records 𝓔 UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.Records.Extends 𝓔 UID _≟UID_ 𝓥
- open import LibraBFT.Abstract.RecordChain 𝓔 UID _≟UID_ 𝓥
- import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 UID _≟UID_ 𝓥
-   as StaticAssumptions
- open import LibraBFT.Concrete.Intermediate 𝓔 UID _≟UID_ 𝓥
 
  ---------------------
  -- * LockedRound * --
@@ -27,7 +28,6 @@ module LibraBFT.Concrete.Obligations.LockedRound
 
  module _ {ℓ}(𝓢 : IntermediateSystemState ℓ) where
   open IntermediateSystemState 𝓢
-  open WithEpochConfig 𝓔
 
  -- The LockedRound rule is a little more involved to be expressed in terms
  -- of /HasBeenSent/: it needs two additional pieces which are introduced
@@ -169,7 +169,7 @@ module LibraBFT.Concrete.Obligations.LockedRound
    ...| B←Q refl refl | B←Q refl refl = inj₂ refl
 
   -- Finally, we can prove the locked round rule from the global version;
-  proof : Type → StaticAssumptions.LockedRoundRule InSys
+  proof : Type → LockedRoundRule InSys
   proof glob-inv α hα {q} {q'} q∈sys q'∈sys c3 va rc' va' hyp
     with ∈QC⇒HasBeenSent q∈sys  hα va
        | ∈QC⇒HasBeenSent q'∈sys hα va'

--- a/LibraBFT/Concrete/Obligations/LockedRound.agda
+++ b/LibraBFT/Concrete/Obligations/LockedRound.agda
@@ -14,13 +14,8 @@ module LibraBFT.Concrete.Obligations.LockedRound
   (𝓔 : EpochConfig)
   (𝓥 : VoteEvidence 𝓔)
   where
- open import LibraBFT.Abstract.Records                 UID _≟UID_ NodeId 𝓔 𝓥
- open import LibraBFT.Abstract.Records.Extends         UID _≟UID_ NodeId 𝓔 𝓥
- open import LibraBFT.Abstract.RecordChain             UID _≟UID_ NodeId 𝓔 𝓥
- open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥
- open import LibraBFT.Abstract.Types                   UID        NodeId 𝓔
+ open import LibraBFT.Abstract.Abstract                UID _≟UID_ NodeId 𝓔 𝓥
  open import LibraBFT.Concrete.Intermediate                              𝓔 𝓥
-
 
  ---------------------
  -- * LockedRound * --

--- a/LibraBFT/Concrete/Obligations/LockedRound.agda
+++ b/LibraBFT/Concrete/Obligations/LockedRound.agda
@@ -8,14 +8,14 @@ open import LibraBFT.Lemmas
 open import LibraBFT.Base.Types
 open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
-open import LibraBFT.Abstract.Types UID NodeId using (VoteEvidence)
+open WithAbsVote
 
 module LibraBFT.Concrete.Obligations.LockedRound
   (𝓔 : EpochConfig)
   (𝓥 : VoteEvidence 𝓔)
   where
- open import LibraBFT.Abstract.Abstract                UID _≟UID_ NodeId 𝓔 𝓥
- open import LibraBFT.Concrete.Intermediate                              𝓔 𝓥
+ open import LibraBFT.Abstract.Abstract UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Concrete.Intermediate               𝓔 𝓥
 
  ---------------------
  -- * LockedRound * --

--- a/LibraBFT/Concrete/Obligations/VotesOnce.agda
+++ b/LibraBFT/Concrete/Obligations/VotesOnce.agda
@@ -13,12 +13,8 @@ module LibraBFT.Concrete.Obligations.VotesOnce
   (𝓔 : EpochConfig)
   (𝓥 : VoteEvidence 𝓔)
  where
- open import LibraBFT.Concrete.Intermediate                              𝓔 𝓥
- open import LibraBFT.Abstract.Types                   UID        NodeId 𝓔
- open import LibraBFT.Abstract.Records                 UID _≟UID_ NodeId 𝓔 𝓥
- open import LibraBFT.Abstract.Records.Extends         UID _≟UID_ NodeId 𝓔 𝓥
- open import LibraBFT.Abstract.RecordChain             UID _≟UID_ NodeId 𝓔 𝓥
- open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.Abstract      UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Concrete.Intermediate                    𝓔 𝓥
 
  -------------------
  -- * VotesOnce * --

--- a/LibraBFT/Concrete/Obligations/VotesOnce.agda
+++ b/LibraBFT/Concrete/Obligations/VotesOnce.agda
@@ -7,7 +7,7 @@ open import LibraBFT.Prelude
 open import LibraBFT.Base.Types
 open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
-open import LibraBFT.Abstract.Types UID NodeId using (VoteEvidence)
+open WithAbsVote
 
 module LibraBFT.Concrete.Obligations.VotesOnce
   (𝓔 : EpochConfig)

--- a/LibraBFT/Concrete/Obligations/VotesOnce.agda
+++ b/LibraBFT/Concrete/Obligations/VotesOnce.agda
@@ -4,19 +4,21 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Abstract.Types
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open import LibraBFT.Abstract.Types UID NodeId using (VoteEvidence)
 
 module LibraBFT.Concrete.Obligations.VotesOnce
   (𝓔 : EpochConfig)
-  (UID    : Set)
-  (_≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁))
-  (𝓥      : VoteEvidence 𝓔 UID)
-  where
-
- open import LibraBFT.Abstract.Records 𝓔 UID _≟UID_ 𝓥
- import LibraBFT.Abstract.RecordChain.Assumptions 𝓔 UID _≟UID_ 𝓥
-   as StaticAssumptions
- open import LibraBFT.Concrete.Intermediate 𝓔 UID _≟UID_ 𝓥
+  (𝓥 : VoteEvidence 𝓔)
+ where
+ open import LibraBFT.Concrete.Intermediate                              𝓔 𝓥
+ open import LibraBFT.Abstract.Types                   UID        NodeId 𝓔
+ open import LibraBFT.Abstract.Records                 UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.Records.Extends         UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.RecordChain             UID _≟UID_ NodeId 𝓔 𝓥
+ open import LibraBFT.Abstract.RecordChain.Assumptions UID _≟UID_ NodeId 𝓔 𝓥
 
  -------------------
  -- * VotesOnce * --
@@ -24,8 +26,6 @@ module LibraBFT.Concrete.Obligations.VotesOnce
 
  module _ {ℓ}(𝓢 : IntermediateSystemState ℓ) where
   open IntermediateSystemState 𝓢
-  open WithEpochConfig 𝓔
-
   Type : Set ℓ
   Type = ∀{α v v'}
        → Meta-Honest-Member α
@@ -39,7 +39,7 @@ module LibraBFT.Concrete.Obligations.VotesOnce
        -- author can send different votes for the same epoch and round that differ on timeout
        -- signature.  Maybe something for liveness?
 
-  proof : Type → StaticAssumptions.VotesOnlyOnceRule InSys
+  proof : Type → VotesOnlyOnceRule InSys
   proof glob-inv α hα {q} {q'} q∈sys q'∈sys va va' VO≡
      with ∈QC⇒HasBeenSent q∈sys  hα va
         | ∈QC⇒HasBeenSent q'∈sys hα va'

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -28,10 +28,7 @@ module LibraBFT.Concrete.Properties
     open PerState st r
     open PerEpoch eid
 
-    open import LibraBFT.Abstract.Records      UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
-    open import LibraBFT.Abstract.RecordChain  UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔)
-    open import LibraBFT.Abstract.System       UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔)
-    open import LibraBFT.Abstract.Properties   UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔)
+    open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
     open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
     import      LibraBFT.Concrete.Obligations.VotesOnce          𝓔 (ConcreteVoteEvidence 𝓔) as VO-obl
     import      LibraBFT.Concrete.Obligations.LockedRound        𝓔 (ConcreteVoteEvidence 𝓔) as LR-obl

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -6,9 +6,9 @@
 open import LibraBFT.Prelude
 open import LibraBFT.Concrete.Obligations
 open import LibraBFT.Concrete.System.Parameters
-open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.Base.Types
-open EpochConfig
+open import LibraBFT.Impl.Consensus.Types
+open        EpochConfig
 open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- In this module, we assume that the implementation meets its
@@ -22,10 +22,10 @@ module LibraBFT.Concrete.Properties
          (r : ReachableSystemState st)
          (eid : Fin e)
          where
-    open ImplObligations impl-correct
+    open        ImplObligations impl-correct
     open import LibraBFT.Concrete.System sps-cor
-    open PerState st r
-    open PerEpoch eid
+    open        PerState st r
+    open        PerEpoch eid
 
     open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
     open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -4,44 +4,39 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
-
-open import LibraBFT.Abstract.Types
-
-open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Consensus.Types
-
-open import LibraBFT.Concrete.System.Parameters
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Abstract.Types UID NodeId
 open import LibraBFT.Concrete.Obligations
-
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
+open import LibraBFT.Concrete.System.Parameters
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- In this module, we assume that the implementation meets its
--- obligations, and use this assumption to prove that the
--- implementatioon enjoys one of the per-epoch correctness conditions
--- proved in Abstract.Properties.  It can be extended to other
+-- obligations, and use this assumption to prove that, in any reachable
+-- state, the implementatioon enjoys one of the per-epoch correctness
+-- conditions proved in Abstract.Properties.  It can be extended to other
 -- properties later.
-
-module LibraBFT.Concrete.Properties (impl-correct : ImplObligations) where
-  open ImplObligations impl-correct
-
-  -- For any reachable state,
-  module _ {e}(st : SystemState e)(r : ReachableSystemState st)(eid : Fin e) where
+module LibraBFT.Concrete.Properties
+         (impl-correct : ImplObligations)
+         {e}(st : SystemState e)
+         (r : ReachableSystemState st)
+         (eid : Fin e)
+         where
+    open ImplObligations impl-correct
     open import LibraBFT.Concrete.System sps-cor
     open PerState st r
     open PerEpoch eid
 
-    import LibraBFT.Abstract.Records 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as Abs
-    open import LibraBFT.Abstract.RecordChain 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
-    open import LibraBFT.Abstract.System 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
-    open import LibraBFT.Abstract.Properties 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
-
-    open import LibraBFT.Concrete.Intermediate 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
-    import LibraBFT.Concrete.Obligations.VotesOnce   𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as VO-obl
-    import LibraBFT.Concrete.Obligations.LockedRound 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as LR-obl
-    open import LibraBFT.Concrete.Properties.VotesOnce as VO
-    open import LibraBFT.Concrete.Properties.LockedRound as LR
+    open import LibraBFT.Abstract.Records      UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
+    open import LibraBFT.Abstract.RecordChain  UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔)
+    open import LibraBFT.Abstract.System       UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔)
+    open import LibraBFT.Abstract.Properties   UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔)
+    open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
+    import      LibraBFT.Concrete.Obligations.VotesOnce          𝓔 (ConcreteVoteEvidence 𝓔) as VO-obl
+    import      LibraBFT.Concrete.Obligations.LockedRound        𝓔 (ConcreteVoteEvidence 𝓔) as LR-obl
+    open import LibraBFT.Concrete.Properties.VotesOnce                                       as VO
+    open import LibraBFT.Concrete.Properties.LockedRound                                     as LR
 
     --------------------------------------------------------------------------------------------
     -- * A /ValidSysState/ is one in which both peer obligations are obeyed by honest peers * --
@@ -52,7 +47,6 @@ module LibraBFT.Concrete.Properties (impl-correct : ImplObligations) where
         vss-votes-once   : VO-obl.Type 𝓢
         vss-locked-round : LR-obl.Type 𝓢
     open ValidSysState public
-
 
     -- TODO-2 : This should be provided as a module parameter here, and the
     -- proofs provided to instantiate it should be refactored into LibraBFT.Impl.

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -6,7 +6,6 @@
 open import LibraBFT.Prelude
 open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.Base.Types
-open import LibraBFT.Abstract.Types UID NodeId
 open import LibraBFT.Concrete.Obligations
 open import LibraBFT.Concrete.System.Parameters
 open EpochConfig

--- a/LibraBFT/Concrete/Properties/LockedRound.agda
+++ b/LibraBFT/Concrete/Properties/LockedRound.agda
@@ -14,7 +14,6 @@ open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
-open import LibraBFT.Abstract.Types UID NodeId
 open EpochConfig
 open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 

--- a/LibraBFT/Concrete/Properties/LockedRound.agda
+++ b/LibraBFT/Concrete/Properties/LockedRound.agda
@@ -5,25 +5,18 @@
 -}
 open import Optics.All
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Lemmas
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
-
-open import LibraBFT.Abstract.Types
-open EpochConfig
-
-open import LibraBFT.Impl.NetworkMsg
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
-
 open import LibraBFT.Concrete.System.Parameters
-
-open import LibraBFT.Yasm.Base
-open import LibraBFT.Yasm.AvailableEpochs using (AvailableEpochs ; lookup'; lookup'')
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
+open import LibraBFT.Abstract.Types UID NodeId
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- This module contains placeholders for the future analog of the
 -- corresponding VotesOnce property.  Defining the implementation
@@ -53,7 +46,7 @@ module LibraBFT.Concrete.Properties.LockedRound where
    open PerState st r
    open PerEpoch eid
 
-   open import LibraBFT.Concrete.Obligations.LockedRound 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as LR
+   open import LibraBFT.Concrete.Obligations.LockedRound 𝓔 (ConcreteVoteEvidence 𝓔) as LR
 
    postulate  -- TODO-3: prove it
      lrr : LR.Type IntSystemState

--- a/LibraBFT/Concrete/Properties/LockedRound.agda
+++ b/LibraBFT/Concrete/Properties/LockedRound.agda
@@ -14,7 +14,7 @@ open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
-open EpochConfig
+open        EpochConfig
 open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- This module contains placeholders for the future analog of the
@@ -24,7 +24,6 @@ open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN 
 -- simpler VotesOnce property to settle down the structural aspects
 -- before tackling the harder semantic issues.
 module LibraBFT.Concrete.Properties.LockedRound where
-
  -- TODO-3: define the implementation obligation
  ImplObligation₁ : Set
  ImplObligation₁ = Unit
@@ -34,7 +33,6 @@ module LibraBFT.Concrete.Properties.LockedRound where
    (sps-corr : StepPeerState-AllValidParts)
    (Impl-LR1 : ImplObligation₁)
    where
-
   -- Any reachable state satisfies the LR rule for any epoch in the system.
   module _ {e}(st : SystemState e)(r : ReachableSystemState st)(eid : Fin e) where
    -- Bring in 'unwind', 'ext-unforgeability' and friends
@@ -42,9 +40,8 @@ module LibraBFT.Concrete.Properties.LockedRound where
 
    -- Bring in IntSystemState
    open import LibraBFT.Concrete.System sps-corr
-   open PerState st r
-   open PerEpoch eid
-
+   open        PerState st r
+   open        PerEpoch eid
    open import LibraBFT.Concrete.Obligations.LockedRound 𝓔 (ConcreteVoteEvidence 𝓔) as LR
 
    postulate  -- TODO-3: prove it

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -15,7 +15,7 @@ open import LibraBFT.Impl.Consensus.Types hiding (EpochConfigFor)
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
-open EpochConfig
+open        EpochConfig
 open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- In this module, we define two "implementation obligations"

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -5,25 +5,17 @@
 -}
 open import Optics.All
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Lemmas
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
-
-open import LibraBFT.Abstract.Types
-open EpochConfig
-
-open import LibraBFT.Impl.NetworkMsg
-open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Impl.Consensus.Types hiding (EpochConfigFor)
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
-
 open import LibraBFT.Concrete.System.Parameters
-
-open import LibraBFT.Yasm.Base
-open import LibraBFT.Yasm.AvailableEpochs using (AvailableEpochs ; lookup'; lookup'')
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- In this module, we define two "implementation obligations"
 -- (ImplObligationᵢ for i ∈ {1 , 2}), which are predicates over
@@ -39,8 +31,8 @@ open import LibraBFT.Yasm.Properties ConcSysParms
 -- semantic obligations, along with a structural one about messages
 -- sent by honest peers in the implementation, then the implemenation
 -- satisfies the LibraBFT.Abstract.Properties.VotesOnce invariant.
-module LibraBFT.Concrete.Properties.VotesOnce where
 
+module LibraBFT.Concrete.Properties.VotesOnce where
  -- TODO-3: This may not be the best way to state the implementation obligation.  Why not reduce
  -- this as much as possible before giving the obligation to the implementation?  For example, this
  -- will still require the implementation to deal with hash collisons (v and v' could be different,
@@ -110,7 +102,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    open PerState st r
    open PerEpoch eid
 
-   open import LibraBFT.Concrete.Obligations.VotesOnce 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as VO
+   open import LibraBFT.Concrete.Obligations.VotesOnce 𝓔 (ConcreteVoteEvidence 𝓔) as VO
 
    -- The VO proof is done by induction on the execution trace leading to 'st'. In
    -- Agda, this is 'r : RechableSystemState st' above. We will use induction to

--- a/LibraBFT/Concrete/Records.agda
+++ b/LibraBFT/Concrete/Records.agda
@@ -1,19 +1,20 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 {-# OPTIONS --allow-unsolved-metas #-}
+open import Optics.All
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
-open import LibraBFT.Abstract.Types
-open import LibraBFT.Impl.Util.Crypto
-
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Impl.Consensus.Types.EpochIndep
 open import LibraBFT.Impl.NetworkMsg
-
-open import Optics.All
+open import LibraBFT.Impl.Util.Crypto
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
 -- Here we have the abstraction functions that connect
 -- the datatypes defined in LibraBFT.Impl.Consensus.Types
@@ -21,14 +22,10 @@ open import Optics.All
 -- for a given EpochConfig.
 --
 module LibraBFT.Concrete.Records (𝓔 : EpochConfig) where
-
- open import LibraBFT.Impl.Consensus.Types.EpochIndep
+ open import LibraBFT.Abstract.Types UID NodeId 𝓔
  open import LibraBFT.Impl.Consensus.Types.EpochDep 𝓔
-
- import LibraBFT.Abstract.Records 𝓔 UID _≟UID_ ConcreteVoteEvidence as Abs
-
  open EpochConfig 𝓔
-
+ import LibraBFT.Abstract.Records UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence as Abs
  --------------------------------
  -- Abstracting Blocks and QCs --
  --------------------------------
@@ -82,7 +79,7 @@ module LibraBFT.Concrete.Records (𝓔 : EpochConfig) where
  voteInEvidence≈rebuiltVote {_} {cqc} {valid} {α , sig , ord} as∈cqc ev refl
    = equivVotes (cong abs-vBlockUID (₋cveIsAbs ev))
                 (cong abs-vRound (₋cveIsAbs ev))
-                (member≡⇒author≡ {𝓔 = 𝓔}
+                (member≡⇒author≡
                   (isJust (₋ivvAuthor (₋cveIsValidVote ev)))
                   (isJust (₋ivvAuthor (All-lookup (₋ivqcVotesValid valid) as∈cqc)))
                   (trans (to-witness-isJust-≡ {prf = ₋ivvAuthor (₋cveIsValidVote ev)})

--- a/LibraBFT/Concrete/Records.agda
+++ b/LibraBFT/Concrete/Records.agda
@@ -15,6 +15,7 @@ open import LibraBFT.Impl.Consensus.Types.EpochIndep
 open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open WithAbsVote
 
 -- Here we have the abstraction functions that connect
 -- the datatypes defined in LibraBFT.Impl.Consensus.Types
@@ -22,10 +23,9 @@ open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 -- for a given EpochConfig.
 --
 module LibraBFT.Concrete.Records (𝓔 : EpochConfig) where
- open import LibraBFT.Abstract.Types UID NodeId 𝓔
  open import LibraBFT.Impl.Consensus.Types.EpochDep 𝓔
+ open import LibraBFT.Abstract.Abstract UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence as Abs hiding (bId; qcVotes; Block)
  open EpochConfig 𝓔
- import LibraBFT.Abstract.Records UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence as Abs
  --------------------------------
  -- Abstracting Blocks and QCs --
  --------------------------------

--- a/LibraBFT/Concrete/Records.agda
+++ b/LibraBFT/Concrete/Records.agda
@@ -25,7 +25,7 @@ open WithAbsVote
 module LibraBFT.Concrete.Records (𝓔 : EpochConfig) where
  open import LibraBFT.Impl.Consensus.Types.EpochDep 𝓔
  open import LibraBFT.Abstract.Abstract UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence as Abs hiding (bId; qcVotes; Block)
- open EpochConfig 𝓔
+ open        EpochConfig 𝓔
  --------------------------------
  -- Abstracting Blocks and QCs --
  --------------------------------

--- a/LibraBFT/Concrete/Records.agda
+++ b/LibraBFT/Concrete/Records.agda
@@ -15,7 +15,7 @@ open import LibraBFT.Impl.Consensus.Types.EpochIndep
 open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
-open WithAbsVote
+open        WithAbsVote
 
 -- Here we have the abstraction functions that connect
 -- the datatypes defined in LibraBFT.Impl.Consensus.Types

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -96,9 +96,7 @@ module LibraBFT.Concrete.System (sps-corr : StepPeerState-AllValidParts) where
    𝓔 = EC-lookup (availEpochs st) eid
    open EpochConfig
 
-   import      LibraBFT.Abstract.Records      UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
-   open import LibraBFT.Abstract.System       UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔)
-   open import LibraBFT.Abstract.Types        UID        NodeId 𝓔
+   open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs hiding (qcVotes; Vote)
    open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
    open import LibraBFT.Concrete.Records                        𝓔
 

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -15,7 +15,7 @@ open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
-open EpochConfig
+open        EpochConfig
 open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- This module defines an abstract system state given a reachable
@@ -93,8 +93,6 @@ module LibraBFT.Concrete.System (sps-corr : StepPeerState-AllValidParts) where
   module PerEpoch (eid : Fin e) where
    𝓔 : EpochConfig
    𝓔 = EC-lookup (availEpochs st) eid
-   open EpochConfig
-
    open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs hiding (qcVotes; Vote)
    open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
    open import LibraBFT.Concrete.Records                        𝓔

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -3,7 +3,6 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-{-# OPTIONS --allow-unsolved-metas #-}
 open import Optics.All
 open import LibraBFT.Prelude
 open import LibraBFT.Hash

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -10,20 +10,14 @@ open import LibraBFT.Hash
 open import LibraBFT.Lemmas
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
-
-open import LibraBFT.Abstract.Types
-
-open import LibraBFT.Impl.NetworkMsg
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
-
 open import LibraBFT.Concrete.System.Parameters
-
-open import LibraBFT.Yasm.Base
-open import LibraBFT.Yasm.AvailableEpochs using (AvailableEpochs ; lookup'; lookup'')
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- This module defines an abstract system state given a reachable
 -- concrete system state.
@@ -98,17 +92,15 @@ module LibraBFT.Concrete.System (sps-corr : StepPeerState-AllValidParts) where
     meta-sha256-cr : ¬ (NonInjective-≡ sha256)
 
   module PerEpoch (eid : Fin e) where
-
-   open import LibraBFT.Yasm.AvailableEpochs
-
    𝓔 : EpochConfig
-   𝓔 = lookup' (availEpochs st) eid
+   𝓔 = EC-lookup (availEpochs st) eid
    open EpochConfig
 
-   open import LibraBFT.Abstract.System 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
-   open import LibraBFT.Concrete.Intermediate 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔)
-   open import LibraBFT.Concrete.Records 𝓔
-   import LibraBFT.Abstract.Records 𝓔 Hash _≟Hash_ (ConcreteVoteEvidence 𝓔) as Abs
+   import      LibraBFT.Abstract.Records      UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
+   open import LibraBFT.Abstract.System       UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔)
+   open import LibraBFT.Abstract.Types        UID        NodeId 𝓔
+   open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
+   open import LibraBFT.Concrete.Records                        𝓔
 
    -- * Auxiliary definitions;
    -- TODO-1: simplify and cleanup
@@ -173,7 +165,7 @@ module LibraBFT.Concrete.System (sps-corr : StepPeerState-AllValidParts) where
        cv            : Vote
        cv∈nm         : cv ⊂Msg nm
        -- And contained a valid vote that, once abstracted, yeilds v.
-       vmsgMember    : Member 𝓔
+       vmsgMember    : EpochConfig.Member 𝓔
        vmsgSigned    : WithVerSig (getPubKey 𝓔 vmsgMember) cv
        vmsg≈v        : α-ValidVote 𝓔 cv vmsgMember ≡ v
        vmsgEpoch     : cv ^∙ vEpoch ≡ epochId 𝓔
@@ -200,8 +192,6 @@ module LibraBFT.Concrete.System (sps-corr : StepPeerState-AllValidParts) where
        vmFor    : ∃VoteMsgFor v
        nmInOuts : nm vmFor ∈ outs
    open ∃VoteMsgInFor public
-
-   open WithEpochConfig 𝓔
 
    ∈QC⇒sent : ∀{e} {st : SystemState e} {q α}
             → Abs.Q q α-Sent (msgPool st)

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -1,15 +1,18 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+open import Optics.All
 open import LibraBFT.Prelude
-open import LibraBFT.Impl.NetworkMsg
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.Util.Crypto
-open import LibraBFT.Yasm.Base
-open import Optics.All
 open import LibraBFT.Impl.Handle sha256 sha256-cr
+open import LibraBFT.Abstract.Types UID NodeId
+open EpochConfig
+open import LibraBFT.Yasm.Base NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN
 
 -- In this module, we instantiate the system model with parameters to
 -- model a system using the simple implementation model we have so
@@ -18,9 +21,9 @@ open import LibraBFT.Impl.Handle sha256 sha256-cr
 -- implementation.
 
 module LibraBFT.Concrete.System.Parameters where
-
  ConcSysParms : SystemParameters
  ConcSysParms = mkSysParms
+                 NodeId
                  EventProcessor
                  NetworkMsg
                  Vote

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -10,7 +10,6 @@ open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
-open import LibraBFT.Abstract.Types UID NodeId
 open EpochConfig
 open import LibraBFT.Yasm.Base NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN
 

--- a/LibraBFT/Impl/Base/Types.agda
+++ b/LibraBFT/Impl/Base/Types.agda
@@ -1,0 +1,16 @@
+{- TODO: copyright -}
+
+
+module LibraBFT.Impl.Base.Types where
+
+  open import LibraBFT.Prelude
+  open import LibraBFT.Hash
+
+  NodeId : Set
+  NodeId = ℕ
+
+  UID : Set
+  UID = Hash
+
+  _≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁)
+  _≟UID_ = _≟Hash_

--- a/LibraBFT/Impl/Base/Types.agda
+++ b/LibraBFT/Impl/Base/Types.agda
@@ -1,8 +1,10 @@
-{- TODO: copyright -}
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
 
 module LibraBFT.Impl.Base.Types where
-
   open import LibraBFT.Prelude
   open import LibraBFT.Hash
 

--- a/LibraBFT/Impl/Consensus/ChainedBFT/EventProcessor.agda
+++ b/LibraBFT/Impl/Consensus/ChainedBFT/EventProcessor.agda
@@ -1,18 +1,20 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+open import Optics.All
 open import LibraBFT.Prelude
 open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Util.Util
-open import LibraBFT.Hash
-open import Optics.All
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
-open RWST-do
 
 -- This is a minimal/fake example handler that obeys the VotesOnce rule, enabling us to start
 -- exploring how we express the algorithm and prove properties about it.  It simply sends a vote for
@@ -24,6 +26,8 @@ module LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor
   (hash    : BitString → Hash)
   (hash-cr : ∀{x y} → hash x ≡ hash y → Collision hash x y ⊎ x ≡ y)
   where
+
+  open RWST-do
 
   processCommitM : LedgerInfoWithSignatures → LBFT (List ExecutedBlock)
   processCommitM finalityProof = pure []

--- a/LibraBFT/Impl/Consensus/Types.agda
+++ b/LibraBFT/Impl/Consensus/Types.agda
@@ -1,17 +1,15 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 {-# OPTIONS --allow-unsolved-metas #-}
+open import Optics.All
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap as KVMap
-
-open import Optics.All
-
+open import LibraBFT.Base.Types
 open import Data.String using (String)
 
 -- This module defines types for an out-of-date implementation, based
@@ -28,11 +26,13 @@ open import Data.String using (String)
 -- defining the epoch config.  However, the separation is not perfect,
 -- so sometimes fields may be modified in EpochIndep even though there
 -- is no epoch change.
-module LibraBFT.Impl.Consensus.Types where
 
-  open import LibraBFT.Impl.NetworkMsg
-  open import LibraBFT.Impl.Consensus.Types.EpochIndep public
-  open import LibraBFT.Impl.Consensus.Types.EpochDep   public
+module LibraBFT.Impl.Consensus.Types where
+  open import LibraBFT.Impl.Base.Types                       public
+  open import LibraBFT.Impl.NetworkMsg                       public
+  open import LibraBFT.Abstract.Types.EpochConfig UID NodeId public
+  open import LibraBFT.Impl.Consensus.Types.EpochIndep       public
+  open import LibraBFT.Impl.Consensus.Types.EpochDep         public
 
   -- The parts of the state of a peer that are used to
   -- define the EpochConfig are the SafetyRules and ValidatorVerifier:

--- a/LibraBFT/Impl/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochDep.agda
@@ -3,8 +3,6 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-{-# OPTIONS --allow-unsolved-metas #-}
-
 open import Optics.All
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas

--- a/LibraBFT/Impl/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochDep.agda
@@ -1,20 +1,20 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 {-# OPTIONS --allow-unsolved-metas #-}
+
+open import Optics.All
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
-open import LibraBFT.Hash
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap as KVMap
-
-open import LibraBFT.Impl.Util.Crypto
+open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types.EpochIndep
-
-open import Optics.All
+open import LibraBFT.Impl.Util.Crypto
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
 -- This module defines the types that depend on an EpochConfig,
 -- but never inspect it. Consequently, we define everyting over
@@ -35,21 +35,10 @@ open import Optics.All
 -- now, this is the easiest way to avoid the issue that making a
 -- module inside Consensus.Types called EpochDep will break
 -- mkLens (not sure why).
+
 module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
+  open import LibraBFT.Abstract.Types UID NodeId 𝓔
   open EpochConfig 𝓔
-
-  -- Blocks and QCs are identified by hashes. In particular;
-  -- Blocks are identified by their hash and QCs are identified
-  -- by the hash of the block they certify.
-  --
-  -- This really means that two QCs that certify the same block
-  -- are (by definition!!) the same. We capture this in the
-  -- abstract model by using the _≈Rec_ relation.
-  UID :  Set
-  UID = Hash
-
-  _≟UID_ : (u₀ u₁ : UID) → Dec (u₀ ≡ u₁)
-  _≟UID_ = _≟Hash_
 
   -- A 'ConcreteVoteEvidence' is a piece of information that
   -- captures that the 'vd : AbsVoteData' in question was not /invented/
@@ -59,12 +48,11 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   -- Moreover, we will also store the RecordChain that leads to the vote;
   -- this requires some mutually-recursive shenanigans, so we first declare
   -- ConcreteVoteEvidence, then import the necessary modules, and then define it.
-  record ConcreteVoteEvidence (vd : AbsVoteData 𝓔 UID) : Set
+  record ConcreteVoteEvidence (vd : AbsVoteData) : Set
 
-  import LibraBFT.Abstract.Records              𝓔 UID _≟UID_ ConcreteVoteEvidence
-    as Abs
-  open import LibraBFT.Abstract.Records.Extends 𝓔 UID _≟UID_ ConcreteVoteEvidence
-  open import LibraBFT.Abstract.RecordChain     𝓔 UID _≟UID_ ConcreteVoteEvidence
+  import      LibraBFT.Abstract.Records         UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence as Abs
+  open import LibraBFT.Abstract.Records.Extends UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence
+  open import LibraBFT.Abstract.RecordChain     UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence
 
   data VoteCoherence (v : Vote) (b : Abs.Block) : Set where
     initial  : v ^∙ vParentId    ≡ genesisUID
@@ -114,7 +102,7 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   -- A valid vote can be directly mapped to an AbsVoteData. Abstraction of QCs
   -- and blocks will be given in LibraBFT.Concrete.Records, since those are
   -- more involved functions.
-  α-ValidVote : (v : Vote) → Member → AbsVoteData 𝓔 UID
+  α-ValidVote : (v : Vote) → Member → AbsVoteData
   α-ValidVote v mbr = mkAbsVoteData (v ^∙ vProposed ∙ biRound)
                                      mbr
                                      (v ^∙ vProposed ∙ biId)

--- a/LibraBFT/Impl/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochDep.agda
@@ -37,7 +37,7 @@ open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 -- mkLens (not sure why).
 
 module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
-  open import LibraBFT.Abstract.Types UID NodeId 𝓔
+  import LibraBFT.Abstract.Types UID NodeId 𝓔 as LAT
   open EpochConfig 𝓔
 
   -- A 'ConcreteVoteEvidence' is a piece of information that
@@ -48,11 +48,9 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   -- Moreover, we will also store the RecordChain that leads to the vote;
   -- this requires some mutually-recursive shenanigans, so we first declare
   -- ConcreteVoteEvidence, then import the necessary modules, and then define it.
-  record ConcreteVoteEvidence (vd : AbsVoteData) : Set
+  record ConcreteVoteEvidence (vd : LAT.AbsVoteData) : Set
 
-  import      LibraBFT.Abstract.Records         UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence as Abs
-  open import LibraBFT.Abstract.Records.Extends UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence
-  open import LibraBFT.Abstract.RecordChain     UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence
+  open import LibraBFT.Abstract.Abstract UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence as Abs hiding (qcVotes; Vote)
 
   data VoteCoherence (v : Vote) (b : Abs.Block) : Set where
     initial  : v ^∙ vParentId    ≡ genesisUID

--- a/LibraBFT/Impl/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochDep.agda
@@ -37,8 +37,8 @@ open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 -- mkLens (not sure why).
 
 module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
-  import LibraBFT.Abstract.Types UID NodeId 𝓔 as LAT
   open EpochConfig 𝓔
+  open WithAbsVote 𝓔
 
   -- A 'ConcreteVoteEvidence' is a piece of information that
   -- captures that the 'vd : AbsVoteData' in question was not /invented/
@@ -48,7 +48,7 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   -- Moreover, we will also store the RecordChain that leads to the vote;
   -- this requires some mutually-recursive shenanigans, so we first declare
   -- ConcreteVoteEvidence, then import the necessary modules, and then define it.
-  record ConcreteVoteEvidence (vd : LAT.AbsVoteData) : Set
+  record ConcreteVoteEvidence (vd : AbsVoteData) : Set
 
   open import LibraBFT.Abstract.Abstract UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence as Abs hiding (qcVotes; Vote)
 

--- a/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
@@ -1,17 +1,17 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-open import LibraBFT.Lemmas
+open import Optics.All
 open import LibraBFT.Prelude
 open import LibraBFT.Hash
-open import LibraBFT.Base.Encode
 open import LibraBFT.Base.ByteString
-open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap as KVMap
-
-open import Optics.All
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.Base.Types
 
 open import Data.String using (String)
 
@@ -20,9 +20,6 @@ open import Data.String using (String)
 -- a substantial undertaking that should probably be led by someone who can
 -- access our internal implementation.
 module LibraBFT.Impl.Consensus.Types.EpochIndep where
-
-  open import LibraBFT.Abstract.Types public
-
   -- Below here is incremental progress towards something
   -- that will eventually mirror the types in LBFT.Consensus.Types
   -- that /DO NOT/ depend on the set of active authors
@@ -33,9 +30,6 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
 
   AccountAddress : Set
   AccountAddress = Author
-
-  _≟AccountAddress_ : (a₁ a₂ : AccountAddress) → Dec (a₁ ≡ a₂)
-  _≟AccountAddress_ = _≟_
 
   HashValue : Set
   HashValue = Hash

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -3,8 +3,6 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-{-# OPTIONS --allow-unsolved-metas #-}
-
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import LibraBFT.Base.ByteString

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -1,22 +1,20 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 {-# OPTIONS --allow-unsolved-metas #-}
 
-open import LibraBFT.Base.ByteString
-open import LibraBFT.Base.KVMap
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Lemmas
+open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.Encode
+open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types
-
 open import LibraBFT.Impl.Util.Util
-
-open RWST-do
 
 -- This module provides some scaffolding to define the handlers for our fake/simple
 -- "implementation" and connect them to the interface of the SystemModel.
@@ -25,9 +23,8 @@ module LibraBFT.Impl.Handle
   (hash    : BitString → Hash)
   (hash-cr : ∀{x y} → hash x ≡ hash y → Collision hash x y ⊎ x ≡ y)
   where
-
  open import LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor hash hash-cr
- open import LibraBFT.Impl.NetworkMsg
+ open RWST-do
 
  postulate
    fakeEP : EventProcessor
@@ -43,8 +40,6 @@ module LibraBFT.Impl.Handle
  ...| P p = processProposalMsg now p
  ...| V v = processVote now v
  ...| C c = return unit            -- We don't do anything with commit messages, they are just for defining Correctness.
-
- open import LibraBFT.Yasm.Base
 
  -- For now, the SystemModel supports only one kind of action: to send a Message.  Later it might
  -- include things like logging, crashes, assertion failures, etc.  At that point, definitions like

--- a/LibraBFT/Impl/NetworkMsg.agda
+++ b/LibraBFT/Impl/NetworkMsg.agda
@@ -1,21 +1,18 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+open import Optics.All
 open import LibraBFT.Prelude
-open import LibraBFT.Hash
 open import LibraBFT.Lemmas
-open import LibraBFT.Abstract.Types
+open import LibraBFT.Hash
 open import LibraBFT.Base.Types
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.PKCS
-
-open import Optics.All
-
+open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types.EpochIndep
-open import LibraBFT.Impl.Consensus.Types.EpochDep
 open import LibraBFT.Impl.Util.Crypto
 
 -- This module defines the types of messages that the implementation
@@ -24,7 +21,6 @@ open import LibraBFT.Impl.Util.Crypto
 -- NetworkMsgs are signed.
 
 module LibraBFT.Impl.NetworkMsg where
-
   data NetworkMsg : Set where
     P : ProposalMsg → NetworkMsg
     V : VoteMsg     → NetworkMsg

--- a/LibraBFT/Impl/Properties.agda
+++ b/LibraBFT/Impl/Properties.agda
@@ -4,7 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Abstract.Types
 open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Concrete.System.Parameters
 
@@ -17,7 +16,6 @@ open import LibraBFT.Concrete.Obligations
 open import LibraBFT.Concrete.System impl-sps-avp
 
 module LibraBFT.Impl.Properties where
-
   theImplObligations : ImplObligations
   theImplObligations = record { sps-cor = impl-sps-avp
                               ; vo₁     = VO.vo₁

--- a/LibraBFT/Impl/Properties.agda
+++ b/LibraBFT/Impl/Properties.agda
@@ -1,26 +1,17 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-open import LibraBFT.Prelude
-open import LibraBFT.Abstract.Types
-open import LibraBFT.Impl.NetworkMsg
-open import LibraBFT.Concrete.System.Parameters
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
-
 -- This module collects the implementation obligations for our (fake/simple, for now)
 -- "implementation" into the structure required by Concrete.Properties.
-
+open import LibraBFT.Impl.Properties.Aux
+import      LibraBFT.Impl.Properties.VotesOnce   as VO
+import      LibraBFT.Impl.Properties.LockedRound as LR
 open import LibraBFT.Concrete.Obligations
+open import LibraBFT.Concrete.System impl-sps-avp
 
 module LibraBFT.Impl.Properties where
-
-  open import LibraBFT.Impl.Properties.Aux
-  open import LibraBFT.Concrete.System impl-sps-avp
-  import      LibraBFT.Impl.Properties.VotesOnce   as VO
-  import      LibraBFT.Impl.Properties.LockedRound as LR
 
   theImplObligations : ImplObligations
   theImplObligations = record { sps-cor = impl-sps-avp

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -10,7 +10,6 @@ open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
-open import LibraBFT.Abstract.Types UID NodeId
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open EpochConfig
 open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -12,7 +12,7 @@ open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
-open EpochConfig
+open        EpochConfig
 open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- In this module, we will prove a structural property that any new signed message produced by an
@@ -22,10 +22,8 @@ open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN 
 -- included below, which we can finish once we do have a compliant implementation.
 
 module LibraBFT.Impl.Properties.Aux where
-
   -- This proof is complete except for pieces that are directly about the handlers.  Our
   -- fake/simple handler does not yet obey the needed properties, so we can't finish this yet.
-
   impl-sps-avp : StepPeerState-AllValidParts
   -- In our fake/simple implementation, init and handling V and C msgs do not send any messages
   impl-sps-avp _ hpk (step-init ix eff) m∈outs part⊂m ver        rewrite (cong proj₂ eff) = ⊥-elim (¬Any[] m∈outs)

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -1,21 +1,19 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 {-# OPTIONS --allow-unsolved-metas #-}
-open import Optics.All
 open import LibraBFT.Prelude
 open import LibraBFT.Base.PKCS
-open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Concrete.System.Parameters
+open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
-open import LibraBFT.Concrete.System.Parameters
-import      LibraBFT.Yasm.AvailableEpochs as AE
-open import LibraBFT.Yasm.Base
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
-open import LibraBFT.Concrete.Obligations
+open import LibraBFT.Abstract.Types UID NodeId
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open EpochConfig
+open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
 
 -- In this module, we will prove a structural property that any new signed message produced by an
 -- honest handler from a reachable state correctly identifies the sender, and is for a valid epoch
@@ -58,7 +56,7 @@ module LibraBFT.Impl.Properties.Aux where
   ...| yes msg∈ = inj₂ msg∈
   ...| no  msg∉ = inj₁ ((mkValidPartForPK      {! epoch !} -- We will need an invariant that says the epoch
                                                            -- used by a voter is "in range".
-                                               (AE.lookup'' (availEpochs st) {!!})
+                                               (EC-lookup (availEpochs st) {!!})
                                                refl
                                                {! !}       -- The implementation will need to check that the voter is a member of
                                                            -- the epoch of the message it's sending.

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -6,7 +6,6 @@
 {-# OPTIONS --allow-unsolved-metas #-}
 open import LibraBFT.Prelude
 open import LibraBFT.Base.PKCS
-open import LibraBFT.Abstract.Types
 open import LibraBFT.Concrete.Obligations
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Impl.Consensus.Types

--- a/LibraBFT/Impl/Properties/LockedRound.agda
+++ b/LibraBFT/Impl/Properties/LockedRound.agda
@@ -1,15 +1,10 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-open import LibraBFT.Impl.NetworkMsg
-open import LibraBFT.Concrete.System.Parameters
 import      LibraBFT.Concrete.Properties.LockedRound as LR
-
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
 
 open import LibraBFT.Concrete.Obligations
 

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -1,30 +1,9 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-{-# OPTIONS --allow-unsolved-metas #-}
-open import Optics.All
-open import LibraBFT.Lemmas
-open import LibraBFT.Prelude
-open import LibraBFT.Base.PKCS
-
-open import LibraBFT.Impl.Consensus.Types
-open import LibraBFT.Impl.NetworkMsg
-open import LibraBFT.Impl.Util.Crypto
-open import LibraBFT.Impl.Properties.Aux
-
-open import LibraBFT.Concrete.System impl-sps-avp
-open import LibraBFT.Concrete.System.Parameters
-import      LibraBFT.Concrete.Properties.VotesOnce as VO
-
-open import LibraBFT.Yasm.AvailableEpochs
-open import LibraBFT.Yasm.Base
-open import LibraBFT.Yasm.System     ConcSysParms
-open import LibraBFT.Yasm.Properties ConcSysParms
-open        Structural impl-sps-avp
-
-open import LibraBFT.Concrete.Obligations
+import LibraBFT.Concrete.Properties.VotesOnce as VO
 
 -- In this module, we (will) prove the two implementation obligations for the VotesOnce rule.  Note
 -- that it is not yet 100% clear that the obligations are the best definitions to use.  See comments
@@ -33,7 +12,6 @@ open import LibraBFT.Concrete.Obligations
 -- ambitious properties.
 
 module LibraBFT.Impl.Properties.VotesOnce where
-
   postulate  -- TODO-3 : prove
     vo₁ : VO.ImplObligation₁
     vo₂ : VO.ImplObligation₂

--- a/LibraBFT/Impl/Util/Crypto.agda
+++ b/LibraBFT/Impl/Util/Crypto.agda
@@ -1,18 +1,16 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-{-# OPTIONS --allow-unsolved-metas #-}
-open import LibraBFT.Lemmas
-open import LibraBFT.Prelude hiding (_⊔_)
-open import LibraBFT.Base.Encode
-open import LibraBFT.Base.ByteString
-open import LibraBFT.Base.PKCS
-open import LibraBFT.Hash
-open import LibraBFT.Impl.Consensus.Types.EpochIndep
-
 open import Optics.All
+open import LibraBFT.Prelude
+open import LibraBFT.Lemmas
+open import LibraBFT.Hash
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.Encode
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Impl.Consensus.Types.EpochIndep
 
 -- This module postulates a collision-resistant cryptographic hash
 -- function (we call it sha256 for concreteness, but it could be any
@@ -21,7 +19,6 @@ open import Optics.All
 -- about it, and how Votes and Blocks are signed.
 
 module LibraBFT.Impl.Util.Crypto where
-
   -- Note that this is an abstraction of a collision-resistant hash function.  It could be any such
   -- hash function, not necessarily sha256.  We just call it sha256 for "concreteness", to remind
   -- ourselves it's modeling such a function.

--- a/LibraBFT/Impl/Util/RWST.agda
+++ b/LibraBFT/Impl/Util/RWST.agda
@@ -1,11 +1,10 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-open import LibraBFT.Prelude
-
 open import Optics.All
+open import LibraBFT.Prelude
 
 -- This module defines syntax and functionality modeling an RWST monad,
 -- which we use to define an implementation.

--- a/LibraBFT/Impl/Util/Util.agda
+++ b/LibraBFT/Impl/Util/Util.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
@@ -11,9 +11,7 @@ open import LibraBFT.Impl.Consensus.Types
 -- to facilitate reasoning about it.
 
 module LibraBFT.Impl.Util.Util where
-
   open import LibraBFT.Impl.Util.RWST public
-
   ----------------
   -- LBFT Monad --
   ----------------
@@ -28,6 +26,7 @@ module LibraBFT.Impl.Util.Util where
   --
   -- This is very convenient to define functions that
   -- do not alter the ec.
+
   LBFT-ec : EpochConfig → Set → Set
   LBFT-ec ec = RWST Unit Output (EventProcessorWithEC ec)
 

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -1,9 +1,11 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+   Copyright (c) 2020 Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
+
+open import Level using (0ℓ)
 
 -- This module incldes various Agda lemmas that are independent of the project's domain
 
@@ -39,7 +41,7 @@ module LibraBFT.Lemmas where
  ++-abs (x ∷ m) imp ()
 
 
- data All-vec {ℓ} {A : Set ℓ} (P : A → Set ℓ) : ∀ {n} → Vec {ℓ} A n → Set (ℓ+1 ℓ) where
+ data All-vec {ℓ} {A : Set ℓ} (P : A → Set ℓ) : ∀ {n} → Vec {ℓ} A n → Set (Level.suc ℓ) where
    []  : All-vec P []
    _∷_ : ∀ {x n} {xs : Vec A n} (px : P x) (pxs : All-vec P xs) → All-vec P (x ∷ xs)
 

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 -- This is a selection of useful functions and definitions

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -1,13 +1,13 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+   Copyright (c) 2020 Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 -- This is a selection of useful functions and definitions
 -- from the standard library that we tend to use a lot.
 module LibraBFT.Prelude where
+
   open import Level
-    using    (0ℓ; Level; Lift)
     renaming (suc to ℓ+1; zero to ℓ0; _⊔_ to _ℓ⊔_)
     public
 

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -3,7 +3,6 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-{-# OPTIONS --allow-unsolved-metas #-}
 open import LibraBFT.Prelude
 open import LibraBFT.Base.Types
 import      LibraBFT.Yasm.Base as LYB

--- a/LibraBFT/Yasm/Yasm.agda
+++ b/LibraBFT/Yasm/Yasm.agda
@@ -1,0 +1,26 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021 Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+open import LibraBFT.Prelude
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+import      LibraBFT.Yasm.Base as LYB
+
+-- This module provides a single import for all Yasm modules
+
+module LibraBFT.Yasm.Yasm
+   (NodeId      : Set)
+   (ℓ-EC        : Level)
+   (EpochConfig : Set ℓ-EC)
+   (epochId     : EpochConfig → EpochId)
+   (authorsN    : EpochConfig → ℕ)
+   (getPubKey   : (ec : EpochConfig) → LYB.Member NodeId ℓ-EC EpochConfig epochId authorsN ec → PK)
+   (parms       : LYB.SystemParameters NodeId ℓ-EC EpochConfig epochId authorsN)
+  where
+ open import LibraBFT.Yasm.AvailableEpochs NodeId ℓ-EC EpochConfig epochId authorsN
+             using (AvailableEpochs) renaming (lookup' to EC-lookup; lookup'' to EC-lookup')                          public
+ open import LibraBFT.Yasm.Base       NodeId ℓ-EC EpochConfig epochId authorsN                 public
+ open import LibraBFT.Yasm.System     NodeId ℓ-EC EpochConfig epochId authorsN           parms public
+ open import LibraBFT.Yasm.Properties NodeId ℓ-EC EpochConfig epochId authorsN getPubKey parms public


### PR DESCRIPTION
The `Abstract.*` modules previously assumed types for `NodeId` and `UID`, which is an abstraction violation.  Also, imports were messy and redundant in place.

This pull request parameterizes `Abstract.*` by `NodeId` and `UID` types, factors `EpochConfig` and `AbsVoteData` into a separate module, and introduces a module `Abstract.Abstract` that enables other modules to import the entire `Abstract` namespace in one import statement.  It also rearranges various imports to conform to the new style guide suggestion, and removes a few pragmas that are no longer needed.

This branch builds on top of `mark-abstract-yasm` (see #14).  Unfortunately, that branch has diverged slightly from this one because one module was not checked in.  We should merge #14 first and then resolve conflicts before merging this one.