### PR TITLE
Proved bft-lemma using allDistinct

### DIFF
--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -39,7 +39,6 @@ module LibraBFT.Abstract.BFT
 
  where
 
-
  -- The set of members of this epoch.
  Member : Set
  Member = Fin authorsN
@@ -49,6 +48,8 @@ module LibraBFT.Abstract.BFT
 
  CombinedPower : List Member → ℕ
  CombinedPower xs = sum (List-map votPower xs)
+
+ open DecLemmas {A = Member} _≟Fin_
 
  -- The bft-assumption states that the combined voting power of
  -- Byzantine nodes must not exceed the security threshold
@@ -73,7 +74,7 @@ module LibraBFT.Abstract.BFT
    -- TODO-2 : Many of these lemmas can be generalized for any list or any
    -- list of Fin. Perhaps establish a Lemmas.FinProps module.
 
-   intersect : ∀ {n} → List (Fin n) → List (Fin n) → List (Fin n)
+   intersect : List Member → List Member → List Member
    intersect xs [] = []
    intersect xs (y ∷ ys)
      with y ∈? xs
@@ -81,7 +82,7 @@ module LibraBFT.Abstract.BFT
    ...| no  _ = intersect xs ys
 
 
-   union :  ∀ {n} → List (Fin n) → List (Fin n) → List (Fin n)
+   union : List Member → List Member → List Member
    union xs [] = xs
    union xs (y ∷ ys)
      with y ∈? xs
@@ -161,7 +162,7 @@ module LibraBFT.Abstract.BFT
      = votingPower≤N (union xs ys) (unionDistinct xs ys dxs dys)
 
 
-   sumIntersect≤ : ∀ {n} (xs ys : List (Fin n)) (f : Fin n → ℕ)
+   sumIntersect≤ : ∀ (xs ys : List Member) (f : Member → ℕ)
                  → sum (List-map f (intersect xs ys)) ≤ sum (List-map f (xs ++ ys))
    sumIntersect≤ _ [] _ = z≤n
    sumIntersect≤ xs (y ∷ ys) f
@@ -309,6 +310,5 @@ module LibraBFT.Abstract.BFT
            honInf      = find-honest {intersect xs ys} intDist f+1≤|q₁∩q₂|
            h∈∩         = ∈-intersect xs ys ((proj₁ ∘ proj₂) honInf)
        in proj₁ honInf ,  proj₁ h∈∩ , proj₂ h∈∩ , (proj₂ ∘ proj₂) honInf
-
 
 

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
@@ -26,7 +26,7 @@ open import LibraBFT.Base.PKCS
 
   -- The bft-lemma is the last lemma in this file and proves that in
   -- the intersection of any quorums, whose combined voting power is
-  -- greater or equal than `N - bizF`, there is an honest Member.
+  -- greater than or equal to `N - bizF`, there is an honest Member.
 
 module LibraBFT.Abstract.BFT
   (authorsN      : ℕ)
@@ -56,10 +56,8 @@ module LibraBFT.Abstract.BFT
  -- The bft-assumption states that the combined voting power of
  -- Byzantine nodes must not exceed the security threshold
  -- `bizF`. Therefore, for any list of distinct participants, the
- -- combined power of the dishonest nodes is less or equal than
+ -- combined power of the dishonest nodes is less than or equal to
  -- `bizF`.
-
-
  module _  (bft-assumption : ∀ (xs : List Member)
                            → allDistinct xs
                            → CombinedPower (List-filter Meta-dishonest? xs) ≤ bizF)
@@ -107,7 +105,6 @@ module LibraBFT.Abstract.BFT
                        | sym (sum-++-commute (List-map votPower xs) (List-map votPower (y ∷ ys)))
                        | sym (map-++-commute votPower xs (y ∷ ys)) = refl
 
-
    quorumInt>biz : ∀ (xs ys : List Member)
                  → TotalVotPower ∸ bizF ≤ CombinedPower xs
                  → TotalVotPower ∸ bizF ≤ CombinedPower ys
@@ -137,7 +134,6 @@ module LibraBFT.Abstract.BFT
                                | sym (*-distribʳ-∸ x 3 2)
                                | sym (+-suc x 0) = refl
 
-
    partition-hon : ∀ {xs dis hon : List Member} {x : Member}
             → partition Meta-dishonest? xs ≡ (dis , x ∷ hon)
             → x ∈ xs × Meta-Honest-PK (getPubKey x)
@@ -149,7 +145,6 @@ module LibraBFT.Abstract.BFT
    ...| _ , x₂ ∷ _ | [ eq₂ ] rewrite just-injective (cong (head ∘ proj₂) eq₁)
      = ×-map₁ there (partition-hon eq₂)
 
-
    partition-dis : ∀ {xs dis : List Member}
             → partition Meta-dishonest? xs ≡ (dis , [])
             → List-filter Meta-dishonest? xs ≡ xs
@@ -160,7 +155,6 @@ module LibraBFT.Abstract.BFT
    ...| yes _  | _
       with partition Meta-dishonest? xs | inspect (partition Meta-dishonest?) xs
    ...| _ , [] | [ eq₁ ] = cong (x ∷_) (partition-dis {xs} eq₁)
-
 
    -- TODO-1 : An alternative to prove this lemma would be:
    -- - First prove that
@@ -181,7 +175,6 @@ module LibraBFT.Abstract.BFT
                 xsVot≤f = subst (_≤ bizF) (cong CombinedPower (partition-dis {xs} eq)) bft
             in ⊥-elim (<⇒≱ biz< xsVot≤f)
    ...| dis , x ∷ hon | [ eq ] = x , partition-hon eq
-
 
    bft-lemma : {xs ys : List Member}
              → allDistinct xs → allDistinct ys

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -89,11 +89,6 @@ module LibraBFT.Abstract.BFT
    ...| no  _ = y ∷ union xs ys
 
 
-   int-[]≡[] : (xs : List Member) → intersect [] xs ≡ []
-   int-[]≡[] [] = refl
-   int-[]≡[] (x ∷ xs) = int-[]≡[] xs
-
-
    ∈-intersect : ∀ (xs ys : List Member) {α}
                → α ∈ intersect xs ys
                → α ∈ xs × α ∈ ys
@@ -102,11 +97,6 @@ module LibraBFT.Abstract.BFT
    ...| no  y∉xs   | α∈        = ×-map₂ there (∈-intersect xs ys α∈)
    ...| yes y∈xs   | here refl = y∈xs , here refl
    ...| yes y∈xs   | there α∈  = ×-map₂ there (∈-intersect xs ys α∈)
-
-
-   morgan₁ : ∀ {A B : Set} → (¬ A) ⊎ (¬ B) → ¬ (A × B)
-   morgan₁ (inj₁ ¬a) = λ a×b → ¬a (proj₁ a×b)
-   morgan₁ (inj₂ ¬b) = λ a×b → ¬b (proj₂ a×b)
 
 
    x∉⇒x∉intersect : ∀ {x} {xs ys : List Member}
@@ -318,9 +308,7 @@ module LibraBFT.Abstract.BFT
            intDist     = intersectDistinct xs ys all≢xs all≢ys
            honInf      = find-honest {intersect xs ys} intDist f+1≤|q₁∩q₂|
            h∈∩         = ∈-intersect xs ys ((proj₁ ∘ proj₂) honInf)
-           α∈xs        = proj₁ h∈∩
-           α∈ys        = proj₂ h∈∩
-       in proj₁ honInf , α∈xs , α∈ys , (proj₂ ∘ proj₂) honInf
+       in proj₁ honInf ,  proj₁ h∈∩ , proj₂ h∈∩ , (proj₂ ∘ proj₂) honInf
 
 
 

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -67,9 +67,6 @@ module LibraBFT.Abstract.BFT
                            → CombinedPower (List-filter Meta-dishonest? xs) ≤ bizF)
    where
 
-   _∈?_ : ∀ {n} (x : Fin n) → (xs : List (Fin n)) → Dec (Any (x ≡_) xs)
-   x ∈? xs = Any-any (x ≟Fin_) xs
-
    participants : List Member
    participants = List-tabulate id
 
@@ -105,18 +102,6 @@ module LibraBFT.Abstract.BFT
    union : List Member → List Member → List Member
    union xs [] = xs
    union xs (y ∷ ys) = unionElem (union xs ys) y
-
-
-   y∉xs⇒Allxs≢y : ∀ {n} {xs : List (Fin n)} {x y}
-           → y ∉ (x ∷ xs)
-           → x ≢ y × y ∉ xs
-   y∉xs⇒Allxs≢y {_} {xs} {x} {y} y∉
-     with y ∈? xs
-   ...| yes y∈xs = ⊥-elim (y∉ (there y∈xs))
-   ...| no  y∉xs
-     with x ≟Fin y
-   ...| yes x≡y = ⊥-elim (y∉ (here (sym x≡y)))
-   ...| no  x≢y = x≢y , y∉xs
 
 
    intersectElem-∈-≡ : ∀ {xs : List Member} {x}
@@ -239,26 +224,6 @@ module LibraBFT.Abstract.BFT
            ...| tri≈ _   _ _   = (x< ∷ sxs)
            ...| tri> _   _ x>y = on-∷ x>y ∷ (x< ∷ sxs)
 
-
-   _⊆List_ : ∀ {A : Set} → List A → List A → Set
-   xs ⊆List ys = All (_∈ ys) xs
-
-
-   ∈List-elim : ∀ {A : Set} {x y : A} {ys : List A}
-              → x ∈ (y ∷ ys) → x ≢ y
-              → x ∈ ys
-   ∈List-elim (here x≡y) x≢y = ⊥-elim (x≢y x≡y)
-   ∈List-elim (there x∈) x≢y = x∈
-
-
-   ⊆List-elim : ∀ {n} {y} {xs ys : List (Fin n)}
-              → xs ⊆List (y ∷ ys) → y ∉ xs
-              → xs ⊆List ys
-   ⊆List-elim [] y∉ = []
-   ⊆List-elim (here refl ∷ xs∈) y∉ = ⊥-elim (proj₁ (y∉xs⇒Allxs≢y y∉) refl)
-   ⊆List-elim (there x∈  ∷ xs∈) y∉
-     with y∉xs⇒Allxs≢y y∉
-   ...| x≢y , y∉xs = ∈List-elim (there x∈) x≢y ∷ ⊆List-elim xs∈ y∉xs
 
 
    sort→∈-disj : ∀ {n} {x y} {xs ys : List (Fin n)}

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -71,83 +71,22 @@ module LibraBFT.Abstract.BFT
    participants = List-tabulate id
 
    -- TODO-2 : Many of these lemmas can be generalized for any list or any
-   -- IsSorted list of Fin. Perhaps establish a Lemmas.FinProps module.
+   -- list of Fin. Perhaps establish a Lemmas.FinProps module.
 
