### PR TITLE
Prove `VotesOnce` properties for fake implementation

### DIFF
--- a/LibraBFT/Concrete/Records.agda
+++ b/LibraBFT/Concrete/Records.agda
@@ -70,23 +70,6 @@ module LibraBFT.Concrete.Records (𝓔 : EpochConfig) where
             ; ₋cveIsAbs       = refl
             }
 
- voteInEvidence≈rebuiltVote
-        : ∀ {vd cqc valid as}
-        → (as∈cqc : Any (_≡_ as) (qcVotes cqc))
-        → (ev : ConcreteVoteEvidence vd)
-        → vd ≡ α-Vote cqc valid as∈cqc
-        → ₋cveVote ev ≈Vote rebuildVote cqc as
- voteInEvidence≈rebuiltVote {_} {cqc} {valid} {α , sig , ord} as∈cqc ev refl
-   = equivVotes (cong abs-vBlockUID (₋cveIsAbs ev))
-                (cong abs-vRound (₋cveIsAbs ev))
-                (member≡⇒author≡
-                  (isJust (₋ivvAuthor (₋cveIsValidVote ev)))
-                  (isJust (₋ivvAuthor (All-lookup (₋ivqcVotesValid valid) as∈cqc)))
-                  (trans (to-witness-isJust-≡ {prf = ₋ivvAuthor (₋cveIsValidVote ev)})
-                         (trans (cong abs-vMember (₋cveIsAbs ev))
-                                (sym (to-witness-isJust-≡ {prf = ₋ivvAuthor (All-lookup (₋ivqcVotesValid valid) as∈cqc)}))))
-                )
-
  α-QC : Σ QuorumCert IsValidQC → Abs.QC
  α-QC (qc , valid) = record
    { qCertBlockId = qc ^∙ qcVoteData ∙ vdProposed ∙ biId

--- a/LibraBFT/Impl/Consensus/ChainedBFT/EventProcessor/Properties.agda
+++ b/LibraBFT/Impl/Consensus/ChainedBFT/EventProcessor/Properties.agda
@@ -1,0 +1,31 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+-- This module contains properties that are only about the behavior of the handlers, nothing to do
+-- with system state
+
+open import Optics.All
+open import LibraBFT.Prelude
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Util.Util
+
+module LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor.Properties
+  (hash    : BitString → Hash)
+  (hash-cr : ∀{x y} → hash x ≡ hash y → Collision hash x y ⊎ x ≡ y)
+  where
+
+  open import LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor hash hash-cr
+
+  -- The quorum certificates sent in SyncInfo with votes are those from the peer state
+  procPMCerts≡ : ∀ {ts pm pre vm αs}
+               → (SendVote vm αs) ∈ LBFT-outs (processProposalMsg ts pm) pre
+               → vm ^∙ vmSyncInfo ≡ mkSyncInfo (₋epHighestQC pre) (₋epHighestCommitQC pre)
+  procPMCerts≡ (there x)   = ⊥-elim (¬Any[] x)  -- processProposalMsg sends only one vote
+  procPMCerts≡ (here refl) = refl

--- a/LibraBFT/Impl/Consensus/Types.agda
+++ b/LibraBFT/Impl/Consensus/Types.agda
@@ -72,21 +72,27 @@ module LibraBFT.Impl.Consensus.Types where
   -- α-EC will compute this EpochConfig by abstracting away the unecessary
   -- pieces from EventProcessorEC.
   -- TODO-2: update and complete when definitions are updated to more recent version
-  α-EC : Σ EventProcessorEC EventProcessorEC-correct → EpochConfig
+  postulate
+    α-EC : Σ EventProcessorEC EventProcessorEC-correct → EpochConfig
+  {-
   α-EC (epec , ok) =
     let numAuthors = kvm-size (epec ^∙ epValidators ∙ vvAddressToValidatorInfo)
         qsize      = epec ^∙ epValidators ∙ vvQuorumVotingPower
         bizF       = numAuthors ∸ qsize
      in (mkEpochConfig {! someHash?!}
                 (epec ^∙ epEpoch) numAuthors {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!})
+  -}
 
-  α-EC-≡ : (epec1  : EventProcessorEC)
-         → (epec2  : EventProcessorEC)
-         → (vals≡  : (epec1 ^∙ epValidators) ≡ (epec2 ^∙ epValidators))
-         → (epoch≡ : (epec1 ^∙ epEpoch)      ≡ (epec2 ^∙ epEpoch))
-         → (epec1-corr : EventProcessorEC-correct epec1)
-         → α-EC (epec1 , epec1-corr) ≡ α-EC (epec2 , EventProcessorEC-correct-≡ epec1 epec2 vals≡ epec1-corr)
+  postulate
+    α-EC-≡ : (epec1  : EventProcessorEC)
+           → (epec2  : EventProcessorEC)
+           → (vals≡  : (epec1 ^∙ epValidators) ≡ (epec2 ^∙ epValidators))
+           → (epoch≡ : (epec1 ^∙ epEpoch)      ≡ (epec2 ^∙ epEpoch))
+           → (epec1-corr : EventProcessorEC-correct epec1)
+           → α-EC (epec1 , epec1-corr) ≡ α-EC (epec2 , EventProcessorEC-correct-≡ epec1 epec2 vals≡ epec1-corr)
+  {-
   α-EC-≡ epec1 epec2 refl refl epec1-corr = refl
+  -}
 
   -- Finally, the EventProcessor is split in two pieces: those
   -- that are used to make an EpochConfig versus those that
@@ -94,7 +100,6 @@ module LibraBFT.Impl.Consensus.Types where
   record EventProcessor : Set where
     constructor mkEventProcessor
     field
-      ₋epMeta-Msgs    : List NetworkMsg  -- List of messages sent by this peer
       ₋epEC           : EventProcessorEC
       ₋epEC-correct   : EventProcessorEC-correct ₋epEC
       ₋epWithEC       : EventProcessorWithEC (α-EC (₋epEC , ₋epEC-correct))

--- a/LibraBFT/Impl/Consensus/Types.agda
+++ b/LibraBFT/Impl/Consensus/Types.agda
@@ -107,3 +107,22 @@ module LibraBFT.Impl.Consensus.Types where
      -- construction of the EC nor need one, they should be defined in
      -- EventProcessor directly
   open EventProcessor public
+
+  α-EC-EP : EventProcessor → EpochConfig
+  α-EC-EP ep = α-EC ((₋epEC ep) , (₋epEC-correct ep))
+
+  ₋epHighestQC : (ep : EventProcessor) → QuorumCert
+  ₋epHighestQC ep = ₋btHighestQuorumCert ((₋epWithEC ep) ^∙ (lBlockTree (α-EC-EP ep)))
+
+  epHighestQC : Lens EventProcessor QuorumCert
+  epHighestQC = mkLens' ₋epHighestQC
+                        (λ (mkEventProcessor ec ecc (mkEventProcessorWithEC (mkBlockStore bsInner))) qc
+                          → mkEventProcessor ec ecc (mkEventProcessorWithEC (mkBlockStore (record bsInner {₋btHighestQuorumCert = qc}))))
+
+  ₋epHighestCommitQC : (ep : EventProcessor) → QuorumCert
+  ₋epHighestCommitQC ep = ₋btHighestCommitCert ((₋epWithEC ep) ^∙ (lBlockTree (α-EC-EP ep)))
+
+  epHighestCommitQC : Lens EventProcessor QuorumCert
+  epHighestCommitQC = mkLens' ₋epHighestCommitQC
+                        (λ (mkEventProcessor ec ecc (mkEventProcessorWithEC (mkBlockStore bsInner))) qc
+                          → mkEventProcessor ec ecc (mkEventProcessorWithEC (mkBlockStore (record bsInner {₋btHighestCommitCert = qc}))))

--- a/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
@@ -167,13 +167,9 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
                                             -- matter?
              }
 
