### PR TITLE
Refactor some general parts of `vo1` proof into system model, fix proofs, minor system model changes for convenience

### DIFF
--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -46,7 +46,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    ∀{e pid pid' s' outs pk}{pre : SystemState e}
    → ReachableSystemState pre
    -- For any honest call to /handle/ or /init/,
-   → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) s' outs
+   → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
    → ∀{v m v' m'} → Meta-Honest-PK pk
    -- For signed every vote v of every outputted message
    → v  ⊂Msg m  → m ∈ outs → (sig : WithVerSig pk v)
@@ -68,7 +68,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    ∀{e pid s' outs pk}{pre : SystemState e}
    → ReachableSystemState pre
    -- For any honest call to /handle/ or /init/,
-   → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) s' outs
+   → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
    → ∀{v m v' m'} → Meta-Honest-PK pk
    -- For every vote v represented in a message output by the call
    → v  ⊂Msg m  → m ∈ outs → (sig : WithVerSig pk v)
@@ -192,7 +192,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
     PredStep-wlog-ht' : ∀{e pid pid' s' outs pk}{pre : SystemState e}
             → ReachableSystemState pre
             → Pred pre
-            → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) s' outs
+            → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
             → ∀{v m v' m'}
             → v  ⊂Msg m  → m ∈ outs
             → v' ⊂Msg m' → (pid' , m') ∈ msgPool pre
@@ -263,7 +263,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
     -- outputs of a step.
     PredStep-hh' : ∀{e pid s' outs pk}{pre : SystemState e}
             → ReachableSystemState pre → Pred pre
-            → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) s' outs
+            → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
             → ∀{v m v' m'}
             → v  ⊂Msg m  → m  ∈ outs
             → v' ⊂Msg m' → m' ∈ outs

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -23,6 +23,7 @@ module LibraBFT.Concrete.System.Parameters where
  ConcSysParms : SystemParameters
  ConcSysParms = mkSysParms
                  NodeId
+                 _≟NodeId_
                  EventProcessor
                  NetworkMsg
                  Vote

--- a/LibraBFT/Impl/Base/Types.agda
+++ b/LibraBFT/Impl/Base/Types.agda
@@ -11,6 +11,9 @@ module LibraBFT.Impl.Base.Types where
   NodeId : Set
   NodeId = ℕ
 
+  _≟NodeId_ : (n1 n2 : NodeId) → Dec (n1 ≡ n2)
+  _≟NodeId_ = _≟ℕ_
+
   UID : Set
   UID = Hash
 

--- a/LibraBFT/Impl/Consensus/Types.agda
+++ b/LibraBFT/Impl/Consensus/Types.agda
@@ -72,16 +72,13 @@ module LibraBFT.Impl.Consensus.Types where
   -- α-EC will compute this EpochConfig by abstracting away the unecessary
   -- pieces from EventProcessorEC.
   -- TODO-2: update and complete when definitions are updated to more recent version
-  postulate
-    α-EC : Σ EventProcessorEC EventProcessorEC-correct → EpochConfig
-  {-
+  α-EC : Σ EventProcessorEC EventProcessorEC-correct → EpochConfig
   α-EC (epec , ok) =
     let numAuthors = kvm-size (epec ^∙ epValidators ∙ vvAddressToValidatorInfo)
         qsize      = epec ^∙ epValidators ∙ vvQuorumVotingPower
         bizF       = numAuthors ∸ qsize
      in (mkEpochConfig {! someHash?!}
                 (epec ^∙ epEpoch) numAuthors {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!})
-  -}
 
   postulate
     α-EC-≡ : (epec1  : EventProcessorEC)

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -76,7 +76,7 @@ module LibraBFT.Impl.Handle.Properties
    -- as opposed to using it to construct a QC using its own unsent vote.
    qcVotesSentB4 : ∀{e pid ps vs pk q vm}{st : SystemState e}
                  → ReachableSystemState st
-                 → Map-lookup pid (peerStates st) ≡ just ps
+                 → just ps ≡ Map-lookup pid (peerStates st)
                  → q QC∈VoteMsg vm
                  → vm ^∙ vmSyncInfo ≡ mkSyncInfo (ps ^∙ epHighestQC) (ps ^∙ epHighestCommitQC)
                  → vs ∈ qcVotes q

--- a/LibraBFT/Impl/NetworkMsg.agda
+++ b/LibraBFT/Impl/NetworkMsg.agda
@@ -58,7 +58,7 @@ module LibraBFT.Impl.NetworkMsg where
             → v ⊂Msg (V (mkVoteMsg v si))
     vote∈qc : ∀ {vs} {qc : QuorumCert} {nm}
             → vs ∈ qcVotes qc