-
-   -- The `intersect` and `union` functions assume that the lists are
-   -- sorted and produce sorted lists
-   intersectElem : List Member → Member → List Member
-   intersectElem [] y = []
-   intersectElem (x ∷ xs) y
-      with Fin-<-cmp x y
-   ...| tri< _ _ _ = intersectElem xs y
-   ...| tri≈ _ _ _ = y ∷ []
-   ...| tri> _ _ _ = []
-
-
-   intersect : List Member → List Member → List Member
+   intersect : ∀ {n} → List (Fin n) → List (Fin n) → List (Fin n)
    intersect xs [] = []
-   intersect xs (y ∷ ys) = intersectElem xs y ++ intersect xs ys
+   intersect xs (y ∷ ys)
+     with y ∈? xs
+   ...| yes _ = y ∷ intersect xs ys
+   ...| no  _ = intersect xs ys
 
 
-   unionElem : List Member → Member → List Member
-   unionElem [] y = y ∷ []
-   unionElem (x ∷ xs) y
-     with Fin-<-cmp x y
-   ...| tri< _ _ _ = x ∷ unionElem xs y
-   ...| tri≈ _ _ _ = x ∷ xs
-   ...| tri> _ _ _ = y ∷ x ∷ xs
-
-
-   union : List Member → List Member → List Member
+   union :  ∀ {n} → List (Fin n) → List (Fin n) → List (Fin n)
    union xs [] = xs
-   union xs (y ∷ ys) = unionElem (union xs ys) y
-
-
-   intersectElem-∈-≡ : ∀ {xs : List Member} {x}
-                     → x ∈ xs → IsSorted _<Fin_ xs
-                     → intersectElem xs x ≡ x ∷ []
-   intersectElem-∈-≡ {x₁ ∷ xs} {.x₁} (here refl) sxs
-     with Fin-<-cmp x₁ x₁
-   ...| tri< _ x₁≢x₁ _ = ⊥-elim (x₁≢x₁ refl)
-   ...| tri≈ _ _     _ = refl
-   ...| tri> _ x₁≢x₁ _ = ⊥-elim (x₁≢x₁ refl)
-   intersectElem-∈-≡ {x₁ ∷ xs} {x} (there x∈xs) (x₂ ∷ sxs)
-     with Fin-<-cmp x₁ x
-   ...| tri< _ _ _    = intersectElem-∈-≡ x∈xs sxs
-   ...| tri≈ _ _ _    = refl
-   ...| tri> _ _ x₁>x
-     = ⊥-elim (<⇒≱ x₁>x (≤-head ≤-refl (≤-trans ∘ <⇒≤) (there x∈xs) (x₂ ∷ sxs)))
-
-
-   intersectElem-∉-[] : ∀ {xs : List Member} {x}
-                      → x ∉ xs
-                      → intersectElem xs x ≡ []
-   intersectElem-∉-[] {[]}      {x} x∉xs = refl
-   intersectElem-∉-[] {x₁ ∷ xs} {x} x∉xs
-      with Fin-<-cmp x₁ x
-   ...| tri< _ _    _ = intersectElem-∉-[] (proj₂ (y∉xs⇒Allxs≢y x∉xs))
-   ...| tri≈ _ x₁≡x _ = ⊥-elim (proj₁ (y∉xs⇒Allxs≢y x∉xs) x₁≡x)
-   ...| tri> _ _    _ = refl
-
-
-   intElem-OnHead : ∀ {xs : List Member} {y x : Member}
-                  → x <Fin y
-                  → OnHead _<Fin_ x (intersectElem xs y)
-   intElem-OnHead {[]} _ = []
-   intElem-OnHead {x₁ ∷ xs} {y} x<y
-      with Fin-<-cmp x₁ y
-   ...| tri< _ _ _ = intElem-OnHead {xs} x<y
-   ...| tri≈ _ _ _ = on-∷ x<y
-   ...| tri> _ _ _ = []
-
-
-   int-OnHead : ∀ {xs ys : List Member} {y : Member}
-              → IsSorted _<Fin_ (y ∷ ys)
-              → OnHead _<Fin_ y (intersect xs ys)
-   int-OnHead      ([] ∷ _) = []
-   int-OnHead {xs} (on-∷ p ∷ sxs) = ++-OnHead (intElem-OnHead {xs} p)
-                                              (transOnHead <-trans (int-OnHead sxs) p)
+   union xs (y ∷ ys)
+     with y ∈? xs
+   ...| yes _ = union xs ys
+   ...| no  _ = y ∷ union xs ys
 
 
    int-[]≡[] : (xs : List Member) → intersect [] xs ≡ []
@@ -155,225 +94,113 @@ module LibraBFT.Abstract.BFT
    int-[]≡[] (x ∷ xs) = int-[]≡[] xs
 
 
-   intersectDiff : ∀ {xs ys : List Member}
-                 → (sxs : IsSorted _<Fin_ xs) → (sys : IsSorted _<Fin_ ys)
-                 → IsSorted _<Fin_ (intersect xs ys)
-   intersectDiff {_}  {.[]}   _   [] = []
-   intersectDiff {xs} {y ∷ _} sxs (y< ∷ sys)
-     with y ∈? xs
-   ...| yes y∈xs rewrite intersectElem-∈-≡ y∈xs sxs
-        = int-OnHead (y< ∷ sys) ∷ intersectDiff sxs sys
-   ...| no  y∉xs rewrite intersectElem-∉-[] y∉xs = intersectDiff sxs sys
-
-
-   ∈-intersectElem : ∀ {α y} (xs : List Member)
-                   → α ∈ intersectElem xs y
-                   → α ∈ xs × α ∈ y ∷ []
-   ∈-intersectElem {_} {y} (x ∷ xs) ∈int
-     with Fin-<-cmp x y
-   ...| tri< _ _ _
-        = Any-++ʳ (x ∷ []) (proj₁ (∈-intersectElem xs ∈int)) , proj₂ (∈-intersectElem xs ∈int)
-   ...| tri≈ _ refl _ = Any-++ˡ ∈int , ∈int
-   ...| tri> _ _ _    = contradiction ∈int ¬Any[]
-
-
-   ∈-intersect : ∀ {xs ys : List Member} {α}
-               → (sxs : IsSorted _<Fin_ xs) → (sys : IsSorted _<Fin_ ys)
+   ∈-intersect : ∀ (xs ys : List Member) {α}
                → α ∈ intersect xs ys
                → α ∈ xs × α ∈ ys
-   ∈-intersect {[]} {_ ∷ ys} [] (_ ∷ _) α∈∩ rewrite int-[]≡[] ys
-     = contradiction α∈∩ ¬Any[]
-   ∈-intersect {x ∷ xs} {y ∷ _} sxs (_ ∷ sys) α∈∩
-     with Fin-<-cmp x y  | α∈∩
-   ...| tri≈ _ refl _    | here refl
-        = here refl , here refl
-   ...| tri≈ _ refl _    | there α∈
-        = proj₁ (∈-intersect sxs sys α∈) , Any-++ʳ (x ∷ []) (proj₂ (∈-intersect sxs sys α∈))
-   ...| tri> _ _ _       | α∈
-        = proj₁ (∈-intersect sxs sys α∈) , there (proj₂ (∈-intersect sxs sys α∈))
-   ...| tri< _ _ _       | α∈
-     with Any-++⁻ (intersectElem xs y) α∈
-   ...| inj₁ x₁ = Any-++ʳ (x ∷ []) (proj₁ (∈-intersectElem xs x₁))
-                , Any-++ˡ (proj₂ (∈-intersectElem xs x₁))
-   ...| inj₂ y₂ = proj₁ (∈-intersect sxs sys y₂)
-                , Any-++ʳ (y ∷ []) (proj₂ (∈-intersect sxs sys y₂))
+   ∈-intersect xs (y ∷ ys) α∈int
+     with y ∈? xs  | α∈int
+   ...| no  y∉xs   | α∈        = ×-map₂ there (∈-intersect xs ys α∈)
+   ...| yes y∈xs   | here refl = y∈xs , here refl
+   ...| yes y∈xs   | there α∈  = ×-map₂ there (∈-intersect xs ys α∈)
 
 
-   unionSorted :  ∀ {xs ys : List Member}
-                → IsSorted _<Fin_ xs → IsSorted _<Fin_ ys
-                → IsSorted _<Fin_ (union xs ys)
-   unionSorted sxs [] = sxs
-   unionSorted sxs (y₁ ∷ sys) = unionElem-sorted (unionSorted sxs sys)
-     where union-OnHead : ∀ {xs : List Member} {x y}
-                        → IsSorted _<Fin_ (x ∷ xs)
-                        → x <Fin y
-                        → OnHead _<Fin_ x (unionElem xs y)
-           union-OnHead {[]} {_} {_} _ x<y = on-∷ x<y
-           union-OnHead {x₁ ∷ _} {x} {y} (on-∷ x<x₁ ∷ _) x<y
-              with Fin-<-cmp x₁ y
-           ...| tri< _ _ _ = on-∷ x<x₁
-           ...| tri≈ _ _ _ = on-∷ x<x₁
-           ...| tri> _ _ _ = on-∷ x<y
-
-           unionElem-sorted : ∀ {xs y} → IsSorted _<Fin_ xs
-                            → IsSorted _<Fin_ (unionElem xs y)
-           unionElem-sorted {[]} {y} [] = [] ∷ []
-           unionElem-sorted {x ∷ xs} {y} (x< ∷ sxs)
-             with Fin-<-cmp x y
-           ...| tri< x<y _ _   = union-OnHead (x< ∷ sxs) x<y ∷ (unionElem-sorted sxs)
-           ...| tri≈ _   _ _   = (x< ∷ sxs)
-           ...| tri> _   _ x>y = on-∷ x>y ∷ (x< ∷ sxs)
+   morgan₁ : ∀ {A B : Set} → (¬ A) ⊎ (¬ B) → ¬ (A × B)
+   morgan₁ (inj₁ ¬a) = λ a×b → ¬a (proj₁ a×b)
+   morgan₁ (inj₂ ¬b) = λ a×b → ¬b (proj₂ a×b)
 
 
+   x∉⇒x∉intersect : ∀ {x} {xs ys : List Member}
+                    → x ∉ xs ⊎ x ∉ ys
+                    → x ∉ intersect xs ys
+   x∉⇒x∉intersect {x} {xs} {ys} x∉ x∈int
+     = contraposition (∈-intersect xs ys) (morgan₁ x∉) x∈int
 