-  record _≈Vote_ (v1 v2 : Vote) : Set where
-    constructor equivVotes
-    field
-      sameProposed : v1 ^∙ vProposedId ≡ v2 ^∙ vProposedId
-      sameRound    : v1 ^∙ vRound      ≡ v2 ^∙ vRound
-      sameAuthor   : v1 ^∙ vAuthor     ≡ v2 ^∙ vAuthor
-  open _≈Vote_ public
+  -- Two votes are equivalent if they are identical except they may differ on timeout signature
+  _≈Vote_ : (v1 v2 : Vote) → Set
+  v1 ≈Vote v2 = v2 ≡ record v1 { ₋vTimeoutSignature = ₋vTimeoutSignature v2 }
 
   qcVotesKV : QuorumCert → KVMap Author Signature
   qcVotesKV = ₋liwsSignatures ∘ ₋qcSignedLedgerInfo

--- a/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
@@ -421,3 +421,9 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
     -- LogInfo           : InfoLog a          → Output
     SendVote          : VoteMsg → List Author → Output
   open Output public
+
+  SendVote-inj-v : ∀ {x1 x2 y1 y2} → SendVote x1 y1 ≡ SendVote x2 y2 → x1 ≡ x2
+  SendVote-inj-v refl = refl
+
+  SendVote-inj-si : ∀ {x1 x2 y1 y2} → SendVote x1 y1 ≡ SendVote x2 y2 → y1 ≡ y2
+  SendVote-inj-si refl = refl

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -81,11 +81,4 @@ module LibraBFT.Impl.Handle
  -- the form required by the new system model, which does not (yet) support actions other
  -- than send.
  peerStepWrapper : NodeId → NetworkMsg → EventProcessor → EventProcessor × List NetworkMsg
- peerStepWrapper id msg st
-    -- run the handler
-    with peerStep (id , msg) 0 st
- ...| st' , acts
-    -- extract the messages to be sent
-    with List-map msgToSend acts
-    -- send them and record that they were sent in the peer state
- ...| msgs = record st' {₋epMeta-Msgs = ₋epMeta-Msgs st' ++ msgs } , msgs
+ peerStepWrapper id msg st = ×-map₂ (List-map msgToSend) (peerStep (id , msg) 0 st)

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -70,7 +70,7 @@ module LibraBFT.Impl.Handle
  outputsToActions {st} = concat ∘ List-map (outputToActions st)
 
  runHandler : EventProcessor → LBFT Unit → EventProcessor × List (Action NetworkMsg)
