### PR TITLE
Proved postulates on System model

### DIFF
--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -23,12 +23,12 @@ module LibraBFT.Concrete.System.Parameters where
  ConcSysParms : SystemParameters
  ConcSysParms = mkSysParms
                  NodeId
+                 _≟_
                  EventProcessor
                  NetworkMsg
                  Vote
                  sig-Vote
                  _⊂Msg_
                  (_^∙ vEpoch)
-                 _≟_
                  initialEventProcessorAndMessages
                  peerStepWrapper

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -29,5 +29,6 @@ module LibraBFT.Concrete.System.Parameters where
                  sig-Vote
                  _⊂Msg_
                  (_^∙ vEpoch)
+                 _≟_
                  initialEventProcessorAndMessages
                  peerStepWrapper

--- a/LibraBFT/Yasm/Base.agda
+++ b/LibraBFT/Yasm/Base.agda
@@ -45,6 +45,9 @@ module LibraBFT.Yasm.Base
     -- Finally, messages must carry an epoch id and might have an author
     part-epoch  : Part → EpochId
 
+    -- A decidable over PeerId's
+    _≟Peer_ : ∀ (p₁ p₂ : PeerId) → Dec (p₁ ≡ p₂)
+
     -- Initializes a potentially-empty state with an EpochConfig
     init : PeerId → EpochConfig → Maybe PeerState → PeerState × List Msg
 

--- a/LibraBFT/Yasm/Base.agda
+++ b/LibraBFT/Yasm/Base.agda
@@ -32,6 +32,7 @@ module LibraBFT.Yasm.Base
   constructor mkSysParms
   field
     PeerId    : Set
+    _≟PeerId_ : ∀ (p₁ p₂ : PeerId) → Dec (p₁ ≡ p₂)
     PeerState : Set
     Msg       : Set
     Part      : Set -- Types of interest that can be represented in Msgs
@@ -44,9 +45,6 @@ module LibraBFT.Yasm.Base
 
     -- Finally, messages must carry an epoch id and might have an author
     part-epoch  : Part → EpochId
-
-    -- A decidable over PeerId's
-    _≟Peer_ : ∀ (p₁ p₂ : PeerId) → Dec (p₁ ≡ p₂)
 
     -- Initializes a potentially-empty state with an EpochConfig
     init : PeerId → EpochConfig → Maybe PeerState → PeerState × List Msg

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -251,13 +251,17 @@ module LibraBFT.Yasm.System
              → (pstep : StepPeer pre pid st' outs)
              → Step pre (StepPeer-post pstep)
 
- postulate -- TODO-1: prove it
-   msgs-stable : ∀ {e e'} {pre : SystemState e} {post : SystemState e'} {m}
-               → (theStep : Step pre post)
-               → m ∈ msgPool pre
-               → m ∈ msgPool post
 
-   peersRemainInitialized : ∀ {e e'} {pre : SystemState e} {post : SystemState e'} {pid}{ppre}
+ msgs-stable : ∀ {e e'} {pre : SystemState e} {post : SystemState e'} {m}
+             → (theStep : Step pre post)
+             → m ∈ msgPool pre
+             → m ∈ msgPool post
+ msgs-stable (step-epoch _)   m∈ = m∈
+ msgs-stable (step-peer {pid = pid} {outs = outs} _) m∈ = Any-++ʳ (List-map (pid ,_) outs) m∈
+
+
+ postulate
+   peersRemainInitialized : ∀ {ppre} {pid} {e e'} {pre : SystemState e} {post : SystemState e'}
                           → (theStep : Step pre post)
                           → Map-lookup pid (peerStates pre) ≡ just ppre
                           → ∃[ ppost ] (Map-lookup pid (peerStates post) ≡ just ppost)

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -256,7 +256,7 @@ module LibraBFT.Yasm.System
              → (theStep : Step pre post)
              → m ∈ msgPool pre
              → m ∈ msgPool post
- msgs-stable (step-epoch _)   m∈ = m∈
+ msgs-stable (step-epoch _) m∈ = m∈
  msgs-stable (step-peer {pid = pid} {outs = outs} _) m∈ = Any-++ʳ (List-map (pid ,_) outs) m∈
 
 
@@ -269,7 +269,7 @@ module LibraBFT.Yasm.System
    with step
  ... | step-cheat _ _ = ppre , trans (cong (Map-lookup pid) Map-set-≡-correct) lkp≡ppre
  ... | step-honest {pidS} {st} {outs} stp
-   with pid ≟Peer pidS
+   with pid ≟PeerId pidS
  ...| yes refl = st , Map-set-correct
  ...| no imp = ppre , trans (sym (Map-set-target-≢ imp)) lkp≡ppre
 

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -273,12 +273,16 @@ module LibraBFT.Yasm.System
  ...| yes refl = st , Map-set-correct
  ...| no imp = ppre , trans (sym (Map-set-target-≢ imp)) lkp≡ppre
 
- postulate -- not used yet, but some proofs could probably be cleaned up using this,
-           -- e.g., prevVoteRnd≤-pred-step in Impl.VotesOnce
-   sendMessages-target : ∀ {m : SenderMsgPair} {sm : SentMessages} {ml : List SenderMsgPair}
-                       → ¬ (m ∈ sm)
-                       → m ∈ (ml ++ sm)
-                       → m ∈ ml
+ -- not used yet, but some proofs could probably be cleaned up using this,
+ -- e.g., prevVoteRnd≤-pred-step in Impl.VotesOnce
+ sendMessages-target : ∀ {m : SenderMsgPair} {sm : SentMessages} {ml : List SenderMsgPair}
+                     → ¬ (m ∈ sm)
+                     → m ∈ (ml ++ sm)
+                     → m ∈ ml
+ sendMessages-target {ml = ml} ¬m∈sm m∈++
+   with Any-++⁻ ml m∈++
+ ...| inj₁ m∈ml = m∈ml
+ ...| inj₂ m∈sm = ⊥-elim (¬m∈sm m∈sm)
 
  step-epoch-does-not-send : ∀ {e} (pre : SystemState e) (𝓔 : EpochConfigFor e)
                             → msgPool (pushEpoch 𝓔 pre) ≡ msgPool pre

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -232,11 +232,12 @@ module LibraBFT.Yasm.System
    ; msgPool    = List-map (pid ,_) outs ++ msgPool pre
    }
 