-   sort→∈-disj : ∀ {n} {x y} {xs ys : List (Fin n)}
-               → IsSorted _<Fin_ (x ∷ xs) → IsSorted _<Fin_ (y ∷ ys)
-               → x ∈ ys
-               → y ∉ xs
-   sort→∈-disj (x< ∷ sxs) (on-∷ y<y₁ ∷ sys) x∈ys y∈xs
-     = let y₁≤x = ≤-head ≤-refl (≤-trans ∘ <⇒≤) x∈ys sys
-           y<x  = <-transˡ y<y₁ y₁≤x
-       in h∉t <⇒≢Fin <-trans (transOnHead <-trans x< y<x ∷ sxs) y∈xs
+
+   intersectDistinct : ∀ (xs ys : List Member)
+                     → allDistinct xs → allDistinct ys
+                     → allDistinct (intersect xs ys)
+   intersectDistinct xs (y ∷ ys) dxs dys
+     with y ∈? xs
+   ...| yes y∈xs = let distTail  = allDistinctTail dys
+                       intDTail  = intersectDistinct xs ys dxs distTail
+                       y∉intTail = x∉⇒x∉intersect (inj₂ (allDistinct⇒∉ dys))
+                   in x∉→AllDistinct intDTail y∉intTail
+   ...| no  y∉xs = intersectDistinct xs ys dxs (allDistinctTail dys)
+
+
+   x∉⇒x∉union : ∀ {x} {xs ys : List Member}
+              → x ∉ xs × x ∉ ys
+              → x ∉ union xs ys
+   x∉⇒x∉union {_} {_} {[]} (x∉xs , _) x∈∪ = ⊥-elim (x∉xs x∈∪)
+   x∉⇒x∉union {x} {xs} {y ∷ ys} (x∉xs , x∉ys) x∈union
+     with y ∈? xs  | x∈union
+   ...| yes y∈xs   | x∈∪
+        = ⊥-elim (x∉⇒x∉union (x∉xs , (proj₂ (y∉xs⇒Allxs≢y x∉ys))) x∈∪)
+   ...| no y∉xs    | here refl
+        = ⊥-elim (proj₁ (y∉xs⇒Allxs≢y x∉ys) refl)
+   ...| no y∉xs    | there x∈∪
+        = ⊥-elim (x∉⇒x∉union (x∉xs , (proj₂ (y∉xs⇒Allxs≢y x∉ys))) x∈∪)
+
+   unionDistinct : ∀ (xs ys : List Member)
+               → allDistinct xs → allDistinct ys
+               → allDistinct (union xs ys)
+   unionDistinct xs [] dxs dys = dxs
+   unionDistinct xs (y ∷ ys) dxs dys
+      with y ∈? xs
+   ...| yes y∈xs = unionDistinct xs ys dxs (allDistinctTail dys)
+   ...| no  y∉xs = let distTail  = allDistinctTail dys
+                       uniDTail  = unionDistinct xs ys dxs distTail
+                       y∉intTail = x∉⇒x∉union (y∉xs , allDistinct⇒∉ dys)
+                   in x∉→AllDistinct uniDTail y∉intTail
 
 
    members⊆ : ∀ {xs : List Member} → xs ⊆List participants
    members⊆ {_} {x} _ = Any-tabulate⁺ {f = id} x refl
 
 
-   votingPower≤N : ∀ {xs : List Member} → IsSorted _<Fin_ xs
+   votingPower≤N : ∀ (xs : List Member) → allDistinct xs
                  → CombinedPower xs ≤ totalVotPower
-   votingPower≤N {xs} sxs rewrite totalVotPower≡
-     = sum-⊆-≤ votPower sxs members⊆
+   votingPower≤N xs dxs rewrite totalVotPower≡
+     = sum-⊆-≤ xs votPower dxs members⊆
 
 
-   union-votPower : ∀ {xs ys : List Member}
-                      → IsSorted _<Fin_ xs → IsSorted _<Fin_ ys
-                      → CombinedPower (union xs ys) ≤ totalVotPower
-   union-votPower sxs sys = votingPower≤N (unionSorted sxs sys)
+   union-votPower : ∀ (xs ys : List Member)
+                  → allDistinct xs → allDistinct ys
+                  → CombinedPower (union xs ys) ≤ totalVotPower
+   union-votPower xs ys dxs dys
+     = votingPower≤N (union xs ys) (unionDistinct xs ys dxs dys)
 
 
-   union-∈ : ∀ {xs} {x} (ys : List Member)
-           → x ∈ xs → x ∈ union xs ys
-   union-∈ [] x∈xs = x∈xs
-   union-∈ (y ∷ ys) x∈xs = unionElem-∈ (union-∈ ys x∈xs)
-     where unionElem-∈ : ∀ {xs : List Member} {x y} → x ∈ xs
-                         → x ∈ unionElem xs y
-           unionElem-∈ {x₁ ∷ _} {_} {y} (here px)
-             with Fin-<-cmp x₁ y
-           ...| tri< _ _ _ = here px
-           ...| tri≈ _ _ _ = here px
-           ...| tri> _ _ _ = there (here px)
-           unionElem-∈ {x₁ ∷ _} {_} {y} (there x∈xs)
-             with Fin-<-cmp x₁ y
-           ...| tri< _ _ _ = there (unionElem-∈ x∈xs)
-           ...| tri≈ _ _ _ = there x∈xs
-           ...| tri> _ _ _ = there (there x∈xs)
-
-
-   unionElem-∈-disj : ∀ {x y} (xs : List Member)
-                    → y ∈ unionElem xs x
-                    → y ≡ x ⊎ y ∈ xs
-   unionElem-∈-disj [] (here px) = inj₁ px
-   unionElem-∈-disj {x} (x₁ ∷ xs) y∈
-     with Fin-<-cmp x₁ x | y∈
-   ...| tri≈ ¬a b ¬c     | y∈∪         = inj₂ y∈∪
-   ...| tri> ¬a ¬b c     | (here px)   = inj₁ px
-   ...| tri> ¬a ¬b c     | (there y∈∪) = inj₂ y∈∪
-   ...| tri< a ¬b ¬c     | (here px)   = inj₂ (here px)
-   ...| tri< a ¬b ¬c     | (there y∈∪)
-     with unionElem-∈-disj xs y∈∪
-   ...| inj₁ y≡x  = inj₁ y≡x
-   ...| inj₂ y∈xs = inj₂ (there y∈xs)
-
-
-   union-∈-disj : ∀ {y} (xs ys : List Member)
-                → y ∈ union xs ys
-                → y ∈ xs ⊎ y ∈ ys
-   union-∈-disj _ [] y∈ = inj₁ y∈
-   union-∈-disj xs (y ∷ ys) y∈
-     with unionElem-∈-disj (union xs ys) y∈
-   ...| inj₁ y≡x = inj₂ (here y≡x)
-   ...| inj₂ y∈un
-     with union-∈-disj xs ys y∈un
-   ...| inj₁ y∈xs = inj₁ y∈xs
-   ...| inj₂ y∈ys = inj₂ (there y∈ys)
-
-
-   union-∉ : ∀ {ys xs : List Member} {y}
-           → y ∉ ys → y ∉ xs
-           → y ∉ union xs ys
-   union-∉ {ys} {xs} y∉ys y∉xs y∈union
-     with union-∈-disj xs ys y∈union
-   ...| inj₁ y∈xs = ⊥-elim (y∉xs y∈xs)
-   ...| inj₂ y∈ys = ⊥-elim (y∉ys y∈ys)
-
-
-   unionElem-∈-≡ : ∀ {xs : List Member} {x}
-                 → x ∈ xs → IsSorted _<Fin_ xs
-                 → unionElem xs x ≡ xs
-   unionElem-∈-≡ {x₁ ∷ x_} {.x₁} (here refl) _
-      with Fin-<-cmp x₁ x₁
-   ...| tri< _ x₁≢x₁ _ = ⊥-elim (x₁≢x₁ refl)
-   ...| tri≈ _ _     _ = refl
-   ...| tri> _ x₁≢x₁ _ = ⊥-elim (x₁≢x₁ refl)
-   unionElem-∈-≡ {x₁ ∷ _} {x} (there x∈xs) (x₂ ∷ sxs)
-      with Fin-<-cmp x₁ x
-   ...| tri< _ _ _    = cong (x₁ ∷_) (unionElem-∈-≡ x∈xs sxs)
-   ...| tri≈ _ _ _    = refl
-   ...| tri> _ _ x₁>x = let x≥x₁ = ≤-head ≤-refl (≤-trans ∘ <⇒≤) (there x∈xs) (x₂ ∷ sxs)
-                        in ⊥-elim (<⇒≱ x₁>x x≥x₁)
-
-
-   unionElem-∉-sum : ∀ {xs : List Member} {x} (f : Member → ℕ) → x ∉ xs
-                   → sum (List-map f (unionElem xs x)) ≡ f x + sum (List-map f xs)
-   unionElem-∉-sum {[]}      {_} _ _ = refl
-   unionElem-∉-sum {x₁ ∷ xs} {x} f x∉xs
-      with Fin-<-cmp x₁ x
-   ...| tri< _ _ _ rewrite unionElem-∉-sum f ((proj₂ (y∉xs⇒Allxs≢y x∉xs)))
-                         | sym (+-assoc (f x) (f x₁) (sum (List-map f xs)))
-                         | +-comm (f x) (f x₁)
-                         | +-assoc (f x₁) (f x) (sum (List-map f xs)) = refl
-   ...| tri≈ _ x₁≢x _ = ⊥-elim (proj₁ (y∉xs⇒Allxs≢y x∉xs) x₁≢x)
-   ...| tri> _ _    _ = refl
-
-
-   sumIntersect≤ : ∀ {xs ys : List Member} (f : Member → ℕ)
-                 → IsSorted _<Fin_ xs → IsSorted _<Fin_ ys
+   sumIntersect≤ : ∀ {n} (xs ys : List (Fin n)) (f : Fin n → ℕ)
                  → sum (List-map f (intersect xs ys)) ≤ sum (List-map f (xs ++ ys))
-   sumIntersect≤ {_} {[]} _ _ _ = z≤n
-   sumIntersect≤ {xs} {y ∷ ys} f sxs (_ ∷ sys)
+   sumIntersect≤ _ [] _ = z≤n
+   sumIntersect≤ xs (y ∷ ys) f
      with y ∈? xs
-   ...| yes y∈xs rewrite intersectElem-∈-≡ y∈xs sxs
-                       | map-++-commute f xs (y ∷ ys)
+   ...| yes y∈xs rewrite map-++-commute f xs (y ∷ ys)
                        | sum-++-commute (List-map f xs) (List-map f (y ∷ ys))
                        | sym (+-assoc (sum (List-map f xs)) (f y) (sum (List-map f ys)))
                        | +-comm (sum (List-map f xs)) (f y)
                        | +-assoc (f y) (sum (List-map f xs)) (sum (List-map f ys))
                        | sym (sum-++-commute (List-map f xs) (List-map f ys))
                        | sym (map-++-commute f xs ys)
