### PR TITLE
Generalize system model, eliminate duplicated `NodeId` type and add some properties

### DIFF
--- a/LibraBFT/Abstract/Types/EpochConfig.agda
+++ b/LibraBFT/Abstract/Types/EpochConfig.agda
@@ -56,6 +56,17 @@ module LibraBFT.Abstract.Types.EpochConfig
 
   open EpochConfig
 
+  module _ (ec : EpochConfig) where
+    NodeId-PK-OK : PK → NodeId → Set
+    NodeId-PK-OK pk pid = ∃[ m ] (toNodeId ec m ≡ pid × getPubKey ec m ≡ pk)
+
+    NodeId-PK-OK-injective : ∀ {pk pid1 pid2}
+                           → NodeId-PK-OK pk pid1
+                           → NodeId-PK-OK pk pid2
+                           → pid1 ≡ pid2
+    NodeId-PK-OK-injective (m1 , pid1 , pk1) (m2 , pid2 , pk2)
+       rewrite PK-inj ec (trans pk1 (sym pk2)) = trans (sym pid1) pid2
+
   record EpochConfigFor (eid : ℕ) : Set₁ where
     field
      epochConfig : EpochConfig

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -9,7 +9,7 @@ import      LibraBFT.Concrete.Properties.VotesOnce   as VO
 import      LibraBFT.Concrete.Properties.LockedRound as LR
 open import LibraBFT.Impl.Consensus.Types hiding (EpochConfigFor)
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
 
 -- This module collects in one place the obligations an
 -- implementation must meet in order to enjoy the properties

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -9,7 +9,7 @@ open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
 
 -- In this module, we assume that the implementation meets its
 -- obligations, and use this assumption to prove that, in any reachable

--- a/LibraBFT/Concrete/Properties/LockedRound.agda
+++ b/LibraBFT/Concrete/Properties/LockedRound.agda
@@ -15,7 +15,7 @@ open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
 
 -- This module contains placeholders for the future analog of the
 -- corresponding VotesOnce property.  Defining the implementation

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -16,7 +16,7 @@ open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
 
 -- This module defines an abstract system state given a reachable
 -- concrete system state.

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -11,7 +11,7 @@ open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open        EpochConfig
-open import LibraBFT.Yasm.Base NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN
+open import LibraBFT.Yasm.Base (ℓ+1 0ℓ) EpochConfig epochId authorsN
 
 -- In this module, we instantiate the system model with parameters to
 -- model a system using the simple implementation model we have so

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -12,7 +12,7 @@ open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm NodeId (ℓ+1 0ℓ) EpochConfig epochId authorsN getPubKey ConcSysParms
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
 
 -- In this module, we will prove a structural property that any new signed message produced by an
 -- honest handler from a reachable state correctly identifies the sender, and is for a valid epoch
@@ -51,11 +51,11 @@ module LibraBFT.Impl.Properties.Aux where
      | vote∈vm {v} {si}
      with MsgWithSig∈? {pk} {ver-signature ver} {msgPool st}
   ...| yes msg∈ = inj₂ msg∈