- postulate
-   cheatStepDNMPeerStates : ∀{e pid st' outs}{pre : SystemState e}
-                          → (theStep : StepPeer pre pid st' outs)
-                          → isCheat theStep
-                          → peerStates (StepPeer-post theStep) ≡ peerStates pre
+
+ cheatStepDNMPeerStates : ∀{e pid st' outs}{pre : SystemState e}
+                        → (theStep : StepPeer pre pid st' outs)
+                        → isCheat theStep
+                        → peerStates (StepPeer-post theStep) ≡ peerStates pre
+ cheatStepDNMPeerStates (step-cheat _ _) _ = Map-set-≡-correct
 
  data Step : ∀{e e'} → SystemState e → SystemState e' → Set ℓ-EC where
    step-epoch : ∀{e}{pre : SystemState e}

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -260,11 +260,18 @@ module LibraBFT.Yasm.System
  msgs-stable (step-peer {pid = pid} {outs = outs} _) m∈ = Any-++ʳ (List-map (pid ,_) outs) m∈
 
 
- postulate
-   peersRemainInitialized : ∀ {ppre} {pid} {e e'} {pre : SystemState e} {post : SystemState e'}
-                          → (theStep : Step pre post)
-                          → Map-lookup pid (peerStates pre) ≡ just ppre
-                          → ∃[ ppost ] (Map-lookup pid (peerStates post) ≡ just ppost)
+ peersRemainInitialized : ∀ {ppre} {pid} {e e'} {pre : SystemState e} {post : SystemState e'}
+                        → (theStep : Step pre post)
+                        → Map-lookup pid (peerStates pre) ≡ just ppre
+                        → ∃[ ppost ] (Map-lookup pid (peerStates post) ≡ just ppost)
+ peersRemainInitialized {ppre} (step-epoch _) lkp≡ppre = ppre , lkp≡ppre
+ peersRemainInitialized {ppre} {pid} (step-peer step) lkp≡ppre
+   with step
+ ... | step-cheat _ _ = ppre , trans (cong (Map-lookup pid) Map-set-≡-correct) lkp≡ppre
+ ... | step-honest {pidS} {st} {outs} stp
+   with pid ≟Peer pidS
+ ...| yes refl = st , Map-set-correct
+ ...| no imp = ppre , trans (sym (Map-set-target-≢ imp)) lkp≡ppre
 
  postulate -- not used yet, but some proofs could probably be cleaned up using this,
            -- e.g., prevVoteRnd≤-pred-step in Impl.VotesOnce


### PR DESCRIPTION
Proved the following postulates on the `LibraBFT.Yasm.System`:
- `cheatStepDNMPeerStates`
- `msgs-stable`
- `sendMessages-target`
- `peersRemainInitialized`

In order to prove the last one I needed to add a new parameter to the `SystemParameters` which is a `Decidable` over `PeerId`. Actually, I think that this new parameter will also be useful for some other lemmas that we may need to prove in future. 