-                         = +-monoʳ-≤ (f y) (sumIntersect≤ f sxs sys)
-   ...| no  y∉xs rewrite intersectElem-∉-[] y∉xs
-                       | map-++-commute f xs (y ∷ ys)
+                         = +-monoʳ-≤ (f y) (sumIntersect≤ xs ys f)
+   ...| no  y∉xs rewrite map-++-commute f xs (y ∷ ys)
                        | sum-++-commute (List-map f xs) (List-map f (y ∷ ys))
                        | +-comm (f y) (sum (List-map f ys))
                        | sym (+-assoc (sum (List-map f xs)) (sum (List-map f ys)) (f y))
                        | sym (sum-++-commute (List-map f xs) (List-map f ys))
                        | sym (map-++-commute f xs ys)
-                         = ≤-stepsʳ (f y) (sumIntersect≤ f sxs sys)
+                         = ≤-stepsʳ (f y) (sumIntersect≤ xs ys f)
 
 
-   union-votPower≡ :  ∀ {xs ys : List Member}
-                      → (sxs : IsSorted _<Fin_ xs) → (sys : IsSorted _<Fin_ ys)
+   union-votPower≡ :  ∀ (xs ys : List Member)
+                      → allDistinct xs → allDistinct ys
                       → CombinedPower (union xs ys) ≡ CombinedPower (xs ++ ys)
                                                     ∸ CombinedPower (intersect xs ys)
-   union-votPower≡ {xs} {[]} _ _
-     rewrite map-++-commute votPower xs []
-           | sum-++-commute (List-map votPower xs) []
-           | +-identityʳ (CombinedPower xs) = refl
-   union-votPower≡ {xs} {y ∷ ys} sxs (y₁ ∷ sys)
-      with y ∈? xs
-   ...| yes y∈xs rewrite unionElem-∈-≡ (union-∈ ys y∈xs) (unionSorted sxs sys)
-                       | union-votPower≡ sxs sys
+   union-votPower≡ xs [] dxs dys rewrite ++-identityʳ xs = refl
+   union-votPower≡ xs (y ∷ ys) dxs dys
+     with y ∈? xs
+   ...| yes y∈xs rewrite union-votPower≡ xs ys dxs (allDistinctTail dys)
                        | sym (m+n∸n≡m (CombinedPower (xs ++ ys)) (votPower y))
                        | ∸-+-assoc (CombinedPower (xs ++ ys) + votPower y)
                                    (votPower y)
@@ -384,29 +211,17 @@ module LibraBFT.Abstract.BFT
                                  (CombinedPower ys)
                                  (votPower y)
                        | +-comm (CombinedPower ys) (votPower y)
-                       | map-++-commute votPower xs (y ∷ ys)
-                       | sum-++-commute (List-map votPower xs) (List-map votPower (y ∷ ys))
-                       | map-++-commute votPower (intersectElem xs y) (intersect xs ys)
-                       | sum-++-commute (List-map votPower (intersectElem xs y))
-                                        (List-map votPower (intersect xs ys))
-                       | intersectElem-∈-≡ y∈xs sxs
-                       | +-identityʳ (votPower y) = refl
-
-   ...| no  y∉xs rewrite map-++-commute votPower xs (y ∷ ys)
-                       | sum-++-commute (List-map votPower xs) (List-map votPower (y ∷ ys))
-                       | sym (+-assoc (CombinedPower xs)
-                                      (votPower y)
-                                      (CombinedPower ys))
-                       | +-comm (CombinedPower xs) (votPower y)
-                       | unionElem-∉-sum votPower (union-∉ (h∉t <⇒≢Fin <-trans (y₁ ∷ sys)) y∉xs)
-                       | union-votPower≡ sxs sys
-                       | intersectElem-∉-[] y∉xs
-                       | +-assoc (votPower y)
-                                 (CombinedPower xs)
-                                 (CombinedPower ys)
-                       | sym (sum-++-commute (List-map votPower xs) (List-map votPower ys))
-                       | sym (map-++-commute votPower xs ys)
-                       | +-∸-assoc (votPower y) (sumIntersect≤ votPower sxs sys) = refl
+                       | sym (sum-++-commute (List-map votPower xs) (List-map votPower (y ∷ ys)))
+                       | sym (map-++-commute votPower xs (y ∷ ys)) = refl
+   ...| no  y∉xs rewrite union-votPower≡ xs ys dxs (allDistinctTail dys)
+                       | sym (+-∸-assoc (votPower y) (sumIntersect≤ xs ys votPower))
+                       | map-++-commute votPower xs ys
+                       | sum-++-commute (List-map votPower xs) (List-map votPower ys)
+                       | sym (+-assoc (votPower y) (CombinedPower xs) (CombinedPower ys))
+                       | +-comm (votPower y) (CombinedPower xs)
+                       | +-assoc (CombinedPower xs) (votPower y) (CombinedPower ys)
+                       | sym (sum-++-commute (List-map votPower xs) (List-map votPower (y ∷ ys)))
+                       | sym (map-++-commute votPower xs (y ∷ ys)) = refl
 
 
    quorumInt>biz : ∀ (xs ys : List Member)
@@ -492,20 +307,19 @@ module LibraBFT.Abstract.BFT
              → totalVotPower ∸ bizF ≤ CombinedPower xs
              → totalVotPower ∸ bizF ≤ CombinedPower ys
              → ∃[ α ] (α ∈ xs × α ∈ ys × Meta-Honest-PK (getPubKey α))
-   bft-lemma {xs} {ys} all≢xs all≢ys q≤≢xs q≤≢ys rewrite sumSort≡ xs votPower
-                                                       | sumSort≡ ys votPower
-     = let sxs         = allDistict⇒Sorted xs all≢xs
-           sys         = allDistict⇒Sorted ys all≢ys
-           |q₁|+|q₂|   = CombinedPower ((sort xs) ++ (sort ys))
-           |q₁∩q₂|     = CombinedPower (intersect (sort xs) (sort ys))
-           |q₁∪q₂|≤n   = union-votPower sxs sys
-           exp₁        = subst (_≤ totalVotPower) (union-votPower≡ sxs sys) |q₁∪q₂|≤n
+   bft-lemma {xs} {ys} all≢xs all≢ys q≤≢xs q≤≢ys
+     = let |q₁|+|q₂|   = CombinedPower (xs ++ ys)
+           |q₁∩q₂|     = CombinedPower (intersect xs ys)
+           |q₁∪q₂|≤n   = union-votPower xs ys all≢xs all≢ys
+           |q₁∪q₂|≡    = union-votPower≡ xs ys all≢xs all≢ys
+           exp₁        = subst (_≤ totalVotPower) |q₁∪q₂|≡ |q₁∪q₂|≤n
            exp₂        = m∸n≤o⇒m∸o≤n |q₁|+|q₂| |q₁∩q₂| totalVotPower exp₁
-           f+1≤|q₁∩q₂| = quorumInt>biz (sort xs) (sort ys) q≤≢xs q≤≢ys exp₂
-           honInf      = find-honest (sorted⇒AllDistinct (intersectDiff sxs sys)) f+1≤|q₁∩q₂|
-           h∈∩         = ∈-intersect sxs sys ((proj₁ ∘ proj₂) honInf)
-           α∈xs        = sort-⊆ xs (proj₁ h∈∩)
-           α∈ys        = sort-⊆ ys (proj₂ h∈∩)
+           f+1≤|q₁∩q₂| = quorumInt>biz xs ys q≤≢xs q≤≢ys exp₂
+           intDist     = intersectDistinct xs ys all≢xs all≢ys
+           honInf      = find-honest {intersect xs ys} intDist f+1≤|q₁∩q₂|
+           h∈∩         = ∈-intersect xs ys ((proj₁ ∘ proj₂) honInf)
+           α∈xs        = proj₁ h∈∩
+           α∈ys        = proj₂ h∈∩
        in proj₁ honInf , α∈xs , α∈ys , (proj₂ ∘ proj₂) honInf
 
 

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -31,9 +31,8 @@ open import LibraBFT.Base.PKCS
 module LibraBFT.Abstract.BFT
   (authorsN      : ℕ)
   (votPower      : Fin authorsN → ℕ)
-  (totalVotPower : ℕ)
   (bizF          : ℕ)
-  (isBFT         : totalVotPower ≥ suc (3 * bizF))
+  (isBFT         : f-sum votPower (allFin authorsN) ≥ suc (3 * bizF))
   (getPubKey     : Fin authorsN → PK)
 
 
@@ -47,7 +46,10 @@ module LibraBFT.Abstract.BFT
  Meta-dishonest? m = Meta-DishonestPK? (getPubKey m)
 
  CombinedPower : List Member → ℕ
- CombinedPower xs = sum (List-map votPower xs)
+ CombinedPower = f-sum votPower
+
+ TotalVotPower : ℕ
+ TotalVotPower = f-sum votPower (allFin authorsN)
 
  open DecLemmas {A = Member} _≟Fin_
 
@@ -58,127 +60,22 @@ module LibraBFT.Abstract.BFT
  -- `bizF`.
 
 