-  ...| no  msg∉ = inj₁ ((mkValidPartForPK      {! epoch !} -- We will need an invariant that says the epoch
-                                                           -- used by a voter is "in range".
-                                               (EC-lookup' (availEpochs st) {!!})
-                                               refl
-                                               {! !}       -- The implementation will need to check that the voter is a member of
-                                                           -- the epoch of the message it's sending.
-                                               refl)
+  ...| no  msg∉ = inj₁ ((mkValidSenderForPK      {! epoch !} -- We will need an invariant that says the epoch
+                                                             -- used by a voter is "in range".
+                                                 (EC-lookup' (availEpochs st) {!!})
+                                                 refl
+                                                 {! !}       -- The implementation will need to check that the voter is a member of
+                                                             -- the epoch of the message it's sending.
+                                                 )
                         , msg∉)

--- a/LibraBFT/Yasm/AvailableEpochs.agda
+++ b/LibraBFT/Yasm/AvailableEpochs.agda
@@ -18,7 +18,7 @@ module LibraBFT.Yasm.AvailableEpochs
    (epochId     : EpochConfig → ℕ)
    (authorsN    : EpochConfig → ℕ)
  where
- open import LibraBFT.Yasm.Base NodeId ℓ-EC EpochConfig epochId authorsN
+ open import LibraBFT.Yasm.Base ℓ-EC EpochConfig epochId authorsN
 
  fin-lower-toℕ : ∀{e}(i : Fin (suc e))(prf : e ≢ toℕ i) → toℕ (Fin.lower₁ i prf) ≡ toℕ i
  fin-lower-toℕ {zero} zero prf = ⊥-elim (prf refl)
@@ -66,6 +66,11 @@ module LibraBFT.Yasm.AvailableEpochs
 
  lookup'' : ∀{e m} → AvailableEpochs e → m < e → EpochConfig
  lookup'' 𝓔s ix = lookup' 𝓔s (fromℕ< ix)
+
+ lookup-𝓔s-injective : ∀ {e m1 m2} → (𝓔s : AvailableEpochs e)
+                     → (p1 : m1 < e) → (p2 : m2 < e) → m1 ≡ m2
+                     → lookup'' 𝓔s p1 ≡ lookup'' 𝓔s p2
+ lookup-𝓔s-injective {e} 𝓔s p1 p2 refl = cong (lookup'' 𝓔s) (<-irrelevant p1 p2)
 
  -- The /transpose/ of append is defined by the semantics of a lookup
  -- over an append; the /append/ function below is defined by tabulating this

--- a/LibraBFT/Yasm/Base.agda
+++ b/LibraBFT/Yasm/Base.agda
@@ -9,7 +9,6 @@ open import LibraBFT.Base.PKCS
 -- This module defines the types used to define a SystemModel.
 
 module LibraBFT.Yasm.Base
-  (NodeId      : Set)
   (ℓ-EC        : Level)
   (EpochConfig : Set ℓ-EC)
   (epochId     : EpochConfig → ℕ)

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -13,83 +13,93 @@ import      LibraBFT.Yasm.Base as LYB
 -- paramaterized by some SystemParameters.
 
 module LibraBFT.Yasm.Properties
-   (NodeId      : Set)
    (ℓ-EC        : Level)
    (EpochConfig : Set ℓ-EC)
    (epochId     : EpochConfig → EpochId)
    (authorsN    : EpochConfig → ℕ)
-   (getPubKey   : (ec : EpochConfig) → LYB.Member NodeId ℓ-EC EpochConfig epochId authorsN ec → PK)
-   (parms       : LYB.SystemParameters NodeId ℓ-EC EpochConfig epochId authorsN)
+   (parms       : LYB.SystemParameters ℓ-EC EpochConfig epochId authorsN)
+   -- In addition to the parameters used by the rest of the system model, this module
+   -- needs to relate Members to PKs and PeerIds, so that StepPeerState-AllValidParts
+   -- can be defined.  This enables the application to prove that honest peers sign
+   -- new messages only for their own public key.  The system model does not know that
+   -- directly.
+   (senderPKOK  : (ec : EpochConfig) → PK → LYB.SystemParameters.PeerId parms → Set)
   where
- open import LibraBFT.Yasm.AvailableEpochs NodeId ℓ-EC EpochConfig epochId authorsN
-             using (AvailableEpochs) renaming (lookup'' to EC-lookup)
- import      LibraBFT.Yasm.AvailableEpochs NodeId ℓ-EC EpochConfig epochId authorsN
-             as AE
- open import LibraBFT.Yasm.Base            NodeId ℓ-EC EpochConfig epochId authorsN
- open import LibraBFT.Yasm.System NodeId ℓ-EC EpochConfig epochId authorsN parms
  open LYB.SystemParameters parms
+ open import LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epochId authorsN
+             using (AvailableEpochs) renaming (lookup'' to EC-lookup)
+ import      LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epochId authorsN
+             as AE
+ open import LibraBFT.Yasm.Base   ℓ-EC EpochConfig epochId authorsN
+ open import LibraBFT.Yasm.System ℓ-EC EpochConfig epochId authorsN parms
 
  -- A ValidPartForPK collects the assumptions about what a /part/ in the outputs of an honest verifier
  -- satisfies: (i) the epoch field is consistent with the existent epochs and (ii) the verifier is
  -- a member of the associated epoch config, and (iii) has the given PK in that epoch.
- record ValidPartForPK {e}(𝓔s : AvailableEpochs e)(part : Part)(pk : PK) : Set ℓ-EC where
-   constructor mkValidPartForPK
+ record ValidSenderForPK {e}(𝓔s : AvailableEpochs e)(part : Part)(sender : PeerId)(pk : PK) : Set ℓ-EC where
+   constructor mkValidSenderForPK
    field
      vp-epoch           : part-epoch part < e
      vp-ec              : EpochConfig
      vp-ec-≡            : AE.lookup'' 𝓔s vp-epoch ≡ vp-ec
-     vp-member          : Member vp-ec
-     vp-key             : getPubKey vp-ec vp-member ≡ pk
- open ValidPartForPK public
+     vp-sender-ok       : senderPKOK vp-ec pk sender
+ open ValidSenderForPK public
 
  -- A valid part remains valid when new epochs are added
- ValidPartForPK-stable-epoch : ∀{e part pk}{𝓔s : AvailableEpochs e}(𝓔 : EpochConfigFor e)
-                          → ValidPartForPK 𝓔s part pk
-                          → ValidPartForPK (AE.append 𝓔 𝓔s) part pk
- ValidPartForPK-stable-epoch {pk = pk} {𝓔s} 𝓔 (mkValidPartForPK e ec refl emem vpk) = record
+ ValidSenderForPK-stable-epoch : ∀{e part α pk}{𝓔s : AvailableEpochs e}(𝓔 : EpochConfigFor e)
+                               → ValidSenderForPK 𝓔s part α pk
+                               → ValidSenderForPK (AE.append 𝓔 𝓔s) part α pk
+ ValidSenderForPK-stable-epoch {pk = pk} {𝓔s = 𝓔s} 𝓔 (mkValidSenderForPK e ec refl vpk) = record
    { vp-epoch           = ≤-step e
    ; vp-ec              = ec
    ; vp-ec-≡            = AE.lookup''-≤-step-lemma 𝓔s 𝓔 e
-   ; vp-member          = emem
-   ; vp-key             = vpk
+   ; vp-sender-ok       = vpk
    }
 
  -- A valid part remains valid
- ValidPartForPK-stable : ∀{e e'}{st : SystemState e}{st' : SystemState e'}
+ ValidSenderForPK-stable : ∀{e e' α}{st : SystemState e}{st' : SystemState e'}
                     → Step* st st' → ∀{part pk}
-                    → ValidPartForPK (availEpochs st) part pk
-                    → ValidPartForPK (availEpochs st') part pk
- ValidPartForPK-stable step-0 v = v
- ValidPartForPK-stable (step-s st (step-epoch 𝓔)) v
-   = ValidPartForPK-stable-epoch 𝓔 (ValidPartForPK-stable st v)
- ValidPartForPK-stable (step-s st (step-peer _)) v
-   = ValidPartForPK-stable st v
+                    → ValidSenderForPK (availEpochs st) part α pk
+                    → ValidSenderForPK (availEpochs st') part α pk
+ ValidSenderForPK-stable step-0 v = v
+ ValidSenderForPK-stable (step-s st (step-epoch 𝓔)) v
+   = ValidSenderForPK-stable-epoch 𝓔 (ValidSenderForPK-stable st v)
+ ValidSenderForPK-stable (step-s st (step-peer _)) v
+   = ValidSenderForPK-stable st v
+
+ sameEpoch⇒sameEC : ∀ {e p1 p2 α1 α2 pk1 pk2}{𝓔s : AvailableEpochs e}
+                    → (vp1 : ValidSenderForPK 𝓔s p1 α1 pk1)
+                    → (vp2 : ValidSenderForPK 𝓔s p2 α2 pk2)
+                    → part-epoch p1 ≡ part-epoch p2
+                    → vp-ec vp1 ≡ vp-ec vp2
+ sameEpoch⇒sameEC {𝓔s = 𝓔s} vp1 vp2 parts≡ =
+   trans (sym (vp-ec-≡ vp1))
+         (trans (AE.lookup-𝓔s-injective 𝓔s (vp-epoch vp1) (vp-epoch vp2) parts≡)
+                (vp-ec-≡ vp2))
 
  -- We say that an implementation produces only valid parts iff all parts of every message in the
- -- output of a 'StepPeerState' are either: (i) a valid new part (i.e., the part is valid and has
- -- not been included in a previously sent message with the same signature), or (ii) the part been
- -- included in a previously sent message with the same signature.
+ -- output of a 'StepPeerState' are either: (i) a valid new part (i.e., the part is valid and no
+ -- message with the same signature has been sent previously), or (ii) a message has been sent
+ -- with the same signature.
  StepPeerState-AllValidParts : Set ℓ-EC
- StepPeerState-AllValidParts = ∀{e s m part pk outs α}{𝓔s : AvailableEpochs e}{st : SystemState e}
+ StepPeerState-AllValidParts = ∀{e s m part pk outs}{α}{𝓔s : AvailableEpochs e}{st : SystemState e}
    → (r : ReachableSystemState st)
    → Meta-Honest-PK pk
    → StepPeerState α 𝓔s (msgPool st) (Map-lookup α (peerStates st)) s outs
    → m ∈ outs → part ⊂Msg m → (ver : WithVerSig pk part)
-                                 -- NOTE: this doesn't DIRECTLY imply that nobody else has sent a
-                                 -- message with the same signature just that the author of the part
-                                 -- hasn't.
-   → (ValidPartForPK 𝓔s part pk × ¬ (MsgWithSig∈ pk (ver-signature ver) (msgPool st)))
+   → (ValidSenderForPK 𝓔s part α pk × ¬ (MsgWithSig∈ pk (ver-signature ver) (msgPool st)))
    ⊎ MsgWithSig∈ pk (ver-signature ver) (msgPool st)
 
  -- A /part/ was introduced by a specific step when:
  IsValidNewPart : ∀{e e'}{pre : SystemState e}{post : SystemState e'} → Signature → PK → Step pre post → Set ℓ-EC
  IsValidNewPart _ _ (step-epoch _) = Lift ℓ-EC ⊥
  -- said step is a /step-peer/ and
- IsValidNewPart {pre = pre} sig pk (step-peer pstep)
+ IsValidNewPart {pre = pre} sig pk (step-peer {pid = pid} pstep)
     -- the part has never been seen before
-    = ¬ (MsgWithSig∈ pk sig (msgPool pre))
+    = ReachableSystemState pre
+    × ¬ (MsgWithSig∈ pk sig (msgPool pre))
     × Σ (MsgWithSig∈ pk sig (msgPool (StepPeer-post pstep)))
-        (λ m → ValidPartForPK (availEpochs pre) (msgPart m) pk)
+        (λ m → ValidSenderForPK (availEpochs pre) (msgPart m) (msgSender m) pk)
 
  -- When we can prove that the implementation provided by 'parms' at the
  -- top of this module satisfies 'StepPeerState-AllValidParts', we can
@@ -135,7 +145,7 @@ module LibraBFT.Yasm.Properties
         | step-honest x
         | (m , refl , m∈outs)
         | inj₁ (valid-part , notBefore) =
-               step-here tr (notBefore , MsgWithSig∈-++ˡ (mkMsgWithSig∈ _ _ p⊂m β thisStep sig refl)
+               step-here tr (tr , notBefore , MsgWithSig∈-++ˡ (mkMsgWithSig∈ _ _ p⊂m β thisStep sig refl)
                                        , valid-part)
 
      -- Unwind is inconvenient to use by itself because we have to do
@@ -148,17 +158,19 @@ module LibraBFT.Yasm.Properties
                      → Meta-Honest-PK pk
                      → v ⊂Msg nm → (sender , nm) ∈ msgPool st → (ver : WithVerSig pk v)
                      → Σ (MsgWithSig∈ pk (ver-signature ver) (msgPool st))
-                         (λ msg → (ValidPartForPK (availEpochs st) (msgPart msg) pk))
+                         (λ msg → (ValidSenderForPK (availEpochs st) (msgPart msg) (msgSender msg) pk))
      honestPartValid {e} {st} r {pk = pk} hpk v⊂m m∈pool ver
      -- We extract two pieces of important information from the place where the part 'v'
      -- was first sent: (a) there is a message with the same signature /in the current pool/
      -- and (b) its epoch is less than e.
         = Any-Step-elim (λ { {st = step-epoch _} ()
-                           ; {st = step-peer ps} (_ , new , valid) tr
+                           ; {st = step-peer {pid = pid} ps} (_ , _ , new , valid) tr
                              →  MsgWithSig∈-Step* tr new
-                                , ValidPartForPK-stable tr
-                                    (subst (λ P → ValidPartForPK _ P pk)
-                                           (MsgWithSig∈-Step*-part tr new) valid)
+                                , ValidSenderForPK-stable tr (subst (λ P → ValidSenderForPK _ P (msgSender (MsgWithSig∈-Step* tr new)) pk)
+                                                                         (MsgWithSig∈-Step*-part tr new)
+                                                                         (subst (λ sndr → ValidSenderForPK _ _ sndr pk)
+                                                                                (MsgWithSig∈-Step*-sender tr new)
+                                                                                valid))
                            })
                         (unwind r hpk v⊂m m∈pool ver)
 
@@ -174,10 +186,10 @@ module LibraBFT.Yasm.Properties
        -- then either the part is a valid part by α (meaning that α can
        -- sign the part itself) or a message with the same signature has
        -- been sent previously.
-       → ValidPartForPK (availEpochs st) part pk
+       → ValidSenderForPK (availEpochs st) part α pk
        ⊎ MsgWithSig∈ pk (ver-signature sig) (msgPool st)
      ext-unforgeability' (step-s st (step-epoch 𝓔)) m∈sm p⊆m sig hpk
-       = ⊎-map (ValidPartForPK-stable-epoch 𝓔) id (ext-unforgeability' st m∈sm p⊆m sig hpk)
+       = ⊎-map (ValidSenderForPK-stable-epoch 𝓔) id (ext-unforgeability' st m∈sm p⊆m sig hpk)
      ext-unforgeability' {part = part} (step-s st (step-peer {pid = β} {outs = outs} {pre = pre} sp)) m∈sm p⊆m sig hpk
        with Any-++⁻ (List-map (β ,_) outs) {msgPool pre} m∈sm
      ...| inj₂ furtherBack = MsgWithSig∈-++ʳ <⊎$> (ext-unforgeability' st furtherBack p⊆m sig hpk)
@@ -189,7 +201,7 @@ module LibraBFT.Yasm.Properties
        with isCheat p⊆m sig
      ...| inj₁ abs    = ⊥-elim (hpk abs)
      ...| inj₂ sentb4 = inj₂ (MsgWithSig∈-++ʳ sentb4)
-     ext-unforgeability' {m = m} {part = part} (step-s st (step-peer {pid = β} {outs = outs} {pre = pre} sp)) m∈sm p⊆m sig hpk
+     ext-unforgeability' {α = α} {m = m} {part = part} (step-s st (step-peer {pid = β} {outs = outs} {pre = pre} sp)) m∈sm p⊆m sig hpk
         | inj₁ thisStep
         | step-honest x
        with Any-satisfied-∈ (Any-map⁻ thisStep)
@@ -231,12 +243,12 @@ module LibraBFT.Yasm.Properties
                             → Meta-Honest-PK pk
                             → MsgWithSig∈ pk sig (msgPool st)
                             → Σ (MsgWithSig∈ pk sig (msgPool st))
-                                λ mws → ValidPartForPK (availEpochs st) (msgPart mws) pk
+                                λ mws → ValidSenderForPK (availEpochs st) (msgPart mws) (msgSender mws) pk
      msgWithSigSentByAuthor step-0 _ ()
      msgWithSigSentByAuthor (step-s {pre = pre} preach (step-epoch 𝓔)) hpk mws
        rewrite step-epoch-does-not-send pre 𝓔
           with msgWithSigSentByAuthor preach hpk mws
-     ...| mws' , vpb =  mws' , ValidPartForPK-stable {st = pre} (step-s step-0 (step-epoch 𝓔)) vpb
+     ...| mws' , vpb =  mws' , ValidSenderForPK-stable {st = pre} (step-s step-0 (step-epoch 𝓔)) vpb
      msgWithSigSentByAuthor {pk = pk} (step-s {pre = pre} preach (step-peer theStep@(step-cheat fm cheatCons))) hpk mws
         with (¬cheatForgeNew theStep refl unit hpk mws)
      ...| mws'

--- a/LibraBFT/Yasm/Yasm.agda
+++ b/LibraBFT/Yasm/Yasm.agda
@@ -11,16 +11,16 @@ import      LibraBFT.Yasm.Base as LYB
 -- This module provides a single import for all Yasm modules
 
 module LibraBFT.Yasm.Yasm
-   (NodeId      : Set)
    (ℓ-EC        : Level)
    (EpochConfig : Set ℓ-EC)
    (epochId     : EpochConfig → EpochId)
    (authorsN    : EpochConfig → ℕ)
-   (getPubKey   : (ec : EpochConfig) → LYB.Member NodeId ℓ-EC EpochConfig epochId authorsN ec → PK)
-   (parms       : LYB.SystemParameters NodeId ℓ-EC EpochConfig epochId authorsN)
+   (parms       : LYB.SystemParameters ℓ-EC EpochConfig epochId authorsN)
+   (senderPKOK  : (ec : EpochConfig) → PK → LYB.SystemParameters.PeerId parms → Set)
   where
- open import LibraBFT.Yasm.AvailableEpochs NodeId ℓ-EC EpochConfig epochId authorsN
-             using (AvailableEpochs) renaming (lookup' to EC-lookup; lookup'' to EC-lookup')   public
- open import LibraBFT.Yasm.Base       NodeId ℓ-EC EpochConfig epochId authorsN                 public
- open import LibraBFT.Yasm.System     NodeId ℓ-EC EpochConfig epochId authorsN           parms public
- open import LibraBFT.Yasm.Properties NodeId ℓ-EC EpochConfig epochId authorsN getPubKey parms public
+ open LYB.SystemParameters parms
+ open import LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epochId authorsN
+             using (AvailableEpochs) renaming (lookup' to EC-lookup; lookup'' to EC-lookup') public
+ open import LibraBFT.Yasm.Base       ℓ-EC EpochConfig epochId authorsN                      public
+ open import LibraBFT.Yasm.System     ℓ-EC EpochConfig epochId authorsN parms                public
+ open import LibraBFT.Yasm.Properties ℓ-EC EpochConfig epochId authorsN parms senderPKOK     public


### PR DESCRIPTION
This pull request:
* Eliminates an unintentionally duplicated `NodeId` type
* Generalises the system model by eliminating the assumption that each peer in an epoch can sign new messages for exactly one public key, replacing this with a predicate over peers and public keys
* Adds some properties that will be used in future proofs, namely:
   *  `lookup-𝓔s-injective`
   *  `sameEpoch⇒sameEC`
   *  `cheatStepDNMPeerStates` (postulated, for now)
   *  `peersRemainInitialized` (postulated, for now)
   *  `Any-Step-⇒`
* Minor renaming for intuition