-            → (rebuildVote qc vs) ≈Vote v
+            → rebuildVote qc vs ≈Vote v
             → qc QC∈NM nm
             → v ⊂Msg nm
 

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -25,15 +25,15 @@ module LibraBFT.Impl.Properties.Aux where
   -- fake/simple handler does not yet obey the needed properties, so we can't finish this yet.
   impl-sps-avp : StepPeerState-AllValidParts
   -- In our fake/simple implementation, init and handling V and C msgs do not send any messages
-  impl-sps-avp _ hpk (step-init ix eff) m∈outs part⊂m ver        rewrite (cong proj₂ eff) = ⊥-elim (¬Any[] m∈outs)
-  impl-sps-avp _ hpk (step-msg {sndr , V vm} _ _ eff) m∈outs _ _ rewrite (cong proj₂ eff) = ⊥-elim (¬Any[] m∈outs)
-  impl-sps-avp _ hpk (step-msg {sndr , C cm} _ _ eff) m∈outs _ _ rewrite (cong proj₂ eff) = ⊥-elim (¬Any[] m∈outs)
+  impl-sps-avp _ hpk (step-init ix) m∈outs part⊂m ver      = ⊥-elim (¬Any[] m∈outs)
+  impl-sps-avp _ hpk (step-msg {sndr , V vm} _ _) m∈outs _ _ = ⊥-elim (¬Any[] m∈outs)
+  impl-sps-avp _ hpk (step-msg {sndr , C cm} _ _) m∈outs _ _ = ⊥-elim (¬Any[] m∈outs)
   -- These aren't true yet, because processProposalMsgM sends fake votes that don't follow the rules for ValidPartForPK
-  impl-sps-avp preach hpk (step-msg {sndr , P pm} m∈pool ps≡ eff) m∈outs v⊂m ver
+  impl-sps-avp preach hpk (step-msg {sndr , P pm} m∈pool ps≡) m∈outs v⊂m ver
      with m∈outs
      -- Handler sends at most one vote, so it can't be "there"
-  ...| there {xs = xs} imp rewrite proj₂ (∷-injective (cong proj₂ eff)) = ⊥-elim (¬Any[] imp)
-  ...| here refl rewrite proj₁ (∷-injective (cong proj₂ eff))
+  ...| there {xs = xs} imp = ⊥-elim (¬Any[] imp)
+  ...| here refl
      with v⊂m
   ...| vote∈qc vs∈qc rbld≈ qc∈m
      with qc∈m
@@ -45,7 +45,7 @@ module LibraBFT.Impl.Properties.Aux where
                                   -- signature injectivity to ensure a different vote was not sent
                                   -- previously with the same signature.
 
-  impl-sps-avp {pk = pk} {α = α} {st = st} preach hpk (step-msg {sndr , P pm} m∈pool ps≡ eff) m∈outs v⊂m ver
+  impl-sps-avp {pk = pk} {α = α} {st = st} preach hpk (step-msg {sndr , P pm} m∈pool ps≡) m∈outs v⊂m ver
      | here refl
      | vote∈vm {si}
      with MsgWithSig∈? {pk} {ver-signature ver} {msgPool st}

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -38,9 +38,8 @@ open        Structural impl-sps-avp
 
 module LibraBFT.Impl.Properties.VotesOnce where
 