- module _  (totalVotPower≡  : totalVotPower ≡ CombinedPower (List-tabulate id))
-           (bft-assumption : ∀ (xs : List Member)
+ module _  (bft-assumption : ∀ (xs : List Member)
                            → allDistinct xs
                            → CombinedPower (List-filter Meta-dishonest? xs) ≤ bizF)
    where
 
    participants : List Member
-   participants = List-tabulate id
-
-   -- TODO-2 : Many of these lemmas can be generalized for any list or any
-   -- list of Fin. Perhaps establish a Lemmas.FinProps module.
-
-   intersect : List Member → List Member → List Member
-   intersect xs [] = []
-   intersect xs (y ∷ ys)
-     with y ∈? xs
-   ...| yes _ = y ∷ intersect xs ys
-   ...| no  _ = intersect xs ys
-
-
-   union : List Member → List Member → List Member
-   union xs [] = xs
-   union xs (y ∷ ys)
-     with y ∈? xs
-   ...| yes _ = union xs ys
-   ...| no  _ = y ∷ union xs ys
-
-
-   ∈-intersect : ∀ (xs ys : List Member) {α}
-               → α ∈ intersect xs ys
-               → α ∈ xs × α ∈ ys
-   ∈-intersect xs (y ∷ ys) α∈int
-     with y ∈? xs  | α∈int
-   ...| no  y∉xs   | α∈        = ×-map₂ there (∈-intersect xs ys α∈)
-   ...| yes y∈xs   | here refl = y∈xs , here refl
-   ...| yes y∈xs   | there α∈  = ×-map₂ there (∈-intersect xs ys α∈)
-
-
-   x∉⇒x∉intersect : ∀ {x} {xs ys : List Member}
-                    → x ∉ xs ⊎ x ∉ ys
-                    → x ∉ intersect xs ys
-   x∉⇒x∉intersect {x} {xs} {ys} x∉ x∈int
-     = contraposition (∈-intersect xs ys) (morgan₁ x∉) x∈int
-
-
-   intersectDistinct : ∀ (xs ys : List Member)
-                     → allDistinct xs → allDistinct ys
-                     → allDistinct (intersect xs ys)
-   intersectDistinct xs (y ∷ ys) dxs dys
-     with y ∈? xs
-   ...| yes y∈xs = let distTail  = allDistinctTail dys
-                       intDTail  = intersectDistinct xs ys dxs distTail
-                       y∉intTail = x∉⇒x∉intersect (inj₂ (allDistinct⇒∉ dys))
-                   in x∉→AllDistinct intDTail y∉intTail
-   ...| no  y∉xs = intersectDistinct xs ys dxs (allDistinctTail dys)
-
-
-   x∉⇒x∉union : ∀ {x} {xs ys : List Member}
-              → x ∉ xs × x ∉ ys
-              → x ∉ union xs ys
-   x∉⇒x∉union {_} {_} {[]} (x∉xs , _) x∈∪ = ⊥-elim (x∉xs x∈∪)
-   x∉⇒x∉union {x} {xs} {y ∷ ys} (x∉xs , x∉ys) x∈union
-     with y ∈? xs  | x∈union
-   ...| yes y∈xs   | x∈∪
-        = ⊥-elim (x∉⇒x∉union (x∉xs , (proj₂ (y∉xs⇒Allxs≢y x∉ys))) x∈∪)
-   ...| no y∉xs    | here refl
-        = ⊥-elim (proj₁ (y∉xs⇒Allxs≢y x∉ys) refl)
-   ...| no y∉xs    | there x∈∪
-        = ⊥-elim (x∉⇒x∉union (x∉xs , (proj₂ (y∉xs⇒Allxs≢y x∉ys))) x∈∪)
-
-   unionDistinct : ∀ (xs ys : List Member)
-               → allDistinct xs → allDistinct ys
-               → allDistinct (union xs ys)
-   unionDistinct xs [] dxs dys = dxs
-   unionDistinct xs (y ∷ ys) dxs dys
-      with y ∈? xs
-   ...| yes y∈xs = unionDistinct xs ys dxs (allDistinctTail dys)
-   ...| no  y∉xs = let distTail  = allDistinctTail dys
-                       uniDTail  = unionDistinct xs ys dxs distTail
-                       y∉intTail = x∉⇒x∉union (y∉xs , allDistinct⇒∉ dys)
-                   in x∉→AllDistinct uniDTail y∉intTail
-
+   participants = allFin authorsN
 
    members⊆ : ∀ {xs : List Member} → xs ⊆List participants
    members⊆ {_} {x} _ = Any-tabulate⁺ {f = id} x refl
 
-
-   votingPower≤N : ∀ (xs : List Member) → allDistinct xs
-                 → CombinedPower xs ≤ totalVotPower
-   votingPower≤N xs dxs rewrite totalVotPower≡
-     = sum-⊆-≤ xs votPower dxs members⊆
-
-
-   union-votPower : ∀ (xs ys : List Member)
+   union-votPower≤N : ∀ (xs ys : List Member)
                   → allDistinct xs → allDistinct ys
-                  → CombinedPower (union xs ys) ≤ totalVotPower
-   union-votPower xs ys dxs dys
-     = votingPower≤N (union xs ys) (unionDistinct xs ys dxs dys)
-
-
-   sumIntersect≤ : ∀ (xs ys : List Member) (f : Member → ℕ)
-                 → sum (List-map f (intersect xs ys)) ≤ sum (List-map f (xs ++ ys))
-   sumIntersect≤ _ [] _ = z≤n
-   sumIntersect≤ xs (y ∷ ys) f
-     with y ∈? xs
-   ...| yes y∈xs rewrite map-++-commute f xs (y ∷ ys)
-                       | sum-++-commute (List-map f xs) (List-map f (y ∷ ys))
-                       | sym (+-assoc (sum (List-map f xs)) (f y) (sum (List-map f ys)))
-                       | +-comm (sum (List-map f xs)) (f y)
-                       | +-assoc (f y) (sum (List-map f xs)) (sum (List-map f ys))
-                       | sym (sum-++-commute (List-map f xs) (List-map f ys))
-                       | sym (map-++-commute f xs ys)
-                         = +-monoʳ-≤ (f y) (sumIntersect≤ xs ys f)
-   ...| no  y∉xs rewrite map-++-commute f xs (y ∷ ys)
-                       | sum-++-commute (List-map f xs) (List-map f (y ∷ ys))
-                       | +-comm (f y) (sum (List-map f ys))
-                       | sym (+-assoc (sum (List-map f xs)) (sum (List-map f ys)) (f y))
-                       | sym (sum-++-commute (List-map f xs) (List-map f ys))
-                       | sym (map-++-commute f xs ys)
-                         = ≤-stepsʳ (f y) (sumIntersect≤ xs ys f)
-
+                  → CombinedPower (union xs ys) ≤ TotalVotPower
+   union-votPower≤N xs ys dxs dys
+     = sum-⊆-≤ (union xs ys) votPower (unionDistinct xs ys dxs dys) members⊆
 
    union-votPower≡ :  ∀ (xs ys : List Member)
                       → allDistinct xs → allDistinct ys
@@ -212,16 +109,16 @@ module LibraBFT.Abstract.BFT
 
 
    quorumInt>biz : ∀ (xs ys : List Member)
-                 → totalVotPower ∸ bizF ≤ CombinedPower xs
-                 → totalVotPower ∸ bizF ≤ CombinedPower ys
-                 → CombinedPower (xs ++ ys) ∸ totalVotPower ≤ CombinedPower (intersect xs ys)
+                 → TotalVotPower ∸ bizF ≤ CombinedPower xs
+                 → TotalVotPower ∸ bizF ≤ CombinedPower ys
+                 → CombinedPower (xs ++ ys) ∸ TotalVotPower ≤ CombinedPower (intersect xs ys)
                  → bizF + 1 ≤ CombinedPower (intersect xs ys)
    quorumInt>biz xs ys q≤x q≤y ≤combPower
      rewrite map-++-commute votPower xs ys
            | sum-++-commute (List-map votPower xs) (List-map votPower ys)
            = let powInt = CombinedPower (intersect xs ys)
-                 p₁     = ≤-trans (∸-monoˡ-≤ totalVotPower (+-mono-≤ q≤x q≤y)) ≤combPower
-                 p₂     = subst (_≤ powInt) (simpExp₁ totalVotPower bizF) p₁
+                 p₁     = ≤-trans (∸-monoˡ-≤ TotalVotPower (+-mono-≤ q≤x q≤y)) ≤combPower
+                 p₂     = subst (_≤ powInt) (simpExp₁ TotalVotPower bizF) p₁
                  p₃     = ≤-trans (∸-monoˡ-≤ (2 * bizF) isBFT) p₂
              in subst (_≤ powInt) (simpExp₂ bizF) p₃
        where  simpExp₁ : ∀ (x y : ℕ) → (x ∸ y) + (x ∸ y) ∸ x ≡ x ∸ (2 * y)
@@ -241,69 +138,67 @@ module LibraBFT.Abstract.BFT
                                | sym (+-suc x 0) = refl
 
 
-   span-hon : ∀ {xs dis hon : List Member} {x : Member}
-            → span Meta-dishonest? xs ≡ (dis , x ∷ hon)
-            → x ∈ xs ×  Meta-Honest-PK (getPubKey x)
-   span-hon {x ∷ xs} eq
+   partition-hon : ∀ {xs dis hon : List Member} {x : Member}
+            → partition Meta-dishonest? xs ≡ (dis , x ∷ hon)
+            → x ∈ xs × Meta-Honest-PK (getPubKey x)
+   partition-hon {x ∷ xs} eq
      with Meta-dishonest? x | eq
    ...| no imp  | refl = here refl , imp
    ...| yes _   | eq₁
-     with span Meta-dishonest? xs | inspect (span Meta-dishonest?) xs
+     with partition Meta-dishonest? xs | inspect (partition Meta-dishonest?) xs
    ...| _ , x₂ ∷ _ | [ eq₂ ] rewrite just-injective (cong (head ∘ proj₂) eq₁)
-     = ×-map₁ there (span-hon eq₂)
+     = ×-map₁ there (partition-hon eq₂)
 
 
-   span-dis : ∀ {xs dis : List Member}
-            → span Meta-dishonest? xs ≡ (dis , [])
+   partition-dis : ∀ {xs dis : List Member}
+            → partition Meta-dishonest? xs ≡ (dis , [])
             → List-filter Meta-dishonest? xs ≡ xs
-   span-dis {[]} _ = refl
-   span-dis {x ∷ xs} span≡
-      with Meta-dishonest? x | span≡
+   partition-dis {[]} _ = refl
+   partition-dis {x ∷ xs} eq
+      with Meta-dishonest? x | eq
    ...| no ¬dis  | ()
    ...| yes _  | _
-      with span Meta-dishonest? xs | inspect (span Meta-dishonest?) xs
-   ...| _ , [] | [ eq₁ ] = cong (x ∷_) (span-dis {xs} eq₁)
+      with partition Meta-dishonest? xs | inspect (partition Meta-dishonest?) xs
+   ...| _ , [] | [ eq₁ ] = cong (x ∷_) (partition-dis {xs} eq₁)
 
 
    -- TODO-1 : An alternative to prove this lemma would be:
    -- - First prove that
    --   CombinedPower (List-filter Meta-dishonest? xs) ≤ CombinedPower xs.
    -- - Then prove that:
-   --   - If CombinedPower (List-filter Meta-dishonest? xs) ≤ CombinedPower xs
+   --   - If CombinedPower (List-filter Meta-dishonest? xs) < CombinedPower xs
    --     then ∃[ α ] (α ∈ xs × Meta-Honest-PK (getPubKey α)).
    --   - If CombinedPower (List-filter Meta-dishonest? xs ≡ CombinedPower xs we
    --   get a contradiction using the bft assumption (as we have now).
    find-honest : ∀ {xs : List Member}
                → allDistinct xs
-               → bizF + 1 ≤ CombinedPower xs
+               → bizF < CombinedPower xs
                → ∃[ α ] (α ∈ xs × Meta-Honest-PK (getPubKey α))
    find-honest {xs} sxs biz<
-     with span Meta-dishonest? xs | inspect (span Meta-dishonest?) xs
+     with partition Meta-dishonest? xs | inspect (partition Meta-dishonest?) xs
    ...| dis , [] | [ eq ]
-        rewrite +-comm bizF 1
           = let bft     = bft-assumption xs sxs
-                xsVot≤f = subst (_≤ bizF) (cong CombinedPower (span-dis {xs} eq)) bft
+                xsVot≤f = subst (_≤ bizF) (cong CombinedPower (partition-dis {xs} eq)) bft
             in ⊥-elim (<⇒≱ biz< xsVot≤f)
-   ...| dis , x ∷ hon | [ eq ] = x , (span-hon eq)
+   ...| dis , x ∷ hon | [ eq ] = x , partition-hon eq
 
 
    bft-lemma : {xs ys : List Member}
-             -- enforcing both xs and ys to be sorted lists according to
-             -- a anti-reflexive linear order ensures authors are distinct.
              → allDistinct xs → allDistinct ys
-             → totalVotPower ∸ bizF ≤ CombinedPower xs
-             → totalVotPower ∸ bizF ≤ CombinedPower ys
+             → TotalVotPower ∸ bizF ≤ CombinedPower xs
+             → TotalVotPower ∸ bizF ≤ CombinedPower ys
              → ∃[ α ] (α ∈ xs × α ∈ ys × Meta-Honest-PK (getPubKey α))
    bft-lemma {xs} {ys} all≢xs all≢ys q≤≢xs q≤≢ys
      = let |q₁|+|q₂|   = CombinedPower (xs ++ ys)
            |q₁∩q₂|     = CombinedPower (intersect xs ys)
-           |q₁∪q₂|≤n   = union-votPower xs ys all≢xs all≢ys
+           |q₁∪q₂|≤n   = union-votPower≤N xs ys all≢xs all≢ys
            |q₁∪q₂|≡    = union-votPower≡ xs ys all≢xs all≢ys
-           exp₁        = subst (_≤ totalVotPower) |q₁∪q₂|≡ |q₁∪q₂|≤n
-           exp₂        = m∸n≤o⇒m∸o≤n |q₁|+|q₂| |q₁∩q₂| totalVotPower exp₁
+           exp₁        = subst (_≤ TotalVotPower) |q₁∪q₂|≡ |q₁∪q₂|≤n
+           exp₂        = m∸n≤o⇒m∸o≤n |q₁|+|q₂| |q₁∩q₂| TotalVotPower exp₁
            f+1≤|q₁∩q₂| = quorumInt>biz xs ys q≤≢xs q≤≢ys exp₂
+           f<|q₁∩q₂|   = subst (_≤ |q₁∩q₂|) (+-comm bizF 1) f+1≤|q₁∩q₂|
            intDist     = intersectDistinct xs ys all≢xs all≢ys
-           honInf      = find-honest {intersect xs ys} intDist f+1≤|q₁∩q₂|
+           honInf      = find-honest {intersect xs ys} intDist f<|q₁∩q₂|
            h∈∩         = ∈-intersect xs ys ((proj₁ ∘ proj₂) honInf)
        in proj₁ honInf ,  proj₁ h∈∩ , proj₂ h∈∩ , (proj₂ ∘ proj₂) honInf
 

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -55,12 +55,8 @@ module LibraBFT.Abstract.BFT
  -- Byzantine nodes must not exceed the security threshold
  -- `bizF`. Therefore, for any list of distinct participants, the
  -- combined power of the dishonest nodes is less or equal than
- -- `bizF`. To express a list of distinct particpants we used the data
- -- type `IsSorted _<Fin_`, enforcing xs to be sorted according to a
- -- anti-reflexive linear order ensures authors are distinct.
+ -- `bizF`.
 
- -- TODO-1 : Replace `IsSorted _<Fin_ xs` with the type `allDistinct`
- -- in `LibraBFT.Lemmas
 
  module _  (totalVotPower≡  : totalVotPower ≡ CombinedPower (List-tabulate id))
            (bft-assumption : ∀ (xs : List Member)

--- a/LibraBFT/Abstract/BFT.agda
+++ b/LibraBFT/Abstract/BFT.agda
@@ -236,29 +236,6 @@ module LibraBFT.Abstract.BFT
        in h∉t <⇒≢Fin <-trans (transOnHead <-trans x< y<x ∷ sxs) y∈xs
 
 
-   sumListMap : ∀ {A : Set} {x} {xs : List A} (f : A → ℕ) → (x∈xs : x ∈ xs)
-              → sum (List-map f xs) ≡ f x + sum (List-map f (xs ─ Any-index x∈xs))
-   sumListMap f (here refl)  = refl
-   sumListMap {_} {x} {x₁ ∷ xs} f (there x∈xs)
-     rewrite sumListMap f x∈xs
-           | sym (+-assoc (f x) (f x₁) (sum (List-map f (xs ─ Any-index x∈xs))))
-           | +-comm (f x) (f x₁)
-           | +-assoc (f x₁) (f x) (sum (List-map f (xs ─ Any-index x∈xs))) = refl
-
-
-   sum-⊆-≤ : ∀ {xs ys : List Member} (f : Member → ℕ)
-           → IsSorted _<Fin_ xs
-           → xs ⊆List ys
-           → sum (List-map f xs) ≤ sum (List-map f ys)
-   sum-⊆-≤ {[]} _ _ _ = z≤n
-   sum-⊆-≤ {x ∷ xs} f (x< ∷ sxs) xxs⊆ys
-     rewrite sumListMap f (xxs⊆ys (here refl))
-     = let x∉xs = h∉t <⇒≢Fin <-trans (x< ∷ sxs)
-           xs⊆ys = xs-⊆List-ysʳ xxs⊆ys
-           xs⊆ys-x = ⊆List-Elim (xxs⊆ys (here refl)) x∉xs xs⊆ys
-       in +-monoʳ-≤ (f x) (sum-⊆-≤ f sxs xs⊆ys-x)
-
-
    members⊆ : ∀ {xs : List Member} → xs ⊆List participants
    members⊆ {_} {x} _ = Any-tabulate⁺ {f = id} x refl
 
@@ -527,8 +504,8 @@ module LibraBFT.Abstract.BFT
            f+1≤|q₁∩q₂| = quorumInt>biz (sort xs) (sort ys) q≤≢xs q≤≢ys exp₂
            honInf      = find-honest (sorted⇒AllDistinct (intersectDiff sxs sys)) f+1≤|q₁∩q₂|
            h∈∩         = ∈-intersect sxs sys ((proj₁ ∘ proj₂) honInf)
-           α∈xs        = ∈-⊆List-trans (proj₁ h∈∩) (sort-⊆ xs)
-           α∈ys        = ∈-⊆List-trans (proj₂ h∈∩) (sort-⊆ ys)
+           α∈xs        = sort-⊆ xs (proj₁ h∈∩)
+           α∈ys        = sort-⊆ ys (proj₂ h∈∩)
        in proj₁ honInf , α∈xs , α∈ys , (proj₂ ∘ proj₂) honInf
 
 

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -265,79 +265,44 @@ module LibraBFT.Lemmas where
  m∸n≤o⇒m∸o≤n (suc x) (suc z) w p≤ = ≤-trans (∸-suc-≤ x w) (s≤s (m∸n≤o⇒m∸o≤n x z w p≤))
 
 
- _∈?_ : ∀ {n} (x : Fin n) → (xs : List (Fin n)) → Dec (Any (x ≡_) xs)
- x ∈? xs = Any-any (x ≟Fin_) xs
+ tail-⊆ : ∀ {A : Set} {x} {xs ys : List A}
+        → (x ∷ xs) ⊆List ys
+        → xs ⊆List ys
+ tail-⊆ xxs⊆ys x∈xs = xxs⊆ys (there x∈xs)
 
-
- y∉xs⇒Allxs≢y : ∀ {n} {xs : List (Fin n)} {x y}
-         → y ∉ (x ∷ xs)
-         → x ≢ y × y ∉ xs
- y∉xs⇒Allxs≢y {_} {xs} {x} {y} y∉
-   with y ∈? xs
- ...| yes y∈xs = ⊥-elim (y∉ (there y∈xs))
- ...| no  y∉xs
-   with x ≟Fin y
- ...| yes x≡y = ⊥-elim (y∉ (here (sym x≡y)))
- ...| no  x≢y = x≢y , y∉xs
-
-
- allDistinctTail : ∀ {A} {x : A} {xs : List A}
+ allDistinctTail : ∀ {A : Set} {x} {xs : List A}
                  → allDistinct (x ∷ xs)
                  → allDistinct xs
- allDistinctTail {_} {x} {xs} allDist (i , i<l) (j , j<l)
-   with allDist ((suc i) , (s≤s i<l)) ((suc j) , s≤s j<l)
+ allDistinctTail allDist (i , i<l) (j , j<l)
+   with allDist (suc i , s≤s i<l) (suc j , s≤s j<l)
  ...| inj₁ 1+i≡1+j = inj₁ (cong pred 1+i≡1+j)
  ...| inj₂ lookup≢ = inj₂ lookup≢
 
 
- xs-⊆List-ysʳ : ∀ {A : Set} {x} {xs ys : List A}
-              → (x ∷ xs) ⊆List ys
-              → xs ⊆List ys
- xs-⊆List-ysʳ xxs⊆ys x∈xs = xxs⊆ys (there x∈xs)
-
-
- ∈-Any-Index-elim :  ∀ {A : Set} {x y} {ys : List A} (x∈ys : x ∈ ys)
+ ∈-Any-Index-elim : ∀ {A : Set} {x y} {ys : List A} (x∈ys : x ∈ ys)
                   → x ≢ y → y ∈ ys
                   → y ∈ ys ─ Any-index x∈ys
  ∈-Any-Index-elim (here refl)  x≢y (here refl)  = ⊥-elim (x≢y refl)
- ∈-Any-Index-elim (here refl)  x≢y (there y∈ys) = y∈ys
- ∈-Any-Index-elim (there x∈ys) x≢y (here refl)  = here refl
+ ∈-Any-Index-elim (here refl)  _   (there y∈ys) = y∈ys
+ ∈-Any-Index-elim (there _)    _   (here refl)  = here refl
  ∈-Any-Index-elim (there x∈ys) x≢y (there y∈ys) = there (∈-Any-Index-elim x∈ys x≢y y∈ys)
 
 
- ⊆List-Elim :  ∀ {n} {x} {xs ys : List (Fin n)} (x∈ys : x ∈ ys)
-                    → x ∉ xs → xs ⊆List ys
-                    → xs ⊆List ys ─ Any-index x∈ys
- ⊆List-Elim {_} {x} {x₁ ∷ xs} {y ∷ ys} (here refl) x∉xs xs∈ys x₂∈xs
-   with xs∈ys x₂∈xs
- ... | here refl  = ⊥-elim (x∉xs x₂∈xs)
- ... | there x∈xs = x∈xs
- ⊆List-Elim {_} {x} {x₁ ∷ xs} {y ∷ ys} (there x∈ys) x∉xs xs∈ys x₂∈xxs
-   with x₂∈xxs
- ... | there x₂∈xs
-       = ⊆List-Elim (there x∈ys) (proj₂ (y∉xs⇒Allxs≢y x∉xs)) (xs-⊆List-ysʳ xs∈ys) x₂∈xs
- ... | here refl
-   with xs∈ys x₂∈xxs
- ... | here refl = here refl
- ... | there x₂∈ys
-       = there (∈-Any-Index-elim x∈ys (≢-sym (proj₁ (y∉xs⇒Allxs≢y x∉xs))) x₂∈ys)
-
-
- ∉∧⊆List⇒∉ : ∀ {n} {x} {xs ys : List (Fin n)}
-             → x ∉ xs → ys ⊆List xs
-             → x ∉ ys
+ ∉∧⊆List⇒∉ : ∀ {A : Set} {x} {xs ys : List A}
+           → x ∉ xs → ys ⊆List xs
+           → x ∉ ys
  ∉∧⊆List⇒∉ x∉xs ys∈xs x∈ys = ⊥-elim (x∉xs (ys∈xs x∈ys))
 
 
- allDistinctʳʳ : ∀ {A} {x x₁ : A} {xs : List A}
-                 → allDistinct (x ∷ x₁ ∷ xs)
-                 → allDistinct (x ∷ xs)
- allDistinctʳʳ allDist (zero , i<l) (zero , j<l) = inj₁ refl
- allDistinctʳʳ {_} {x} {x₁} {xs} allDist (zero , i<l) (suc j , j<l)
+ allDistinctʳʳ : ∀ {A : Set} {x x₁ : A} {xs : List A}
+               → allDistinct (x ∷ x₁ ∷ xs)
+               → allDistinct (x ∷ xs)
+ allDistinctʳʳ _ (zero , _) (zero , _) = inj₁ refl
+ allDistinctʳʳ allDist (zero , i<l) (suc j , j<l)
    with allDist (0 , s≤s z≤n) (suc (suc j) , s≤s j<l)
  ...| inj₂ x≢lookup
       = inj₂ λ x≡lkpxs → ⊥-elim (x≢lookup x≡lkpxs)
- allDistinctʳʳ {_} {x} {_} {xs} allDist (suc i , i<l) (zero , j<l)
+ allDistinctʳʳ allDist (suc i , i<l) (zero , j<l)
    with allDist (suc (suc i) , s≤s i<l) (0 , s≤s z≤n)
  ...| inj₂ x≢lookup
       = inj₂ λ x≡lkpxs → ⊥-elim (x≢lookup x≡lkpxs)
@@ -347,7 +312,7 @@ module LibraBFT.Lemmas where
  ...| inj₂ lookup≡ = inj₂ lookup≡
 
 
- allDistinct⇒∉ : ∀ {n} {x} {xs : List (Fin n)}
+ allDistinct⇒∉ : ∀ {A : Set} {x} {xs : List A}
                → allDistinct (x ∷ xs)
                → x ∉ xs
  allDistinct⇒∉ allDist (here x≡x₁)
@@ -359,7 +324,7 @@ module LibraBFT.Lemmas where
 
  sumListMap : ∀ {A : Set} {x} {xs : List A} (f : A → ℕ) → (x∈xs : x ∈ xs)
             → sum (List-map f xs) ≡ f x + sum (List-map f (xs ─ Any-index x∈xs))
- sumListMap f (here refl)  = refl
+ sumListMap _ (here refl)  = refl
  sumListMap {_} {x} {x₁ ∷ xs} f (there x∈xs)
    rewrite sumListMap f x∈xs
          | sym (+-assoc (f x) (f x₁) (sum (List-map f (xs ─ Any-index x∈xs))))
@@ -367,39 +332,73 @@ module LibraBFT.Lemmas where
          | +-assoc (f x₁) (f x) (sum (List-map f (xs ─ Any-index x∈xs))) = refl
 
 
- sum-⊆-≤ : ∀ {n} {ys} (xs : List (Fin n)) (f : (Fin n) → ℕ)
-         → allDistinct xs
-         → xs ⊆List ys
-         → sum (List-map f xs) ≤ sum (List-map f ys)
- sum-⊆-≤ [] f dxs xs⊆ys = z≤n
- sum-⊆-≤ (x ∷ xs) f dxs xs⊆ys
-    rewrite sumListMap f (xs⊆ys (here refl))
-    = let x∉xs    = allDistinct⇒∉ dxs
-          xs⊆ysT  = xs-⊆List-ysʳ xs⊆ys
-          xs⊆ys-x = ⊆List-Elim (xs⊆ys (here refl)) x∉xs xs⊆ysT
-          disTail = allDistinctTail dxs
-     in +-monoʳ-≤ (f x) (sum-⊆-≤ xs f disTail xs⊆ys-x)
-
-
  lookup⇒Any : ∀ {A : Set} {xs : List A} {P : A → Set} (i : Fin (length xs))
             → P (List-lookup xs i) → Any P xs
- lookup⇒Any {xs = x₁ ∷ xs} zero px = here px
- lookup⇒Any {xs = x₁ ∷ xs} (suc i) px = there (lookup⇒Any i px)
+ lookup⇒Any {_} {_ ∷ _} zero    px = here px
+ lookup⇒Any {_} {_ ∷ _} (suc i) px = there (lookup⇒Any i px)
 
 
- x∉→AllDistinct : ∀ {n} {x} {xs : List (Fin n)}
+ x∉→AllDistinct : ∀ {A : Set} {x} {xs : List A}
                 → allDistinct xs
                 → x ∉ xs
                 → allDistinct (x ∷ xs)
- x∉→AllDistinct {xs = []} allDist x∉xs (0 , s≤s z≤n) (0 , s≤s z≤n) = inj₁ refl
- x∉→AllDistinct {_} {x} {x₁ ∷ xs} allDist x∉xs (zero , i<l) (zero , j<l) = inj₁ refl
- x∉→AllDistinct {_} {x} {x₁ ∷ xs} allDist x∉xs (zero , i<l) (suc j , j<l)
+ x∉→AllDistinct _ _ (0 , _) (0 , _) = inj₁ refl
+ x∉→AllDistinct _ x∉xs (0 , _) (suc j , j<l)
    = inj₂ (λ x≡lkp → x∉xs (lookup⇒Any (fromℕ< (≤-pred j<l)) x≡lkp))
- x∉→AllDistinct {_} {x} {x₁ ∷ xs} allDist x∉xs (suc i , i<l) (zero , j<l)
+ x∉→AllDistinct _ x∉xs (suc i , i<l) (0 , _)
    = inj₂ (λ x≡lkp → x∉xs (lookup⇒Any (fromℕ< (≤-pred i<l)) (sym x≡lkp)))
- x∉→AllDistinct {_} {x} {x₁ ∷ xs} allDist x∉xs (suc i , i<l) (suc j , j<l)
+ x∉→AllDistinct allDist x∉xs (suc i , i<l) (suc j , j<l)
    with allDist (i , (≤-pred i<l)) (j , (≤-pred j<l))
- ... | inj₁ i≡j   = inj₁ (cong suc i≡j)
- ... | inj₂ lkup≢ = inj₂ lkup≢
+ ...| inj₁ i≡j   = inj₁ (cong suc i≡j)
+ ...| inj₂ lkup≢ = inj₂ lkup≢
 
 
+ module DecLemmas {A : Set} (_≟D_ : Decidable {A = A} (_≡_)) where
+
+   _∈?_ : ∀ (x : A) → (xs : List A) → Dec (Any (x ≡_) xs)
+   x ∈? xs = Any-any (x ≟D_) xs
+
+
+   y∉xs⇒Allxs≢y : ∀ {xs : List A} {x y}
+                → y ∉ (x ∷ xs)
+                → x ≢ y × y ∉ xs
+   y∉xs⇒Allxs≢y {xs} {x} {y} y∉
+     with y ∈? xs
+   ...| yes y∈xs = ⊥-elim (y∉ (there y∈xs))
+   ...| no  y∉xs
+     with x ≟D y
+   ...| yes x≡y = ⊥-elim (y∉ (here (sym x≡y)))
+   ...| no  x≢y = x≢y , y∉xs
+
+
+   ⊆List-Elim :  ∀ {x} {xs ys : List A} (x∈ys : x ∈ ys)
+              → x ∉ xs → xs ⊆List ys
+              → xs ⊆List ys ─ Any-index x∈ys
+   ⊆List-Elim (here refl) x∉xs xs∈ys x₂∈xs
+     with xs∈ys x₂∈xs
+   ...| here refl  = ⊥-elim (x∉xs x₂∈xs)
+   ...| there x∈xs = x∈xs
+   ⊆List-Elim (there x∈ys) x∉xs xs∈ys x₂∈xxs
+     with x₂∈xxs
+   ...| there x₂∈xs
+         = ⊆List-Elim (there x∈ys) (proj₂ (y∉xs⇒Allxs≢y x∉xs)) (tail-⊆ xs∈ys) x₂∈xs
+   ...| here refl
+     with xs∈ys x₂∈xxs
+   ...| here refl = here refl
+   ...| there x₂∈ys
+         = there (∈-Any-Index-elim x∈ys (≢-sym (proj₁ (y∉xs⇒Allxs≢y x∉xs))) x₂∈ys)
+
+
+
+   sum-⊆-≤ : ∀ {ys} (xs : List A) (f : A → ℕ)
+           → allDistinct xs
+           → xs ⊆List ys
+           → sum (List-map f xs) ≤ sum (List-map f ys)
+   sum-⊆-≤ [] _ _ _ = z≤n
+   sum-⊆-≤ (x ∷ xs) f dxs xs⊆ys
+      rewrite sumListMap f (xs⊆ys (here refl))
+      = let x∉xs    = allDistinct⇒∉ dxs
+            xs⊆ysT  = tail-⊆ xs⊆ys
+            xs⊆ys-x = ⊆List-Elim (xs⊆ys (here refl)) x∉xs xs⊆ysT
+            disTail = allDistinctTail dxs
+       in +-monoʳ-≤ (f x) (sum-⊆-≤ xs f disTail xs⊆ys-x)

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
@@ -142,7 +142,6 @@ module LibraBFT.Lemmas where
  IsSorted-map⁻ f .(_ ∷ []) (x ∷ []) = [] ∷ []
  IsSorted-map⁻ f .(_ ∷ _ ∷ _) (on-∷ x ∷ (x₁ ∷ is)) = (on-∷ x) ∷ IsSorted-map⁻ f _ (x₁ ∷ is)
 
-
  transOnHead : ∀ {A} {l : List A} {y x : A} {_<_ : A → A → Set}
               → Transitive _<_
               → OnHead _<_ y l
@@ -172,7 +171,6 @@ module LibraBFT.Lemmas where
         → _≤_ x y
  ≤-head ref≤ trans (here refl) _ = ref≤
  ≤-head ref≤ trans (there y∈) (on-∷ x<x₁ ∷ sl) = trans x<x₁ (≤-head ref≤ trans y∈ sl)
-
 
  -- TODO-1 : Better name and/or replace with library property
  Any-sym : ∀ {a b}{A : Set a}{B : Set b}{tgt : B}{l : List A}{f : A → B}
@@ -264,7 +262,6 @@ module LibraBFT.Lemmas where
  m∸n≤o⇒m∸o≤n zero (suc z) w p≤ rewrite 0∸n≡0 w = z≤n
  m∸n≤o⇒m∸o≤n (suc x) (suc z) w p≤ = ≤-trans (∸-suc-≤ x w) (s≤s (m∸n≤o⇒m∸o≤n x z w p≤))
 
-
  tail-⊆ : ∀ {A : Set} {x} {xs ys : List A}
         → (x ∷ xs) ⊆List ys
         → xs ⊆List ys
@@ -278,7 +275,6 @@ module LibraBFT.Lemmas where
  ...| inj₁ 1+i≡1+j = inj₁ (cong pred 1+i≡1+j)
  ...| inj₂ lookup≢ = inj₂ lookup≢
 
-
  ∈-Any-Index-elim : ∀ {A : Set} {x y} {ys : List A} (x∈ys : x ∈ ys)
                   → x ≢ y → y ∈ ys
                   → y ∈ ys ─ Any-index x∈ys
@@ -287,12 +283,10 @@ module LibraBFT.Lemmas where
  ∈-Any-Index-elim (there _)    _   (here refl)  = here refl
  ∈-Any-Index-elim (there x∈ys) x≢y (there y∈ys) = there (∈-Any-Index-elim x∈ys x≢y y∈ys)
 
-
  ∉∧⊆List⇒∉ : ∀ {A : Set} {x} {xs ys : List A}
            → x ∉ xs → ys ⊆List xs
            → x ∉ ys
  ∉∧⊆List⇒∉ x∉xs ys∈xs x∈ys = ⊥-elim (x∉xs (ys∈xs x∈ys))
-
 
  allDistinctʳʳ : ∀ {A : Set} {x x₁ : A} {xs : List A}
                → allDistinct (x ∷ x₁ ∷ xs)
@@ -311,7 +305,6 @@ module LibraBFT.Lemmas where
  ...| inj₁ si≡sj   = inj₁ (cong pred si≡sj)
  ...| inj₂ lookup≡ = inj₂ lookup≡
 
-
  allDistinct⇒∉ : ∀ {A : Set} {x} {xs : List A}
                → allDistinct (x ∷ xs)
                → x ∉ xs
@@ -320,7 +313,6 @@ module LibraBFT.Lemmas where
  ... | inj₂ x≢x₁ = ⊥-elim (x≢x₁ x≡x₁)
  allDistinct⇒∉ allDist (there x∈xs)
    = allDistinct⇒∉ (allDistinctʳʳ allDist) x∈xs
-
 
  sumListMap : ∀ {A : Set} {x} {xs : List A} (f : A → ℕ) → (x∈xs : x ∈ xs)
             → f-sum f xs ≡ f x + f-sum f (xs ─ Any-index x∈xs)
@@ -331,12 +323,10 @@ module LibraBFT.Lemmas where
          | +-comm (f x) (f x₁)
          | +-assoc (f x₁) (f x) (f-sum f (xs ─ Any-index x∈xs)) = refl
 
-
  lookup⇒Any : ∀ {A : Set} {xs : List A} {P : A → Set} (i : Fin (length xs))
             → P (List-lookup xs i) → Any P xs
  lookup⇒Any {_} {_ ∷ _} zero    px = here px
  lookup⇒Any {_} {_ ∷ _} (suc i) px = there (lookup⇒Any i px)
-
 
  x∉→AllDistinct : ∀ {A : Set} {x} {xs : List A}
                 → allDistinct xs
@@ -352,12 +342,10 @@ module LibraBFT.Lemmas where
  ...| inj₁ i≡j   = inj₁ (cong suc i≡j)
  ...| inj₂ lkup≢ = inj₂ lkup≢
 
-
  module DecLemmas {A : Set} (_≟D_ : Decidable {A = A} (_≡_)) where
 
    _∈?_ : ∀ (x : A) → (xs : List A) → Dec (Any (x ≡_) xs)
    x ∈? xs = Any-any (x ≟D_) xs
-
 
    y∉xs⇒Allxs≢y : ∀ {xs : List A} {x y}
                 → y ∉ (x ∷ xs)
@@ -369,7 +357,6 @@ module LibraBFT.Lemmas where
      with x ≟D y
    ...| yes x≡y = ⊥-elim (y∉ (here (sym x≡y)))
    ...| no  x≢y = x≢y , y∉xs
-
 
    ⊆List-Elim :  ∀ {x} {xs ys : List A} (x∈ys : x ∈ ys)
               → x ∉ xs → xs ⊆List ys
@@ -388,8 +375,6 @@ module LibraBFT.Lemmas where
    ...| there x₂∈ys
          = there (∈-Any-Index-elim x∈ys (≢-sym (proj₁ (y∉xs⇒Allxs≢y x∉xs))) x₂∈ys)
 
-
-
    sum-⊆-≤ : ∀ {ys} (xs : List A) (f : A → ℕ)
            → allDistinct xs
            → xs ⊆List ys
@@ -403,7 +388,6 @@ module LibraBFT.Lemmas where
             disTail = allDistinctTail dxs
        in +-monoʳ-≤ (f x) (sum-⊆-≤ xs f disTail xs⊆ys-x)
 
-
    intersect : List A → List A → List A
    intersect xs [] = []
    intersect xs (y ∷ ys)
@@ -411,14 +395,12 @@ module LibraBFT.Lemmas where
    ...| yes _ = y ∷ intersect xs ys
    ...| no  _ = intersect xs ys
 
-
    union : List A → List A → List A
    union xs [] = xs
    union xs (y ∷ ys)
      with y ∈? xs
    ...| yes _ = union xs ys
    ...| no  _ = y ∷ union xs ys
-
 
    ∈-intersect : ∀ (xs ys : List A) {α}
                → α ∈ intersect xs ys
@@ -429,13 +411,11 @@ module LibraBFT.Lemmas where
    ...| yes y∈xs   | here refl = y∈xs , here refl
    ...| yes y∈xs   | there α∈  = ×-map₂ there (∈-intersect xs ys α∈)
 
-
    x∉⇒x∉intersect : ∀ {x} {xs ys : List A}
                     → x ∉ xs ⊎ x ∉ ys
                     → x ∉ intersect xs ys
    x∉⇒x∉intersect {x} {xs} {ys} x∉ x∈int
      = contraposition (∈-intersect xs ys) (deMorgan x∉) x∈int
-
 
    intersectDistinct : ∀ (xs ys : List A)
                      → allDistinct xs → allDistinct ys
@@ -447,7 +427,6 @@ module LibraBFT.Lemmas where
                        y∉intTail = x∉⇒x∉intersect (inj₂ (allDistinct⇒∉ dys))
                    in x∉→AllDistinct intDTail y∉intTail
    ...| no  y∉xs = intersectDistinct xs ys dxs (allDistinctTail dys)
-
 
    x∉⇒x∉union : ∀ {x} {xs ys : List A}
               → x ∉ xs × x ∉ ys
@@ -494,4 +473,3 @@ module LibraBFT.Lemmas where
                        | sym (sum-++-commute (List-map f xs) (List-map f ys))
                        | sym (map-++-commute f xs ys)
                          = ≤-stepsʳ (f y) (sumIntersect≤ xs ys f)
-

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -250,6 +250,9 @@ module LibraBFT.Lemmas where
     with to-witness-lemma (isJust {aMB = just a'} {a} prf) refl
  ...| xxx = just-injective (trans (sym xxx) prf)
 
+ morgan₁ : ∀ {A B : Set} → (¬ A) ⊎ (¬ B) → ¬ (A × B)
+ morgan₁ (inj₁ ¬a) = λ a×b → ¬a (proj₁ a×b)
+ morgan₁ (inj₂ ¬b) = λ a×b → ¬b (proj₂ a×b)
 
  ∸-suc-≤ : ∀ (x w : ℕ) → suc x ∸ w ≤ suc (x ∸ w)
  ∸-suc-≤ x zero = ≤-refl

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -39,6 +39,11 @@ module LibraBFT.Prelude where
     using (∷-injective; length-++; map-++-commute; sum-++-commute; map-tabulate)
     public
 
+  open import Data.List.Relation.Binary.Subset.Propositional
+    renaming (_⊆_ to _⊆List_)
+    public
+
+
   open import Data.List.Relation.Unary.Any
     using (Any; here; there)
     renaming (lookup to Any-lookup; map to Any-map; satisfied to Any-satisfied

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -1,6 +1,6 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020 Oracle and/or its affiliates.
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 -- This is a selection of useful functions and definitions

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -319,3 +319,6 @@ module LibraBFT.Prelude where
   Any-satisfied-∈ (here px) = _ , (px , here refl)
   Any-satisfied-∈ (there p) = let (a , px , prf) = Any-satisfied-∈ p
                                in (a , px , there prf)
+
+  f-sum : ∀{a}{A : Set a} → (A → ℕ) → List A → ℕ
+  f-sum f = sum ∘ List-map f

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -130,7 +130,8 @@ module LibraBFT.Prelude where
 
   open import Data.Fin
     using (Fin; suc; zero; fromℕ; fromℕ< ; toℕ ; cast)
-    renaming (_≟_ to _≟Fin_; _≤_ to _≤Fin_ ; _<_ to _<Fin_; inject₁ to Fin-inject₁; inject+ to Fin-inject+)
+    renaming (_≟_ to _≟Fin_; _≤?_ to _≤?Fin_; _≤_ to _≤Fin_ ; _<_ to _<Fin_;
+              inject₁ to Fin-inject₁; inject+ to Fin-inject+)
     public
 
   fins : (n : ℕ) → List (Fin n)
@@ -195,7 +196,7 @@ module LibraBFT.Prelude where
   if-dec x then f else g = if-yes x then const f else const g
 
   open import Relation.Nullary.Negation
-    using (contradiction)
+    using (contradiction; contraposition)
     public
 
   open import Relation.Binary

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -36,7 +36,7 @@ module LibraBFT.Prelude where
 
   open import Data.List.Properties
     renaming (≡-dec to List-≡-dec; length-map to List-length-map; map-compose to List-map-compose)
-    using (∷-injective; length-++; map-++-commute; sum-++-commute; map-tabulate)
+    using (∷-injective; length-++; map-++-commute; sum-++-commute; map-tabulate; ++-identityʳ)
     public
 
   open import Data.List.Relation.Binary.Subset.Propositional


### PR DESCRIPTION
Addressed `TODO-1` of proving bft-lemma using the `allDistinct` data type instead of the `IsSorted` used before. 