- runHandler st handler = ×-map₂ (outputsToActions {st}) (proj₂ (RWST-run handler unit st))
+ runHandler st handler = ×-map₂ (outputsToActions {st}) (proj₂ (LBFT-run handler st))
 
  -- And ultimately, the all-knowing system layer only cares about the
  -- step function.

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -1,9 +1,12 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
-   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+   Copyright (c) 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 {-# OPTIONS --allow-unsolved-metas #-}
+
+-- This module provides some scaffolding to define the handlers for our fake/simple "implementation"
+-- and connect them to the interface of the SystemModel.
 
 open import Optics.All
 open import LibraBFT.Prelude
@@ -23,10 +26,6 @@ open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
 open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
 open        Structural impl-sps-avp
-
-
--- This module provides some scaffolding to define the handlers for our fake/simple "implementation"
--- and connect them to the interface of the SystemModel.
 
 module LibraBFT.Impl.Handle.Properties
   (hash    : BitString → Hash)

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -1,0 +1,47 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+{-# OPTIONS --allow-unsolved-metas #-}
+
+open import Optics.All
+open import LibraBFT.Prelude
+open import LibraBFT.Lemmas
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.Encode
+open import LibraBFT.Base.KVMap
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Util.Util
+
+open import LibraBFT.Impl.Properties.Aux  -- TODO-1: maybe Aux properties should be in this file?
+open import LibraBFT.Concrete.System impl-sps-avp
+open import LibraBFT.Concrete.System.Parameters
+open        EpochConfig
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open        Structural impl-sps-avp
+
+
+-- This module provides some scaffolding to define the handlers for our fake/simple "implementation"
+-- and connect them to the interface of the SystemModel.
+
+module LibraBFT.Impl.Handle.Properties
+  (hash    : BitString → Hash)
+  (hash-cr : ∀{x y} → hash x ≡ hash y → Collision hash x y ⊎ x ≡ y)
+  where
+  open import LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor hash hash-cr
+  open import LibraBFT.Impl.Handle hash hash-cr
+
+  ----- Properties that bridge the system model gap to the handler -----
+
+  postulate -- TODO-1: prove
+   msgsToSendWereSent1 : ∀ {pid ts pm vm} {st : EventProcessor}
+                       → send (V vm) ∈ proj₂ (peerStep (pid , P pm) ts st)
+                       → ∃[ αs ] (SendVote vm αs ∈ LBFT-outs (handle (pid , P pm) ts) st)
+
+   msgsToSendWereSent : ∀ {pid ts nm m} {st : EventProcessor}
+                      → m ∈ proj₂ (peerStepWrapper pid nm st)
+                      → ∃[ vm ] (m ≡ V vm × send (V vm) ∈ proj₂ (peerStep (pid , nm) ts st))

--- a/LibraBFT/Impl/NetworkMsg.agda
+++ b/LibraBFT/Impl/NetworkMsg.agda
@@ -35,12 +35,12 @@ module LibraBFT.Impl.NetworkMsg where
      withVoteSIHighCC : ∀ {vm : VoteMsg}     → vm ^∙ vmSyncInfo ∙ siHighestCommitCert ≡ qc       → qc QC∈NM (V vm)
      withCommitMsg    : ∀ {cm : CommitMsg}   → cm ^∙ cCert ≡ qc                                  → qc QC∈NM (C cm)
 
-  data _⊂Msg_ : Vote → NetworkMsg → Set where
-    vote∈vm : ∀ {v si}
+  data _⊂Msg_ (v : Vote) : NetworkMsg → Set where
+    vote∈vm : ∀ {si}
             → v ⊂Msg (V (mkVoteMsg v si))
-    vote∈qc : ∀ {v vs} {qc : QuorumCert} {nm}
+    vote∈qc : ∀ {vs} {qc : QuorumCert} {nm}
             → vs ∈ qcVotes qc
-            → v ≈Vote (rebuildVote qc vs)
+            → (rebuildVote qc vs) ≈Vote v
             → qc QC∈NM nm
             → v ⊂Msg nm
 

--- a/LibraBFT/Impl/NetworkMsg.agda
+++ b/LibraBFT/Impl/NetworkMsg.agda
@@ -26,6 +26,15 @@ module LibraBFT.Impl.NetworkMsg where
     V : VoteMsg     → NetworkMsg
     C : CommitMsg   → NetworkMsg
 
+  P≢V : ∀ {p v} → P p ≢ V v
+  P≢V ()
+
+  C≢V : ∀ {c v} → C c ≢ V v
+  C≢V ()
+
+  V-inj : ∀ {vm1 vm2} → V vm1 ≡ V vm2 → vm1 ≡ vm2
+  V-inj refl = refl
+
   -- What does it mean for a (concrete) Vote to be represented in a NetworkMsg?
   data _QC∈ProposalMsg_ (qc : QuorumCert) (pm : ProposalMsg) : Set where
      inProposal       : pm ^∙ pmProposal ∙ bBlockData ∙ bdQuorumCert ≡ qc → qc QC∈ProposalMsg pm

--- a/LibraBFT/Impl/NetworkMsg.agda
+++ b/LibraBFT/Impl/NetworkMsg.agda
@@ -27,13 +27,22 @@ module LibraBFT.Impl.NetworkMsg where
     C : CommitMsg   → NetworkMsg
 
   -- What does it mean for a (concrete) Vote to be represented in a NetworkMsg?
+  data _QC∈ProposalMsg_ (qc : QuorumCert) (pm : ProposalMsg) : Set where
+     inProposal       : pm ^∙ pmProposal ∙ bBlockData ∙ bdQuorumCert ≡ qc → qc QC∈ProposalMsg pm
+     inPMSIHighQC     : pm ^∙ pmSyncInfo ∙ siHighestQuorumCert ≡ qc       → qc QC∈ProposalMsg pm
+     inPMSIHighCC     : pm ^∙ pmSyncInfo ∙ siHighestCommitCert ≡ qc       → qc QC∈ProposalMsg pm
+
+  data _QC∈VoteMsg_ (qc : QuorumCert) (vm : VoteMsg) : Set where
+     withVoteSIHighQC : vm ^∙ vmSyncInfo ∙ siHighestQuorumCert ≡ qc       → qc QC∈VoteMsg vm
+     withVoteSIHighCC : vm ^∙ vmSyncInfo ∙ siHighestCommitCert ≡ qc       → qc QC∈VoteMsg vm
+
+  data _QC∈CommitMsg_ (qc : QuorumCert) (cm : CommitMsg) : Set where
+     withCommitMsg    : cm ^∙ cCert ≡ qc                                  → qc QC∈CommitMsg cm
+
   data _QC∈NM_ (qc : QuorumCert) : NetworkMsg → Set where
-     inProposal       : ∀ {pm : ProposalMsg} → pm ^∙ pmProposal ∙ bBlockData ∙ bdQuorumCert ≡ qc → qc QC∈NM (P pm)
-     inPMSIHighQC     : ∀ {pm : ProposalMsg} → pm ^∙ pmSyncInfo ∙ siHighestQuorumCert ≡ qc       → qc QC∈NM (P pm)
-     inPMSIHighCC     : ∀ {pm : ProposalMsg} → pm ^∙ pmSyncInfo ∙ siHighestCommitCert ≡ qc       → qc QC∈NM (P pm)
-     withVoteSIHighQC : ∀ {vm : VoteMsg}     → vm ^∙ vmSyncInfo ∙ siHighestQuorumCert ≡ qc       → qc QC∈NM (V vm)
-     withVoteSIHighCC : ∀ {vm : VoteMsg}     → vm ^∙ vmSyncInfo ∙ siHighestCommitCert ≡ qc       → qc QC∈NM (V vm)
-     withCommitMsg    : ∀ {cm : CommitMsg}   → cm ^∙ cCert ≡ qc                                  → qc QC∈NM (C cm)
+    inP : ∀ {pm} → qc QC∈ProposalMsg pm → qc QC∈NM (P pm)
+    inV : ∀ {vm} → qc QC∈VoteMsg     vm → qc QC∈NM (V vm)
+    inC : ∀ {cm} → qc QC∈CommitMsg   cm → qc QC∈NM (C cm)
 
   data _⊂Msg_ (v : Vote) : NetworkMsg → Set where
     vote∈vm : ∀ {si}

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -37,14 +37,13 @@ module LibraBFT.Impl.Properties.Aux where
      with v⊂m
   ...| vote∈qc vs∈qc rbld≈ qc∈m
      with qc∈m
-  ...| withVoteSIHighQC x = {!x!} -- We will prove that votes represented in the SyncInfo of a
-                                  -- proposal message were sent before, so these will both be inj₂.
+  ...| xxx = {!x!}                -- We will prove that votes represented in the SyncInfo of a
+                                  -- proposal message were sent before, so these will be inj₂.
                                   -- This will be based on an invariant of the implementation, for
                                   -- example that the QCs included in the SyncInfo of a VoteMsg have
                                   -- been sent before.  We will need to use hash injectivity and
                                   -- signature injectivity to ensure a different vote was not sent
                                   -- previously with the same signature.
-  ...| withVoteSIHighCC x = {!!}
 
   impl-sps-avp {pk = pk} {α = α} {st = st} preach hpk (step-msg {sndr , P pm} m∈pool ps≡ eff) m∈outs v⊂m ver
      | here refl

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -48,7 +48,7 @@ module LibraBFT.Impl.Properties.Aux where
 
   impl-sps-avp {pk = pk} {α = α} {st = st} preach hpk (step-msg {sndr , P pm} m∈pool ps≡ eff) m∈outs v⊂m ver
      | here refl
-     | vote∈vm {v} {si}
+     | vote∈vm {si}
      with MsgWithSig∈? {pk} {ver-signature ver} {msgPool st}
   ...| yes msg∈ = inj₂ msg∈
   ...| no  msg∉ = inj₁ ((mkValidSenderForPK      {! epoch !} -- We will need an invariant that says the epoch

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -37,7 +37,9 @@ open        Structural impl-sps-avp
 
 module LibraBFT.Impl.Properties.VotesOnce where
 
-  postulate  -- TODO : prove
+  postulate  -- TODO-2: prove.  Note that these are really just properties about the handler,
+             -- but are currently wrapped up into properties about SystemState.  These should
+             -- probably be "unbundled" and move to LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor
     newVoteSameEpochGreaterRound : ∀ {e 𝓔s pid pool ms s s' outs v m pk}
                                  → StepPeerState {e} pid 𝓔s pool ms s' outs
                                  → ms ≡ just s

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -4,6 +4,9 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 {-# OPTIONS --allow-unsolved-metas #-}
+
+-- This module proves the two "VotesOnce" proof obligations for our fake handler
+
 open import Optics.All
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -3,7 +3,28 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-import LibraBFT.Concrete.Properties.VotesOnce as VO
+{-# OPTIONS --allow-unsolved-metas #-}
+open import Optics.All
+open import LibraBFT.Prelude
+open import LibraBFT.Lemmas
+open import LibraBFT.Base.KVMap
+open import LibraBFT.Base.PKCS
+
+import      LibraBFT.Concrete.Properties.VotesOnce as VO
+open import LibraBFT.Impl.Base.Types
+
+open import LibraBFT.Impl.Consensus.Types hiding (EpochConfigFor)
+open import LibraBFT.Impl.Util.Crypto
+open import LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor.Properties  sha256 sha256-cr
+open import LibraBFT.Impl.Handle                                          sha256 sha256-cr
+open import LibraBFT.Impl.Handle.Properties                               sha256 sha256-cr
+open import LibraBFT.Impl.NetworkMsg
+open import LibraBFT.Impl.Properties.Aux
+open import LibraBFT.Concrete.System impl-sps-avp
+open import LibraBFT.Concrete.System.Parameters
+open        EpochConfig
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open        Structural impl-sps-avp
 
 -- In this module, we (will) prove the two implementation obligations for the VotesOnce rule.  Note
 -- that it is not yet 100% clear that the obligations are the best definitions to use.  See comments
@@ -12,6 +33,213 @@ import LibraBFT.Concrete.Properties.VotesOnce as VO
 -- ambitious properties.
 
 module LibraBFT.Impl.Properties.VotesOnce where
-  postulate  -- TODO-3 : prove
-    vo₁ : VO.ImplObligation₁
-    vo₂ : VO.ImplObligation₂
+
+  postulate  -- TODO : prove
+    newVoteSameEpochGreaterRound : ∀ {e 𝓔s pid pool ms s s' outs v m pk}
+                                 → StepPeerState {e} pid 𝓔s pool ms s' outs
+                                 → ms ≡ just s
+                                 → v  ⊂Msg m → m ∈ outs → (sig : WithVerSig pk v)
+                                 → ¬ MsgWithSig∈ pk (ver-signature sig) pool
+                                 → (v ^∙ vEpoch) ≡ (₋epEC s) ^∙ epEpoch
+                                 × suc ((₋epEC s) ^∙ epLastVotedRound) ≡ (v ^∙ vRound)  -- New vote for higher round than last voted
+                                 × (v ^∙ vRound) ≡ ((₋epEC s') ^∙ epLastVotedRound)     -- Last voted round is round of new vote
+
+    -- Always true, so far, as no epoch changes.
+    noEpochChangeYet : ∀ {e e'}{pre : SystemState e}{post : SystemState e'}{pid}{ppre ppost}
+                        → Step pre post -- Might or might not be a step by pid
+                        → Map-lookup pid (peerStates pre)  ≡ just ppre
+                        → Map-lookup pid (peerStates post) ≡ just ppost
+                        → (₋epEC ppre) ^∙ epEpoch ≡ (₋epEC ppost) ^∙ epEpoch
+
+    -- We resist the temptation to combine this with the noEpochChangeYet because in future there will be epoch changes
+    lastVoteRound-mono' : ∀ {e e'}{pre : SystemState e}{post : SystemState e'}{pid}{ppre ppost}
+                        → Step pre post -- Might or might not be a step by pid
+                        → Map-lookup pid (peerStates pre)  ≡ just ppre
+                        → Map-lookup pid (peerStates post) ≡ just ppost
+                        → (₋epEC ppre) ^∙ epEpoch ≡ (₋epEC ppost) ^∙ epEpoch
+                        → (₋epEC ppre) ^∙ epLastVotedRound ≤ (₋epEC ppost) ^∙ epLastVotedRound
+
+  -- This is the information we can establish about the state after the first time a signature is
+  -- sent, and that we can carry forward to subsequent states, so we can use it to prove
+  -- VO.ImplObligation₁.
+  -- TODO-2: Only lvrcLvr is specific to the property we are proving here, so much of this
+  -- can be refactored into Yasm.Properties, paramerized by a predicate over Part and PeerState,
+  -- along with a proof that every honest peer step preserves it.  This will provide useful
+  -- infrastructure for proving other properties.
+  record LvrCarrier (pk : PK) (sig : Signature) {e} (st : SystemState e) : Set₁ where
+    constructor mkLvrCarrier
+    field
+      lvrcSent    : MsgWithSig∈ pk sig (msgPool st)
+      lvrcValid   : ValidSenderForPK (availEpochs st) (msgPart lvrcSent) (msgSender lvrcSent) pk
+      lvrcSndrSt  : EventProcessor
+      lvrcSndrSt≡ : Map-lookup (msgSender lvrcSent) (peerStates st) ≡ just lvrcSndrSt
+      lvrcLvr     : (msgPart lvrcSent) ^∙ vRound ≤ (₋epEC lvrcSndrSt) ^∙ epLastVotedRound
+  open LvrCarrier
+
+  firstSendEstablishes : ∀ {e} → Vote → PK → SystemState e → SystemStateRel Step
+  firstSendEstablishes _ _ _ (step-epoch _)               = Lift (ℓ+1 0ℓ) ⊥
+  firstSendEstablishes _ _ _ (step-peer (step-cheat _ _)) = Lift (ℓ+1 0ℓ) ⊥
+  firstSendEstablishes {e} v' pk origSt sysStep@(step-peer {e'} {pid'} {pre = pre} pstep@(step-honest _)) =
+                         ( ReachableSystemState pre
+                         × ¬ MsgWithSig∈ pk (signature v' unit) (msgPool pre)
+                         × LvrCarrier pk (signature v' unit) origSt
+                         )
+
+  isValidNewPart⇒fSE : ∀ {e e' pk v'}{pre : SystemState e} {post : SystemState e'} {theStep : Step pre post}
+                     → Meta-Honest-PK pk
+                     → IsValidNewPart (₋vSignature v') pk theStep
+                     → firstSendEstablishes v' pk post theStep
+  isValidNewPart⇒fSE {pre = pre}{theStep = step-peer {pid = β} {outs = outs} pstep} hpk (_ , ¬sentb4 , mws , _)
+     with Any-++⁻ (List-map (β ,_) outs) {msgPool pre} (msg∈pool mws)
+     -- TODO-1 : DRY fail, see proof of unwind, refactor?
+  ...| inj₂ furtherBack = ⊥-elim (¬sentb4 (MsgWithSig∈-transp mws furtherBack))
+  ...| inj₁ thisStep
+     with pstep
+  ...| step-cheat fm isCheat
+     with thisStep
+  ...| here refl
+     with isCheat (msg⊆ mws) (msgSigned mws)
+  ...| inj₁ dis = ⊥-elim (hpk dis)
+  ...| inj₂ sentb4 rewrite msgSameSig mws = ⊥-elim (¬sentb4 sentb4)
+
+  isValidNewPart⇒fSE {e' = e'}{pk}{v'}{pre}{post}{theStep = step-peer {pid = β} {outs = outs} pstep} hpk (r , ¬sentb4 , mws , vpk)
+     | inj₁ thisStep
+     | step-honest x
+     with Any-satisfied-∈ (Any-map⁻ thisStep)
+  ...| nm , refl , nm∈outs
+     with impl-sps-avp {m = msgWhole mws} r hpk x nm∈outs (msg⊆ mws) (msgSigned mws)
+  ...| inj₂ sentb4 rewrite msgSameSig mws = ⊥-elim (¬sentb4 sentb4)
+  ...| inj₁ (vpk' , _)
+     with x
+  ...| step-init _ refl = ⊥-elim (¬Any[] nm∈outs)
+  ...| step-msg {s' = st} m∈pool ms≡ handle≡
+     with sameEpoch⇒sameEC vpk vpk' refl
+  ...| refl
+     with newVoteSameEpochGreaterRound x ms≡ (msg⊆ mws) nm∈outs (msgSigned mws)
+                                       (subst (λ sig → ¬ MsgWithSig∈ pk sig (msgPool pre))
+                                              (sym (msgSameSig mws))
+                                              ¬sentb4)
+  ...| _ , refl , newlvr = r , ¬sentb4
+                         , (mkLvrCarrier mws vpk st Map-set-correct (≤-reflexive newlvr))
+
+  LvrCarrier-transp : ∀ {e e' e'' pk sig} {orig : SystemState e} {pre : SystemState e'}{post : SystemState e''}
+                     → (theStep : Step pre post)
+                     → LvrCarrier pk sig pre
+                     → LvrCarrier pk sig post
+  LvrCarrier-transp {e} {pre = pre} {post} (step-epoch ec) (mkLvrCarrier mws vpk spre spre≡ lvr) =
+    mkLvrCarrier mws (ValidSenderForPK-stable-epoch ec vpk) spre spre≡ lvr
+  LvrCarrier-transp {e' = e'} {pre = pre} {post} sp@(step-peer {pid = pid} {st'} {pre = .pre} sps) (mkLvrCarrier mws vpk spre spre≡ lvr)
+     with sps
+  ...| step-cheat fm isch rewrite cheatStepDNMPeerStates (step-cheat {pre = pre} fm isch) unit =
+                  mkLvrCarrier (MsgWithSig∈-++ʳ mws) vpk spre spre≡ (≤-trans lvr (≤-reflexive refl)) -- PeerStates not changed by cheat steps
+  ...| step-honest (step-init _ handle≡) = {!!}
+                                         -- We cannot prove this yet because
+                                         -- initialEventProcessorAndMessages is faked for now.  We
+                                         -- need to establish rules for what initialization by a
+                                         -- peer pid does.  It must ensure that if pid's new
+                                         -- peerState is for epoch e and has lastVotedRound = r,
+                                         -- then pid has not previously sent any messages containing
+                                         -- votes for the epoch e and for a round higher than r.
+
+  ...| theStep@(step-honest {pid} msgStep@(step-msg {s = s} {s' = s'}{outs = outs} m∈pool ps≡pre handler≡))
+     -- If the epoch doesn't change (which it never does, so far), then the lastVotedRound is
+     -- monotonically nondecreasing for each honest peer step.
+     with Map-lookup (msgSender mws) (peerStates pre) | inspect (Map-lookup (msgSender mws)) (peerStates pre)
+  ...| nothing    | _ = ⊥-elim (maybe-⊥ spre≡ refl)
+  ...| just spre' | [ R ] rewrite just-injective spre≡
+     with peersRemainInitialized (step-peer theStep) R
+  ...| spost , spost≡
+     with lastVoteRound-mono' (step-peer theStep) R spost≡
+  ...| lvrmono = mkLvrCarrier (MsgWithSig∈-++ʳ mws) vpk spost spost≡
+                              (≤-trans lvr (lvrmono (noEpochChangeYet (step-peer theStep) R spost≡)))
+
+  LvrCarrier-transp* : ∀ {e e' pk sig} {start : SystemState e}{final : SystemState e'}
+                     → LvrCarrier pk sig start
+                     → (step* : Step* start final)
+                     → LvrCarrier pk sig final
+  LvrCarrier-transp* lvrc step-0 = lvrc
+  LvrCarrier-transp* {start = start} lvrc (step-s s* s) = LvrCarrier-transp {orig = start} s (LvrCarrier-transp* lvrc s*)
+
+  fSE⇒rnd≤lvr : ∀ {v' pk e'}
+              → {final : SystemState e'}
+              → Meta-Honest-PK pk
+              → ∀ {d d'}{pre : SystemState d} {post : SystemState d'}{theStep : Step pre post}
+              → firstSendEstablishes v' pk post theStep
+              → (step* : Step* post final)
+              → LvrCarrier pk (signature v' unit) final
+  fSE⇒rnd≤lvr _ {theStep = step-epoch _} ()
+  fSE⇒rnd≤lvr {v' = v'} {pk} hpk {pre = pre} {post} {theStep = step-peer {pid = β} {outs = outs} (step-honest sps)}
+              (r , ¬sentb4 , lvrc@(mkLvrCarrier mws vpk spre spre≡ lvr)) step*
+              = LvrCarrier-transp* lvrc step*
+
+  vo₁ : VO.ImplObligation₁
+  -- Initialization doesn't send any messages at all so far.  In future it may send messages, but
+  -- probably not containing Votes?
+  vo₁ r (step-init _ eff) _ _ m∈outs _ _ _ _ _ _ _ _ rewrite cong proj₂ eff = ⊥-elim (¬Any[] m∈outs)
+  vo₁ {e} {pid} {pk = pk} {pre = pre} r (step-msg m∈pool ps≡ hndl≡)
+      {v' = v'} hpk v⊂m m∈outs sig ¬sentb4 vpb v'⊂m' m'∈pool sig' refl rnds≡
+       with newVoteSameEpochGreaterRound {e} {availEpochs pre} {pid}
+                                          (step-msg m∈pool ps≡ hndl≡) ps≡ v⊂m m∈outs sig ¬sentb4
+  ...| eIds≡' , suclvr≡v'rnd , _
+     -- Use unwind to find the step that first sent the signature for v', then Any-Step-elim to
+     -- prove that going from the poststate of that step to pre results in a state in which the
+     -- round of v' is at most the last voted round recorded in the peerState of the peer that
+     -- sent v'
+     with Any-Step-elim {Q = LvrCarrier pk (ver-signature sig') pre}
+                        (fSE⇒rnd≤lvr {v'} hpk)
+                        (Any-Step-⇒ (λ _ ivnp → isValidNewPart⇒fSE hpk ivnp)
+                                    (unwind r hpk v'⊂m' m'∈pool sig'))
+  ...| mkLvrCarrier mws vpf' sndrst sndrst≡ v'rnd≤lvr
+     -- The fake/trivial handler always sends a vote for its current epoch, but for a
+     -- round greater than its last voted round
+     with sameHonestSig⇒sameVoteData hpk (msgSigned mws) sig' (msgSameSig mws)
+  ...| inj₁ hb = ⊥-elim (PerState.meta-sha256-cr pre r hb)
+  ...| inj₂ refl
+     -- Both votes have the same epochID, therefore same EpochConfig
+     with sameEpoch⇒sameEC vpb vpf' refl
+                    -- Both peers are allowed to sign for the same PK, so they are the same peer
+  ...| refl rewrite NodeId-PK-OK-injective (vp-ec vpb) (vp-sender-ok vpb) (vp-sender-ok vpf') |
+                    -- So their peer states are the same
+                    just-injective (trans (sym ps≡) sndrst≡)
+                    -- So we have proved both that the round of v' is ≤ the lastVotedRound of
+                    -- the peer's state and that the round of v' is one greater than that value,
+                    -- which contradicts the original assumption that they are equal
+                    = ⊥-elim (1+n≰n (≤-trans (≤-reflexive suclvr≡v'rnd)
+                                             (≤-trans (≤-reflexive rnds≡) v'rnd≤lvr)))
+
+  vo₂ : VO.ImplObligation₂
+  vo₂ _ (step-init _ eff) _ _ m∈outs _ _ _ _ _ _ _ _ rewrite cong proj₂ eff = ⊥-elim (¬Any[] m∈outs)
+  vo₂ {pk = pk} {st} r (step-msg {pid , nm} {s = ps} _ ps≡ hndl≡) {v} {m} {v'} {m'} hpk v⊂m m∈outs sig vnew vpk v'⊂m' m'∈outs sig' v'new vpk' es≡ rnds≡
+     rewrite cong proj₂ hndl≡
+    with nm
+  ...| P msg
+    with msgsToSendWereSent {pid} {0} {P msg} {m} {ps} m∈outs
+  ...| vm , refl , vmSent
+    with msgsToSendWereSent1 {pid} {0} {msg} {vm} {ps} vmSent
+  ...| _ , v∈outs
+     rewrite SendVote-inj-v  (Any-singleton⁻ v∈outs)
+           | SendVote-inj-si (Any-singleton⁻ v∈outs)
+    with v⊂m
+       -- Rebuilding keeps the same signature, and the SyncInfo included with the
+       -- VoteMsg sent comprises QCs from the peer's state.  Votes represented in
+       -- those QCS have signatures that have been sent before, contradicting the
+       -- assumption that v's signature has not been sent before.
+  ...| vote∈qc {vs = vs} {qc} vs∈qc v≈rbld (inV qc∈m)
+                  rewrite cong ₋vSignature v≈rbld
+                        | procPMCerts≡ {0} {msg} {ps} {vm} v∈outs
+     = ⊥-elim (vnew (qcVotesSentB4 r ps≡ qc∈m refl vs∈qc))
+  ...| vote∈vm {si}
+     with m'
+  ...| P _ = ⊥-elim (P≢V (Any-singleton⁻ m'∈outs))
+  ...| C _ = ⊥-elim (C≢V (Any-singleton⁻ m'∈outs))
+  ...| V vm'
+       -- Because the handler sends only one message, the two VoteMsgs vm and vm' are the same
+     rewrite V-inj (trans (Any-singleton⁻ m'∈outs) (sym (Any-singleton⁻ m∈outs)))
+     with v'⊂m'
+       -- Both votes are the vote in the (single) VoteMsg, so their biIds must be the same
+  ...| vote∈vm = refl
+       -- Here we use the same reasoning as above to show that v' is not new
+  ...| vote∈qc vs∈qc v≈rbld (inV qc∈m)
+                  rewrite cong ₋vSignature v≈rbld
+                        | procPMCerts≡ {0} {msg} {ps} {vm} v∈outs
+     = ⊥-elim (v'new (qcVotesSentB4 r ps≡ qc∈m refl vs∈qc))

--- a/LibraBFT/Impl/Util/Util.agda
+++ b/LibraBFT/Impl/Util/Util.agda
@@ -20,6 +20,12 @@ module LibraBFT.Impl.Util.Util where
   LBFT : Set → Set
   LBFT = RWST Unit Output EventProcessor
 
+  LBFT-run : ∀ {A} → LBFT A → EventProcessor → (A × EventProcessor × List Output)
+  LBFT-run m = RWST-run m unit
+
+  LBFT-outs : ∀ {A} → LBFT A → EventProcessor → List Output
+  LBFT-outs m ep = proj₂ (proj₂ (LBFT-run m ep))
+
   -- Local 'LBFT' monad; which operates only over the part of
   -- the state that /depends/ on the ec; not the part
   -- of the state that /defines/ the ec.


### PR DESCRIPTION
This pull request supersedes #2.  It proves the two implementation obligations for `VotesOnce`.  One (`vo₁`) says that if a handler sends a new vote for a given epoch and round as a previous vote for the same epoch and round signed for the same honest public key, then it is for the same `blockID`.  The other (`vo₂`) says that if a handler sends two votes for the same epoch and round, then they are for the same `blockID`.  (In fact, our fake implementation does not send multiple votes for the same epoch and round, so the proofs are contradictions, but this helps us put the pieces together before we start proofs for a more complete implementation model.)

The proof of `vo₁` demonstrates the use of `unwind` to find where a signature is first introduced, and then proving it establishes a property which can then be carried forward to the current state.

In `LibraBFT.Impl.Handle.Properties`, some properties are proved that bridge the gap between the system model and the (fake) implementation handlers.  One of these (`msgsToSendWereSent1`) is not very general yet; it simply piggybacks on the fake implementation sending all votes to just one peer.

In the same module, the postulated `qcVotesSentB4` represents the future property that honest peers store `QuorumCerts` in their state only of the signatures represented in them have been sent before.  Some implementations might not have that property (for example, the leader of the next round could construct its own vote and include its signature in a `QuorumCert`).  However, in LibraBFT, such a leader sends its vote to itself first, so this property will hold.

Proving `vo₂` required changing the definition of ` ≈Vote` (used by the ` vote∈qc` constructor of `⊂Msg`) to capture that a rebuilt vote has the same signature as represented in the `QuorumCert`.  This change broke the previous proof of `∈QC⇒sent`.  Fixing that resulted in significant simplification because it eliminated an unnecessary "detour" through the abstract `QC` in the previous proof of `vote∈QcProps` (which is now eliminated).

The proof of `vo₁` depends on some postulated properties that are really just about the handler, but are wrapped up into statements relating to `SystemState` transitions.  These should be unbundled, moved somewhere appropriate and proved (see comments in `LibraBFT.Impl.Properties.VotesOnce`).