-  postulate  -- TODO-2: prove.  Note that these are really just properties about the handler,
-             -- but are currently wrapped up into properties about SystemState.  These should
-             -- probably be "unbundled" and move to LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor
+  postulate  -- TODO-2: Prove these and move them somewhere appropriate
+             -- (LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor.Properties?)
     newVoteSameEpochGreaterRound : ∀ {e 𝓔s pid pool ms s s' outs v m pk}
                                  → StepPeerState {e} pid 𝓔s pool ms (s' , outs)
                                  → just s ≡ ms

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -41,8 +41,8 @@ module LibraBFT.Impl.Properties.VotesOnce where
              -- but are currently wrapped up into properties about SystemState.  These should
              -- probably be "unbundled" and move to LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor
     newVoteSameEpochGreaterRound : ∀ {e 𝓔s pid pool ms s s' outs v m pk}
-                                 → StepPeerState {e} pid 𝓔s pool ms s' outs
-                                 → ms ≡ just s
+                                 → StepPeerState {e} pid 𝓔s pool ms (s' , outs)
+                                 → just s ≡ ms
                                  → v  ⊂Msg m → m ∈ outs → (sig : WithVerSig pk v)
                                  → ¬ MsgWithSig∈ pk (ver-signature sig) pool
                                  → (v ^∙ vEpoch) ≡ (₋epEC s) ^∙ epEpoch

--- a/LibraBFT/Impl/Util/Util.agda
+++ b/LibraBFT/Impl/Util/Util.agda
@@ -23,6 +23,9 @@ module LibraBFT.Impl.Util.Util where
   LBFT-run : ∀ {A} → LBFT A → EventProcessor → (A × EventProcessor × List Output)
   LBFT-run m = RWST-run m unit
 
+  LBFT-post : ∀ {A} → LBFT A → EventProcessor → EventProcessor
+  LBFT-post m ep = proj₁ (proj₂ (LBFT-run m ep))
+
   LBFT-outs : ∀ {A} → LBFT A → EventProcessor → List Output
   LBFT-outs m ep = proj₂ (proj₂ (LBFT-run m ep))
 

--- a/LibraBFT/Yasm/Base.agda
+++ b/LibraBFT/Yasm/Base.agda
@@ -32,6 +32,7 @@ module LibraBFT.Yasm.Base
   constructor mkSysParms
   field
     PeerId    : Set
+    _≟PeerId_ : (p1 p2 : PeerId) → Dec (p1 ≡ p2)
     PeerState : Set
     Msg       : Set
     Part      : Set -- Types of interest that can be represented in Msgs

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -85,7 +85,7 @@ module LibraBFT.Yasm.Properties
  StepPeerState-AllValidParts = ∀{e s m part pk outs}{α}{𝓔s : AvailableEpochs e}{st : SystemState e}
    → (r : ReachableSystemState st)
    → Meta-Honest-PK pk
-   → StepPeerState α 𝓔s (msgPool st) (Map-lookup α (peerStates st)) s outs
+   → StepPeerState α 𝓔s (msgPool st) (Map-lookup α (peerStates st)) (s , outs)
    → m ∈ outs → part ⊂Msg m → (ver : WithVerSig pk part)
    → (ValidSenderForPK 𝓔s part α pk × ¬ (MsgWithSig∈ pk (ver-signature ver) (msgPool st)))
    ⊎ MsgWithSig∈ pk (ver-signature ver) (msgPool st)

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -283,7 +283,7 @@ module LibraBFT.Yasm.Properties
   record PropCarrier (pk : PK) (sig : Signature) {e} (st : SystemState e) : Set (ℓ-EC ℓ⊔ (ℓ+1 0ℓ)) where
     constructor mkCarrier
     field
-      carrStReach : ReachableSystemState st
+      carrStReach : ReachableSystemState st -- Enables use of invariants when proving that steps preserve carrProp
       carrSent    : MsgWithSig∈ pk sig (msgPool st)
       carrValid   : ValidSenderForPK (availEpochs st) (msgPart carrSent) (msgSender carrSent) pk
       carrSndrSt  : Maybe PeerState

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -188,26 +188,25 @@ module LibraBFT.Yasm.System
 
  -- The pre and post states of Honest peers are related iff
  data StepPeerState {e}(pid : PeerId)(𝓔s : AvailableEpochs e)(pool : SentMessages)
-          : Maybe PeerState → PeerState → List Msg → Set where
+                       (ms : Maybe PeerState) : (PeerState × List Msg) → Set where
    -- The peer receives an "initialization package"; for now, this consists
    -- of the actual EpochConfig for the epoch being initialized.  Later, we
    -- may move to a more general scheme, enabled by assuming a function
    -- 'render : InitPackage -> EpochConfig'.
-   step-init : ∀{ms s' outs}(ix : Fin e)
-             → (s' , outs) ≡ init pid (AE.lookup' 𝓔s ix) ms
-             → StepPeerState pid 𝓔s pool ms s' outs
+   step-init : ∀ (ix : Fin e)
+             → StepPeerState pid 𝓔s pool ms (init pid (AE.lookup' 𝓔s ix) ms)
 
    -- The peer processes a message in the pool
-   step-msg  : ∀{m ms s s' outs}
+   step-msg  : ∀{m s}
              → m ∈ pool
-             → ms ≡ just s → (s' , outs) ≡ handle pid (proj₂ m) s
-             → StepPeerState pid 𝓔s pool ms s' outs
+             → just s ≡ ms
+             → StepPeerState pid 𝓔s pool ms (handle pid (proj₂ m) s)
 
  -- The pre-state of the suplied PeerId is related to the post-state and list of output messages iff:
  data StepPeer {e}(pre : SystemState e) : PeerId → Maybe PeerState → List Msg → Set where
    -- it can be obtained by a handle or init call.
    step-honest : ∀{pid st outs}
-               → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) st outs
+               → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (st , outs)
                → StepPeer pre pid (just st) outs
 
    -- or the peer decides to cheat.  CheatMsgConstraint ensures it cannot


### PR DESCRIPTION
* Replace last two parameters of `StepPeerState` with a pair, matching handler out put type
* Other minor changes to `Yasm` for convenience
* Factor "generic" parts of `vo1` proof into `Yasm.Properties`, redo proof
* Revise and prove postulated properties used by the `vo1` proof
