### PR TITLE
Make `peerStates` total, eliminate pain dealing with `Maybe PeerState`

### DIFF
--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -43,10 +43,10 @@ module LibraBFT.Concrete.Properties.VotesOnce where
 
  ImplObligation₁ : Set₁
  ImplObligation₁ =
-   ∀{e pid pid' s' outs pk}{pre : SystemState e}
+   ∀{e pid pid' inits' s' outs pk}{pre : SystemState e}
    → ReachableSystemState pre
    -- For any honest call to /handle/ or /init/,
-   → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
+   → StepPeerState pid (availEpochs pre) (msgPool pre) (initialised pre) (peerStates pre pid) inits' (s' , outs)
    → ∀{v m v' m'} → Meta-Honest-PK pk
    -- For signed every vote v of every outputted message
    → v  ⊂Msg m  → m ∈ outs → (sig : WithVerSig pk v)
@@ -65,10 +65,10 @@ module LibraBFT.Concrete.Properties.VotesOnce where
 
  ImplObligation₂ : Set₁
  ImplObligation₂ =
-   ∀{e pid s' outs pk}{pre : SystemState e}
+   ∀{e pid inits' s' outs pk}{pre : SystemState e}
    → ReachableSystemState pre
    -- For any honest call to /handle/ or /init/,
-   → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
+   → StepPeerState pid (availEpochs pre) (msgPool pre) (initialised pre) (peerStates pre pid) inits' (s' , outs)
    → ∀{v m v' m'} → Meta-Honest-PK pk
    -- For every vote v represented in a message output by the call
    → v  ⊂Msg m  → m ∈ outs → (sig : WithVerSig pk v)
@@ -189,10 +189,10 @@ module LibraBFT.Concrete.Properties.VotesOnce where
     -- step is at most replaying these votes, not producing them. Producing them would
     -- require the cheater to forge a signature. This is the purpose of the isCheat constraint.
 
-    PredStep-wlog-ht' : ∀{e pid pid' s' outs pk}{pre : SystemState e}
+    PredStep-wlog-ht' : ∀{e pid pid' inits' s' outs pk}{pre : SystemState e}
             → ReachableSystemState pre
             → Pred pre
-            → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
+            → StepPeerState pid (availEpochs pre) (msgPool pre) (initialised pre) (peerStates pre pid) inits' (s' , outs)
             → ∀{v m v' m'}
             → v  ⊂Msg m  → m ∈ outs
             → v' ⊂Msg m' → (pid' , m') ∈ msgPool pre
@@ -261,9 +261,9 @@ module LibraBFT.Concrete.Properties.VotesOnce where
 
     -- Analogous to PredStep-wlog-ht', but here we must reason about two messages that are in the
     -- outputs of a step.
-    PredStep-hh' : ∀{e pid s' outs pk}{pre : SystemState e}
+    PredStep-hh' : ∀{e pid inits' s' outs pk}{pre : SystemState e}
             → ReachableSystemState pre → Pred pre
-            → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
+            → StepPeerState pid (availEpochs pre) (msgPool pre) (initialised pre) (peerStates pre pid) inits' (s' , outs)
             → ∀{v m v' m'}
             → v  ⊂Msg m  → m  ∈ outs
             → v' ⊂Msg m' → m' ∈ outs

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -25,6 +25,7 @@ module LibraBFT.Concrete.System.Parameters where
                  NodeId
                  _≟NodeId_
                  EventProcessor
+                 fakeEP
                  NetworkMsg
                  Vote
                  sig-Vote

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -80,10 +80,10 @@ module LibraBFT.Impl.Handle
  -- And ultimately, the all-knowing system layer only cares about the
  -- step function.
  peerStep : NodeId → NetworkMsg → Instant → EventProcessor → EventProcessor × List (Action NetworkMsg)
- peerStep id msg ts st = runHandler st (handle id msg ts)
+ peerStep nid msg ts st = runHandler st (handle nid msg ts)
 
  -- This (temporary) wrapper bridges the gap between our (draft) concrete handler and
  -- the form required by the new system model, which does not (yet) support actions other
  -- than send.
  peerStepWrapper : NodeId → NetworkMsg → EventProcessor → EventProcessor × List NetworkMsg
- peerStepWrapper id msg st = ×-map₂ (List-map msgToSend) (peerStep id msg 0 st)
+ peerStepWrapper nid msg st = ×-map₂ (List-map msgToSend) (peerStep nid msg 0 st)

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -24,13 +24,18 @@ module LibraBFT.Impl.Handle
  open import LibraBFT.Impl.Consensus.ChainedBFT.EventProcessor hash hash-cr
  open RWST-do
 
+ -- This represents an uninitialised EventProcessor, about which we know nothing, which we use as
+ -- the initial EventProcessor for every peer until it is initialised.
  postulate
    fakeEP : EventProcessor
 
+ -- Eventually, the initialization should establish some properties we care about, but for now we
+ -- just initialise again to fakeEP, which means we cannot prove the base case for various
+ -- properties, e.g., in Impl.Properties.VotesOnce
  initialEventProcessorAndMessages
-     : (a : Author) → EpochConfig → Maybe EventProcessor
+     : (a : Author) → EpochConfig → EventProcessor
      → EventProcessor × List NetworkMsg
- initialEventProcessorAndMessages a _ mep = fakeEP , []
+ initialEventProcessorAndMessages a _ _ = fakeEP , []
 
  handle : NodeId × NetworkMsg → Instant → LBFT Unit
  handle (sender , msg) now

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -37,8 +37,8 @@ module LibraBFT.Impl.Handle
      → EventProcessor × List NetworkMsg
  initialEventProcessorAndMessages a _ _ = fakeEP , []
 
- handle : NodeId × NetworkMsg → Instant → LBFT Unit
- handle (sender , msg) now
+ handle : NodeId → NetworkMsg → Instant → LBFT Unit
+ handle _self msg now
     with msg
  ...| P p = processProposalMsg now p
  ...| V v = processVote now v
@@ -79,11 +79,11 @@ module LibraBFT.Impl.Handle
 
  -- And ultimately, the all-knowing system layer only cares about the
  -- step function.
- peerStep : NodeId × NetworkMsg → Instant → EventProcessor → EventProcessor × List (Action NetworkMsg)
- peerStep msg ts st = runHandler st (handle msg ts)
+ peerStep : NodeId → NetworkMsg → Instant → EventProcessor → EventProcessor × List (Action NetworkMsg)
+ peerStep id msg ts st = runHandler st (handle id msg ts)
 
  -- This (temporary) wrapper bridges the gap between our (draft) concrete handler and
  -- the form required by the new system model, which does not (yet) support actions other
  -- than send.
  peerStepWrapper : NodeId → NetworkMsg → EventProcessor → EventProcessor × List NetworkMsg
- peerStepWrapper id msg st = ×-map₂ (List-map msgToSend) (peerStep (id , msg) 0 st)
+ peerStepWrapper id msg st = ×-map₂ (List-map msgToSend) (peerStep id msg 0 st)

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -36,8 +36,8 @@ module LibraBFT.Impl.Handle.Properties
 
   ----- Properties that bridge the system model gap to the handler -----
   msgsToSendWereSent1 : ∀ {pid ts pm vm} {st : EventProcessor}
-                      → send (V vm) ∈ proj₂ (peerStep (pid , P pm) ts st)
-                      → ∃[ αs ] (SendVote vm αs ∈ LBFT-outs (handle (pid , P pm) ts) st)
+                      → send (V vm) ∈ proj₂ (peerStep pid (P pm) ts st)
+                      → ∃[ αs ] (SendVote vm αs ∈ LBFT-outs (handle pid (P pm) ts) st)
   msgsToSendWereSent1 {pid} {ts} {pm} {vm} {st} send∈acts
      with send∈acts
      -- The fake handler sends only to node 0 (fakeAuthor), so this doesn't
@@ -53,7 +53,7 @@ module LibraBFT.Impl.Handle.Properties
 
   msgsToSendWereSent : ∀ {pid ts nm m} {st : EventProcessor}
                      → m ∈ proj₂ (peerStepWrapper pid nm st)
-                     → ∃[ vm ] (m ≡ V vm × send (V vm) ∈ proj₂ (peerStep (pid , nm) ts st))
+                     → ∃[ vm ] (m ≡ V vm × send (V vm) ∈ proj₂ (peerStep pid nm ts st))
   msgsToSendWereSent {pid} {nm = nm} {m} {st} m∈outs
     with nm
   ...| C _ = ⊥-elim (¬Any[] m∈outs)

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -76,6 +76,7 @@ module LibraBFT.Impl.Handle.Properties
    -- as opposed to using it to construct a QC using its own unsent vote.
    qcVotesSentB4 : ∀{e pid ps vs pk q vm}{st : SystemState e}
                  → ReachableSystemState st
+                 → initialised st pid ≡ initd
                  → ps ≡ peerStates st pid
                  → q QC∈VoteMsg vm
                  → vm ^∙ vmSyncInfo ≡ mkSyncInfo (ps ^∙ epHighestQC) (ps ^∙ epHighestCommitQC)

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -76,7 +76,7 @@ module LibraBFT.Impl.Handle.Properties
    -- as opposed to using it to construct a QC using its own unsent vote.
    qcVotesSentB4 : ∀{e pid ps vs pk q vm}{st : SystemState e}
                  → ReachableSystemState st
-                 → just ps ≡ Map-lookup pid (peerStates st)
+                 → ps ≡ peerStates st pid
                  → q QC∈VoteMsg vm
                  → vm ^∙ vmSyncInfo ≡ mkSyncInfo (ps ^∙ epHighestQC) (ps ^∙ epHighestCommitQC)
                  → vs ∈ qcVotes q

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -149,8 +149,8 @@ module LibraBFT.Impl.Properties.VotesOnce where
   ...| refl
      with newVoteSameEpochGreaterRound r hstep (msg⊆ mws) nm∈outs (msgSigned mws)
                                        (subst (λ sig → ¬ MsgWithSig∈ pk sig (msgPool pre))
-                                               (sym (msgSameSig mws))
-                                               ¬sentb4)
+                                              (sym (msgSameSig mws))
+                                              ¬sentb4)
   ...| refl , refl , newlvr
      with noEpochChangeYet {ppre = peerStates pre β} r refl hstep
   ...| eids≡

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -77,8 +77,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
                    → StepPeerState pid (availEpochs pre) (msgPool pre) (initialised pre) ppre initd' (ppost , msgs)
                    → (₋epEC ppre) ^∙ epEpoch ≡ (₋epEC ppost) ^∙ epEpoch
   noEpochChangeYet _ ppre≡ (step-init ix) = {!!}
-  noEpochChangeYet _ ppre≡ (step-msg {(_ , m)} _ ms≡)
-     rewrite ms≡
+  noEpochChangeYet _ ppre≡ (step-msg {(_ , m)} _ _)
      with m
   ...| P p = refl
   ...| V v = refl

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -40,23 +40,22 @@ module LibraBFT.Impl.Properties.VotesOnce where
 
   -- TODO-1: It seems that vo₂ should be proved via a couple of invocations of this property;
   -- the proofs are quite similar.
-  newVoteSameEpochGreaterRound : ∀ {e}{pre : SystemState e}{pid s s' outs v m pk}
+  newVoteSameEpochGreaterRound : ∀ {e}{pre : SystemState e}{pid initd' s' outs v m pk}
                                → ReachableSystemState pre
-                               → StepPeerState {e} pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
-                               → just s ≡ Map-lookup pid (peerStates pre)
+                               → StepPeerState {e} pid (availEpochs pre) (msgPool pre) (initialised pre) (peerStates pre pid) initd' (s' , outs)
                                → v  ⊂Msg m → m ∈ outs → (sig : WithVerSig pk v)
                                → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
-                               → (v ^∙ vEpoch) ≡ (₋epEC s) ^∙ epEpoch
-                               × suc ((₋epEC s) ^∙ epLastVotedRound) ≡ (v ^∙ vRound)  -- New vote for higher round than last voted
+                               → (v ^∙ vEpoch) ≡ (₋epEC (peerStates pre pid)) ^∙ epEpoch
+                               × suc ((₋epEC (peerStates pre pid)) ^∙ epLastVotedRound) ≡ (v ^∙ vRound)  -- New vote for higher round than last voted
                                × (v ^∙ vRound) ≡ ((₋epEC s') ^∙ epLastVotedRound)     -- Last voted round is round of new vote
-  newVoteSameEpochGreaterRound _ (step-init _) ms≡ v⊂m m∈outs sig = {!!}
-  newVoteSameEpochGreaterRound {pid = pid} {s = ps} {m = m} r (step-msg {(_ , nm)} msg∈pool ps≡) ms≡ v⊂m m∈outs sig vnew
-     rewrite just-injective (trans ps≡ (sym ms≡))
+  newVoteSameEpochGreaterRound _ (step-init _) v⊂m m∈outs sig = ⊥-elim (¬Any[] m∈outs)
+  newVoteSameEpochGreaterRound {pre = pre} {pid} {m = m} r (step-msg {(_ , nm)} msg∈pool pinit) v⊂m m∈outs sig vnew
+     rewrite pinit
      with nm
   ...| P msg
-    with msgsToSendWereSent {pid} {0} {P msg} {m} {ps} m∈outs
+    with msgsToSendWereSent {pid} {0} {P msg} {m} {peerStates pre pid} m∈outs
   ...| vm , refl , vmSent
-    with msgsToSendWereSent1 {pid} {0} {msg} {vm} {ps} vmSent
+    with msgsToSendWereSent1 {pid} {0} {msg} {vm} {peerStates pre pid} vmSent
   ...| _ , v∈outs
      rewrite SendVote-inj-v  (Any-singleton⁻ v∈outs)
            | SendVote-inj-si (Any-singleton⁻ v∈outs)
@@ -67,34 +66,33 @@ module LibraBFT.Impl.Properties.VotesOnce where
        -- assumption that v's signature has not been sent before.
   ...| vote∈qc {vs = vs} {qc} vs∈qc v≈rbld (inV qc∈m)
                   rewrite cong ₋vSignature v≈rbld
-                        | procPMCerts≡ {0} {msg} {ps} {vm} v∈outs
-     = ⊥-elim (vnew (qcVotesSentB4 r ms≡ qc∈m refl vs∈qc))
+                        | procPMCerts≡ {0} {msg} {peerStates pre pid} {vm} v∈outs
+     = ⊥-elim (vnew (qcVotesSentB4 r pinit refl qc∈m refl vs∈qc))
   ...| vote∈vm {si} = refl , refl , refl
 
   -- Always true, so far, as no epoch changes.
-  noEpochChangeYet : ∀ {e}{pre : SystemState e}{pid}{ppre ppost msgs}
+  noEpochChangeYet : ∀ {e}{pre : SystemState e}{pid}{initd' ppre ppost msgs}
                    → ReachableSystemState pre
-                   → just ppre ≡ Map-lookup pid (peerStates pre)
-                   → StepPeerState pid (availEpochs pre) (msgPool pre) (just ppre) (ppost , msgs)
+                   → ppre ≡ peerStates pre pid
+                   → StepPeerState pid (availEpochs pre) (msgPool pre) (initialised pre) ppre initd' (ppost , msgs)
                    → (₋epEC ppre) ^∙ epEpoch ≡ (₋epEC ppost) ^∙ epEpoch
   noEpochChangeYet _ ppre≡ (step-init ix) = {!!}
   noEpochChangeYet _ ppre≡ (step-msg {(_ , m)} _ ms≡)
-     rewrite just-injective ms≡
+     rewrite ms≡
      with m
   ...| P p = refl
   ...| V v = refl
   ...| C c = refl
 
   -- We resist the temptation to combine this with the noEpochChangeYet because in future there will be epoch changes
-  lastVoteRound-mono : ∀ {e}{pre : SystemState e}{pid}{ppre ppost msgs}
+  lastVoteRound-mono : ∀ {e}{pre : SystemState e}{pid}{initd' ppre ppost msgs}
                      → ReachableSystemState pre
-                     → just ppre ≡ Map-lookup pid (peerStates pre)
-                     → StepPeerState pid (availEpochs pre) (msgPool pre) (just ppre) (ppost , msgs)
+                     → ppre ≡ peerStates pre pid
+                     → StepPeerState pid (availEpochs pre) (msgPool pre) (initialised pre) ppre initd' (ppost , msgs)
                      → (₋epEC ppre) ^∙ epEpoch ≡ (₋epEC ppost) ^∙ epEpoch
                      → (₋epEC ppre) ^∙ epLastVotedRound ≤ (₋epEC ppost) ^∙ epLastVotedRound
   lastVoteRound-mono _ ppre≡ (step-init ix) _ = {!!}
-  lastVoteRound-mono _ ppre≡ (step-msg {(_ , m)} _ ms≡)
-     rewrite just-injective ms≡
+  lastVoteRound-mono _ ppre≡ (step-msg {(_ , m)} _ _)
      with m
   ...| P p = const (≤-step (≤-reflexive refl))
   ...| V v = const (≤-reflexive refl)
@@ -104,9 +102,8 @@ module LibraBFT.Impl.Properties.VotesOnce where
   -- sent, and that we can carry forward to subsequent states, so we can use it to prove
   -- VO.ImplObligation₁.
   LvrProp : CarrierProp
-  LvrProp v mep = ∃[ ep ]( mep ≡ just ep
-                         × (  v ^∙ vEpoch ≢ (₋epEC ep) ^∙ epEpoch
-                           ⊎ (v ^∙ vEpoch ≡ (₋epEC ep) ^∙ epEpoch × v ^∙ vRound ≤ (₋epEC ep) ^∙ epLastVotedRound)))
+  LvrProp v ep = (  v ^∙ vEpoch ≢ (₋epEC ep) ^∙ epEpoch
+                 ⊎ (v ^∙ vEpoch ≡ (₋epEC ep) ^∙ epEpoch × v ^∙ vRound ≤ (₋epEC ep) ^∙ epLastVotedRound))
 
   LvrCarrier = PropCarrier LvrProp
  
@@ -118,11 +115,12 @@ module LibraBFT.Impl.Properties.VotesOnce where
                          × ¬ MsgWithSig∈ pk (signature v' unit) (msgPool pre)
                          × LvrCarrier pk (₋vSignature v') (StepPeer-post pstep)
                          )
+
   isValidNewPart⇒fSE : ∀ {e e' pk v'}{pre : SystemState e} {post : SystemState e'} {theStep : Step pre post}
                      → Meta-Honest-PK pk
                      → (ivnp : IsValidNewPart (₋vSignature v') pk theStep)
                      → firstSendEstablishes v' pk pre theStep
-  isValidNewPart⇒fSE {theStep = step-peer {pid = β} {outs = outs} pstep} hpk (_ , ¬sentb4 , mws , _)
+  isValidNewPart⇒fSE {pre = pre} {theStep = step-peer {pid = β} {outs = outs} pstep} hpk (_ , ¬sentb4 , mws , _)
      with Any-++⁻ (List-map (β ,_) outs) (msg∈pool mws)
      -- TODO-1 : Much of this proof is not specific to the particular property being proved, and could be
      -- refactored into Yasm.Properties.  See proof of unwind and refactor to avoid redundancy?
@@ -136,56 +134,52 @@ module LibraBFT.Impl.Properties.VotesOnce where
   ...| inj₁ dis = ⊥-elim (hpk dis)
   ...| inj₂ sentb4 rewrite msgSameSig mws = ⊥-elim (¬sentb4 sentb4)
 
-  isValidNewPart⇒fSE {pk = pk}{pre = pre}{theStep = step-peer pstep} hpk (r , ¬sentb4 , mws , vpk)
+  isValidNewPart⇒fSE {e}{pk = pk}{pre = pre}{theStep = step-peer {.e} {β} {postst} {outs} {.pre} pstep} hpk (r , ¬sentb4 , mws , vpk)
      | inj₁ thisStep
-     | step-honest hstep
+     | step-honest {.β} {postst} {outs} {init'} hstep
      with Any-satisfied-∈ (Any-map⁻ thisStep)
   ...| nm , refl , nm∈outs
+     with hstep
+  ...| step-init _ = ⊥-elim (¬Any[] nm∈outs)
+  ...| step-msg {m} m∈pool _
      with impl-sps-avp {m = msgWhole mws} r hpk hstep nm∈outs (msg⊆ mws) (msgSigned mws)
   ...| inj₂ sentb4 rewrite msgSameSig mws = ⊥-elim (¬sentb4 sentb4)
   ...| inj₁ (vpk' , _)
-     with hstep
-  ...| step-init _ = ⊥-elim (¬Any[] nm∈outs)
-  ...| step-msg {m} {s = s} m∈pool ms≡
      with sameEpoch⇒sameEC vpk vpk' refl
   ...| refl
-     with newVoteSameEpochGreaterRound r hstep ms≡ (msg⊆ mws) nm∈outs (msgSigned mws)
+     with newVoteSameEpochGreaterRound r hstep (msg⊆ mws) nm∈outs (msgSigned mws)
                                        (subst (λ sig → ¬ MsgWithSig∈ pk sig (msgPool pre))
-                                              (sym (msgSameSig mws))
-                                              ¬sentb4)
+                                               (sym (msgSameSig mws))
+                                               ¬sentb4)
   ...| refl , refl , newlvr
-     with LBFT-post (handle m 0) s | inspect (LBFT-post (handle m 0)) s
-  ...| ps' | [ refl ] rewrite sym ms≡ = r , ¬sentb4 ,
-                                        mkCarrier (step-s r (step-peer pstep)) mws vpk
-                                                  (just ps')
-                                                  Map-set-correct
-                                                  (ps' , refl , inj₂ (noEpochChangeYet r ms≡ hstep , ≤-reflexive newlvr))
+     with noEpochChangeYet {ppre = peerStates pre β} r refl hstep
+  ...| eids≡
+     with StepPeer-post-lemma pstep
+  ...| post≡ = r , ¬sentb4 , mkCarrier (step-s r (step-peer pstep)) mws vpk
+                                       (inj₂ ( trans  eids≡ (auxEid post≡)
+                                             , ≤-reflexive (trans newlvr (auxLvr post≡))))
+                                       where auxEid = cong (_^∙ epEpoch ∘ ₋epEC)
+                                             auxLvr = cong (_^∙ epLastVotedRound ∘ ₋epEC)
 
   ImplPreservesLvr : PeerStepPreserves LvrProp
   -- We don't have a real model for the initial peer state, so we can't prove this case yet.
   -- Eventually, we'll prove something like a peer doesn't initialize to an epoch for which
   -- it has already sent votes.
   ImplPreservesLvr r _ (step-init ix) = {!!}
-  ImplPreservesLvr {pre = pre} r prop (step-msg {m} {s} m∈pool ms≡justs)
+  ImplPreservesLvr {pre = pre} r prop (step-msg {m} m∈pool inited)
      with carrProp prop
-  ...| (ppre' , ppre≡ , preprop)
-     with just-injective (trans ms≡justs (trans (carrSndrSt≡ prop) ppre≡))
-  ...| refl
-     with noEpochChangeYet r ms≡justs (step-msg m∈pool refl)
+  ...| preprop
+     with noEpochChangeYet r refl (step-msg m∈pool inited)
   ...| stepDNMepoch
      with preprop
-  ...| inj₁ diffEpoch = LBFT-post (handle m 0) ppre' , refl , inj₁ λ x → diffEpoch (trans x (sym stepDNMepoch))
+  ...| inj₁ diffEpoch = inj₁ λ x → diffEpoch (trans x (sym stepDNMepoch))
   ...| inj₂ (sameEpoch , rnd≤ppre)
-     with (msgPart (carrSent prop)) ^∙ vEpoch ≟ (₋epEC ppre') ^∙ epEpoch
-  ...| no neq = LBFT-post (handle m 0) ppre'
-              , refl
-              , ⊥-elim (neq sameEpoch)
+     with (msgPart (carrSent prop)) ^∙ vEpoch ≟ (₋epEC (peerStates pre (msgSender (carrSent prop)))) ^∙ epEpoch
+  ...| no neq = ⊥-elim (neq sameEpoch)
   ...| yes refl
-     with lastVoteRound-mono {ppre = ppre'} r ms≡justs (step-msg m∈pool refl)
+     with lastVoteRound-mono r refl (step-msg m∈pool inited)
   ...| es≡⇒lvr≤
-     = LBFT-post (handle m 0) ppre'
-     , refl
-     , inj₂ (stepDNMepoch , ≤-trans rnd≤ppre (es≡⇒lvr≤ stepDNMepoch))
+     = inj₂ (stepDNMepoch , ≤-trans rnd≤ppre (es≡⇒lvr≤ stepDNMepoch))
 
   LvrCarrier-transp* : ∀ {e e' pk sig} {start : SystemState e}{final : SystemState e'}
                      → LvrCarrier pk sig start
@@ -211,7 +205,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
   vo₁ {e} {pid} {pk = pk} {pre = pre} r (step-msg m∈pool ps≡)
       {v' = v'} hpk v⊂m m∈outs sig ¬sentb4 vpb v'⊂m' m'∈pool sig' refl rnds≡
      with newVoteSameEpochGreaterRound {e} {pre} {pid = pid} r
-                                       (step-msg m∈pool ps≡) ps≡ v⊂m m∈outs sig ¬sentb4
+                                       (step-msg m∈pool ps≡) v⊂m m∈outs sig ¬sentb4
   ...| eIds≡' , suclvr≡v'rnd , _
      -- Use unwind to find the step that first sent the signature for v', then Any-Step-elim to
      -- prove that going from the poststate of that step to pre results in a state in which the
@@ -221,7 +215,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
                         (fSE⇒rnd≤lvr {v'} hpk)
                         (Any-Step-⇒ (λ _ ivnp → isValidNewPart⇒fSE {v' = v'} hpk ivnp)
                                     (unwind r hpk v'⊂m' m'∈pool sig'))
-  ...| mkCarrier r' mws vpf' sndrst sndrst≡ (_ , ps≡' , preprop)
+  ...| mkCarrier r' mws vpf' preprop
      -- The fake/trivial handler always sends a vote for its current epoch, but for a
      -- round greater than its last voted round
      with sameHonestSig⇒sameVoteData hpk (msgSigned mws) sig' (msgSameSig mws)
@@ -230,10 +224,8 @@ module LibraBFT.Impl.Properties.VotesOnce where
      -- Both votes have the same epochID, therefore same EpochConfig
      with sameEpoch⇒sameEC vpb vpf' refl
                     -- Both peers are allowed to sign for the same PK, so they are the same peer
-  ...| refl rewrite NodeId-PK-OK-injective (vp-ec vpb) (vp-sender-ok vpb) (vp-sender-ok vpf') |
-                    -- So their peer states are the same
-                    sym (just-injective (trans (trans ps≡ sndrst≡) ps≡'))
-     with noEpochChangeYet r' ps≡ (step-msg m∈pool refl)
+  ...| refl rewrite NodeId-PK-OK-injective (vp-ec vpb) (vp-sender-ok vpb) (vp-sender-ok vpf')
+     with noEpochChangeYet r' refl (step-msg m∈pool ps≡)
   ...| stepDNMepoch
      with preprop
   ...| inj₁ diffEpoch = ⊥-elim (diffEpoch eIds≡')
@@ -248,13 +240,13 @@ module LibraBFT.Impl.Properties.VotesOnce where
   -- newVoteSameEpochGreaterRound property uses similar reasoning.
   vo₂ : VO.ImplObligation₂
   vo₂ _ (step-init _) _ _ m∈outs _ _ _ _ _ _ _ _ = ⊥-elim (¬Any[] m∈outs)
-  vo₂ r (step-msg {pid , nm} {s = ps} _ ps≡) {m = m} {m' = m'}
+  vo₂ {pid = pid} {pre = pre} r (step-msg {_ , nm} _ pinit) {m = m} {m' = m'}
       hpk v⊂m m∈outs sig vnew vpk v'⊂m' m'∈outs sig' v'new vpk' es≡ rnds≡
     with nm
   ...| P msg
-    with msgsToSendWereSent {pid} {0} {P msg} {m} {ps} m∈outs
+    with msgsToSendWereSent {pid} {0} {P msg} {m} {peerStates pre pid} m∈outs
   ...| vm , refl , vmSent
-    with msgsToSendWereSent1 {pid} {0} {msg} {vm} {ps} vmSent
+    with msgsToSendWereSent1 {pid} {0} {msg} {vm} {peerStates pre pid} vmSent
   ...| _ , v∈outs
     with v⊂m
        -- Rebuilding keeps the same signature, and the SyncInfo included with the
@@ -263,9 +255,9 @@ module LibraBFT.Impl.Properties.VotesOnce where
        -- assumption that v's signature has not been sent before.
   ...| vote∈qc {vs = vs} {qc} vs∈qc v≈rbld (inV qc∈m)
                   rewrite cong ₋vSignature v≈rbld
-                        | procPMCerts≡ {0} {msg} {ps} {vm} v∈outs
+                        | procPMCerts≡ {0} {msg} {peerStates pre pid} {vm} v∈outs
                         | SendVote-inj-v (Any-singleton⁻ v∈outs)
-     = ⊥-elim (vnew (qcVotesSentB4 r ps≡ qc∈m refl vs∈qc))
+     = ⊥-elim (vnew (qcVotesSentB4 r pinit refl qc∈m refl vs∈qc))
   ...| vote∈vm {si}
      with m'
   ...| P _ = ⊥-elim (P≢V (Any-singleton⁻ m'∈outs))
@@ -279,5 +271,5 @@ module LibraBFT.Impl.Properties.VotesOnce where
        -- Here we use the same reasoning as above to show that v' is not new
   ...| vote∈qc vs∈qc v≈rbld (inV qc∈m)
                   rewrite cong ₋vSignature v≈rbld
-                        | procPMCerts≡ {0} {msg} {ps} {vm} v∈outs
-     = ⊥-elim (v'new (qcVotesSentB4 r ps≡ qc∈m refl vs∈qc))
+                        | procPMCerts≡ {0} {msg} {peerStates pre pid} {vm} v∈outs
+     = ⊥-elim (v'new (qcVotesSentB4 r pinit refl qc∈m refl vs∈qc))

--- a/LibraBFT/Yasm/Base.agda
+++ b/LibraBFT/Yasm/Base.agda
@@ -28,7 +28,7 @@ module LibraBFT.Yasm.Base
 
  -- Our system is configured through a value of type
  -- SystemParameters where we specify:
- record SystemParameters : Set ((ℓ+1 0ℓ) ℓ⊔ ℓ-EC) where
+ record SystemParameters : Set (ℓ+1 0ℓ ℓ⊔ ℓ-EC) where
   constructor mkSysParms
   field
     PeerId    : Set

--- a/LibraBFT/Yasm/Base.agda
+++ b/LibraBFT/Yasm/Base.agda
@@ -34,6 +34,7 @@ module LibraBFT.Yasm.Base
     PeerId    : Set
     _≟PeerId_ : ∀ (p₁ p₂ : PeerId) → Dec (p₁ ≡ p₂)
     PeerState : Set
+    initPS    : PeerState  -- Represents an uninitialised PeerState, about which we know nothing whatsoever
     Msg       : Set
     Part      : Set -- Types of interest that can be represented in Msgs
 
@@ -47,7 +48,7 @@ module LibraBFT.Yasm.Base
     part-epoch  : Part → EpochId
 
     -- Initializes a potentially-empty state with an EpochConfig
-    init : PeerId → EpochConfig → Maybe PeerState → PeerState × List Msg
+    init : PeerId → EpochConfig → PeerState → PeerState × List Msg
 
     -- Handles a message on a previously initialized peer.
     handle : PeerId → Msg → PeerState → PeerState × List Msg
@@ -70,45 +71,3 @@ module LibraBFT.Yasm.Base
     -- > libraHandle _ (Crashed , l , s) = Crashed , s , [] -- i.e., crashed peers never send messages
     -- >
     -- > handle = filter isSend ∘ libraHandle
-
- -- We also require a standard key-value store interface, along with its
- -- functionality and various properties about it.  Most of the properties
- -- are not currently used, but they are included here based on our
- -- experience in other work, as we think many of them will be needed when
- -- reasoning about an actual LibraBFT implementation.
-
- -- Although we believe the assumptions here are reasonable, it is always
- -- possible that we made a mistake in postulating one of the properties,
- -- making it impossible to implement.  Thus, it would a useful contribution
- -- to:
- --
- -- TODO-1: construct an actual implementation and provide and prove the
- -- necessary properties to satisfy the requirements of this module
- --
- -- Note that this would require some work, but should be relatively
- -- straightforward and requires only "local" changes.
-
- postulate
-   Map        : Set → Set → Set
-   Map-empty  : ∀{k v} → Map k v
-   Map-lookup : ∀{k v} → k → Map k v → Maybe v
-   Map-insert : ∀{k v} → k → v → Map k v → Map k v
-   Map-set    : ∀{k v} → k → Maybe v → Map k v → Map k v
-
-   -- It must satisfy the following properties
-   Map-insert-correct  : ∀ {K V : Set}{k : K}{v : V}{m : Map K V}
-                       → Map-lookup k (Map-insert k v m) ≡ just v
-
-   Map-insert-target-≢ : ∀ {K V : Set}{k k' : K}{v : V}{m}
-                       → k' ≢ k
-                       → Map-lookup k' m ≡ Map-lookup k' (Map-insert k v m)
-
-   Map-set-correct     : ∀ {K V : Set}{k : K}{mv : Maybe V}{m : Map K V}
-                       → Map-lookup k (Map-set k mv m) ≡ mv
-
-   Map-set-target-≢    : ∀ {K V : Set}{k k' : K}{mv : Maybe V}{m}
-                       → k' ≢ k
-                       → Map-lookup k' m ≡ Map-lookup k' (Map-set k mv m)
-
-   Map-set-≡-correct   : ∀ {K V : Set}{k : K}{m : Map K V}
-                       → Map-set k (Map-lookup k m) m ≡ m

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -83,7 +83,7 @@ module LibraBFT.Yasm.Properties
  -- output of a 'StepPeerState' are either: (i) a valid new part (i.e., the part is valid and no
  -- message with the same signature has been sent previously), or (ii) a message has been sent
  -- with the same signature.
- StepPeerState-AllValidParts : Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)
+ StepPeerState-AllValidParts : Set ℓ-EC
  StepPeerState-AllValidParts = ∀{e s m part pk initd' outs}{α}{𝓔s : AvailableEpochs e}{st : SystemState e}
    → (r : ReachableSystemState st)
    → Meta-Honest-PK pk
@@ -93,8 +93,8 @@ module LibraBFT.Yasm.Properties
    ⊎ MsgWithSig∈ pk (ver-signature ver) (msgPool st)
 
  -- A /part/ was introduced by a specific step when:
- IsValidNewPart : ∀{e e'}{pre : SystemState e}{post : SystemState e'} → Signature → PK → Step pre post → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)
- IsValidNewPart _ _ (step-epoch _) = Lift (ℓ+1 ℓ0 ℓ⊔ ℓ-EC) ⊥
+ IsValidNewPart : ∀{e e'}{pre : SystemState e}{post : SystemState e'} → Signature → PK → Step pre post → Set ℓ-EC
+ IsValidNewPart _ _ (step-epoch _) = Lift (ℓ-EC) ⊥
  -- said step is a /step-peer/ and
  IsValidNewPart {pre = pre} sig pk (step-peer {pid = pid} pstep)
     -- the part has never been seen before

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -83,18 +83,18 @@ module LibraBFT.Yasm.Properties
  -- output of a 'StepPeerState' are either: (i) a valid new part (i.e., the part is valid and no
  -- message with the same signature has been sent previously), or (ii) a message has been sent
  -- with the same signature.
- StepPeerState-AllValidParts : Set ℓ-EC
- StepPeerState-AllValidParts = ∀{e s m part pk outs}{α}{𝓔s : AvailableEpochs e}{st : SystemState e}
+ StepPeerState-AllValidParts : Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)
+ StepPeerState-AllValidParts = ∀{e s m part pk initd' outs}{α}{𝓔s : AvailableEpochs e}{st : SystemState e}
    → (r : ReachableSystemState st)
    → Meta-Honest-PK pk
-   → StepPeerState α 𝓔s (msgPool st) (Map-lookup α (peerStates st)) (s , outs)
+   → StepPeerState α 𝓔s (msgPool st) (initialised st) (peerStates st α) initd' (s , outs)
    → m ∈ outs → part ⊂Msg m → (ver : WithVerSig pk part)
    → (ValidSenderForPK 𝓔s part α pk × ¬ (MsgWithSig∈ pk (ver-signature ver) (msgPool st)))
    ⊎ MsgWithSig∈ pk (ver-signature ver) (msgPool st)
 
  -- A /part/ was introduced by a specific step when:
- IsValidNewPart : ∀{e e'}{pre : SystemState e}{post : SystemState e'} → Signature → PK → Step pre post → Set ℓ-EC
- IsValidNewPart _ _ (step-epoch _) = Lift ℓ-EC ⊥
+ IsValidNewPart : ∀{e e'}{pre : SystemState e}{post : SystemState e'} → Signature → PK → Step pre post → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)
+ IsValidNewPart _ _ (step-epoch _) = Lift (ℓ+1 ℓ0 ℓ⊔ ℓ-EC) ⊥
  -- said step is a /step-peer/ and
  IsValidNewPart {pre = pre} sig pk (step-peer {pid = pid} pstep)
     -- the part has never been seen before
@@ -277,7 +277,7 @@ module LibraBFT.Yasm.Properties
  -- just one peer's state.  However, this would put more burden on the user and is not required so
  -- far.
  CarrierProp : Set₁
- CarrierProp = Part → Maybe PeerState → Set
+ CarrierProp = Part → PeerState → Set
 
  module _ (P   : CarrierProp) where
 
@@ -287,21 +287,21 @@ module LibraBFT.Yasm.Properties
       carrStReach : ReachableSystemState st -- Enables use of invariants when proving that steps preserve carrProp
       carrSent    : MsgWithSig∈ pk sig (msgPool st)
       carrValid   : ValidSenderForPK (availEpochs st) (msgPart carrSent) (msgSender carrSent) pk
-      carrSndrSt  : Maybe PeerState
-      carrSndrSt≡ : Map-lookup (msgSender carrSent) (peerStates st) ≡ carrSndrSt
-      carrProp    : P (msgPart carrSent) (carrSndrSt)
+      carrProp    : P (msgPart carrSent) (peerStates st (msgSender carrSent))
   open PropCarrier public
 
   PeerStepPreserves : Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)
-  PeerStepPreserves = ∀ {e ps' outs pk sig}{pre : SystemState e}
+  PeerStepPreserves = ∀ {e initd' ps' outs pk sig}{pre : SystemState e}
                       → (r : ReachableSystemState pre)
                       → (pc : PropCarrier pk sig {e} pre)
                       → (sps : StepPeerState {e} (msgSender (carrSent pc))
                                                  (availEpochs pre)
                                                  (msgPool pre)
-                                                 (Map-lookup (msgSender (carrSent pc)) (peerStates pre))
+                                                 (initialised pre)
+                                                 (peerStates pre (msgSender (carrSent pc)))
+                                                 initd'
                                                  (ps' , outs))
-                      → P (msgPart (carrSent pc)) (just ps')
+                      → P (msgPart (carrSent pc)) ps'
 
   module _ (PSP : PeerStepPreserves) where
 
@@ -309,16 +309,18 @@ module LibraBFT.Yasm.Properties
                    → (theStep : Step pre post)
                    → PropCarrier pk sig pre
                    → PropCarrier pk sig post
-    Carrier-transp {pre = pre} {post} (step-epoch ec) (mkCarrier r mws vpk spre spre≡ lvr) =
-       mkCarrier (step-s r (step-epoch ec)) mws (ValidSenderForPK-stable-epoch ec vpk) spre spre≡ lvr
-    Carrier-transp {e' = e'} {pre = pre} {post} theStep@(step-peer {pid = pid} {st'} {pre = .pre} sps) pc@(mkCarrier r mws vpk spre spre≡ prop)
+    Carrier-transp {pre = pre} {post} (step-epoch ec) (mkCarrier r mws vpk lvr) =
+       mkCarrier (step-s r (step-epoch ec)) mws (ValidSenderForPK-stable-epoch ec vpk) lvr
+    Carrier-transp {e' = e'} {pre = pre} {post} theStep@(step-peer {pid = pid} {st'} {pre = .pre} sps) pc@(mkCarrier r mws vpk prop)
        with step-s r theStep
     ...| postReach
        with sps
-    ...| step-cheat fm isch = mkCarrier postReach (MsgWithSig∈-++ʳ mws) vpk spre (subst (λ x → Map-lookup (msgSender mws) x ≡ spre) (sym Map-set-≡-correct) spre≡) prop
+    ...| step-cheat fm isch = mkCarrier postReach (MsgWithSig∈-++ʳ mws) vpk
+           (subst (λ ps → P (msgPart mws) (ps (msgSender mws))) (sym (cheatStepDNMPeerStates {pre = pre} (step-cheat fm isch) unit)) prop)
     -- PeerStates not changed by cheat steps
     ...| step-honest {st = st} sps'
        with msgSender mws ≟PeerId pid
-    ...| no neq = mkCarrier postReach (MsgWithSig∈-++ʳ mws) vpk spre (subst (_≡ spre) (Map-set-target-≢ neq) spre≡) prop
-    ...| yes refl = mkCarrier postReach (MsgWithSig∈-++ʳ mws) vpk (just st) Map-set-correct
-                              (PSP r pc sps')
+    ...| no neq = mkCarrier postReach (MsgWithSig∈-++ʳ mws) vpk
+                            (subst (λ ps → P (msgPart mws) ps) (override-target-≢ {f = peerStates pre} neq) prop)
+    ...| yes refl = mkCarrier postReach (MsgWithSig∈-++ʳ mws) vpk
+                              (subst (λ ps → P (msgPart mws) ps) (sym override-target-≡) (PSP r pc sps'))

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -33,6 +33,7 @@ module LibraBFT.Yasm.Properties
              as AE
  open import LibraBFT.Yasm.Base   ℓ-EC EpochConfig epochId authorsN
  open import LibraBFT.Yasm.System ℓ-EC EpochConfig epochId authorsN parms
+ open import Util.FunctionOverride PeerId _≟PeerId_
 
  -- A ValidPartForPK collects the assumptions about what a /part/ in the outputs of an honest verifier
  -- satisfies: (i) the epoch field is consistent with the existent epochs and (ii) the verifier is

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -320,7 +320,7 @@ module LibraBFT.Yasm.Properties
     -- PeerStates not changed by cheat steps
     ...| step-honest {st = st} sps'
        with msgSender mws ≟PeerId pid
-    ...| no neq = mkCarrier postReach (MsgWithSig∈-++ʳ mws) vpk
-                            (subst (λ ps → P (msgPart mws) ps) (override-target-≢ {f = peerStates pre} neq) prop)
+    ...| no neq   = mkCarrier postReach (MsgWithSig∈-++ʳ mws) vpk
+                              (subst (λ ps → P (msgPart mws) ps) (override-target-≢ {f = peerStates pre} neq) prop)
     ...| yes refl = mkCarrier postReach (MsgWithSig∈-++ʳ mws) vpk
                               (subst (λ ps → P (msgPart mws) ps) (sym override-target-≡) (PSP r pc sps'))

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -24,11 +24,17 @@ module LibraBFT.Yasm.System
    (authorsN    : EpochConfig → ℕ)
    (parms : LYB.SystemParameters ℓ-EC EpochConfig epochId authorsN)
  where
+
+ data InitStatus : Set where
+   uninitd : InitStatus
+   initd   : InitStatus
+
  open import LibraBFT.Yasm.Base            ℓ-EC EpochConfig epochId authorsN
  open SystemParameters parms
  open import LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epochId authorsN
              using (AvailableEpochs) renaming (lookup'' to EC-lookup)
  import LibraBFT.Yasm.AvailableEpochs      PeerId ℓ-EC EpochConfig epochId authorsN as AE
+ open import Util.FunctionOverride PeerId _≟PeerId_
 
  open import LibraBFT.Base.PKCS
 
@@ -155,16 +161,18 @@ module LibraBFT.Yasm.System
  --
  -- A system consists in a partial map from PeerId to PeerState, a pool
  -- of sent messages and a number of available epochs.
- record SystemState (e : ℕ) : Set ℓ-EC where
+ record SystemState (e : ℕ) : Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC) where
    field
-     peerStates  : Map PeerId PeerState
+     peerStates  : PeerId → PeerState
+     initialised : PeerId → InitStatus
      msgPool     : SentMessages          -- All messages ever sent
      availEpochs : AvailableEpochs e
  open SystemState public
 
  initialState : SystemState 0
  initialState = record
-   { peerStates  = Map-empty
+   { peerStates  = const initPS
+   ; initialised = const uninitd
    ; msgPool     = []
    ; availEpochs = []
    }
@@ -173,6 +181,7 @@ module LibraBFT.Yasm.System
  pushEpoch : ∀{e} → EpochConfigFor e → SystemState e → SystemState (suc e)
  pushEpoch 𝓔 st = record
    { peerStates  = peerStates st
+   ; initialised = initialised st
    ; msgPool     = msgPool st
    ; availEpochs = AE.append 𝓔 (availEpochs st)
    }
@@ -188,36 +197,37 @@ module LibraBFT.Yasm.System
 
  -- The pre and post states of Honest peers are related iff
  data StepPeerState {e}(pid : PeerId)(𝓔s : AvailableEpochs e)(pool : SentMessages)
-                       (ms : Maybe PeerState) : (PeerState × List Msg) → Set where
+                       (peerInits : PeerId → InitStatus) (ps : PeerState) :
+                       (PeerId → InitStatus) → (PeerState × List Msg) → Set where
    -- The peer receives an "initialization package"; for now, this consists
    -- of the actual EpochConfig for the epoch being initialized.  Later, we
    -- may move to a more general scheme, enabled by assuming a function
    -- 'render : InitPackage -> EpochConfig'.
    step-init : ∀ (ix : Fin e)
-             → StepPeerState pid 𝓔s pool ms (init pid (AE.lookup' 𝓔s ix) ms)
+             → StepPeerState pid 𝓔s pool peerInits ps ⟦ peerInits , pid ← initd ⟧ (init pid (AE.lookup' 𝓔s ix) ps)
 
    -- The peer processes a message in the pool
-   step-msg  : ∀{m s}
+   step-msg  : ∀{m}
              → m ∈ pool
-             → just s ≡ ms
-             → StepPeerState pid 𝓔s pool ms (handle pid (proj₂ m) s)
+             → peerInits pid ≡ initd
+             → StepPeerState pid 𝓔s pool peerInits ps peerInits (handle pid (proj₂ m) ps)
 
  -- The pre-state of the suplied PeerId is related to the post-state and list of output messages iff:
- data StepPeer {e}(pre : SystemState e) : PeerId → Maybe PeerState → List Msg → Set where
+ data StepPeer {e}(pre : SystemState e) : PeerId → PeerState → List Msg → Set where
    -- it can be obtained by a handle or init call.
-   step-honest : ∀{pid st outs}
-               → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (st , outs)
-               → StepPeer pre pid (just st) outs
+   step-honest : ∀{pid st outs init'}
+               → StepPeerState pid (availEpochs pre) (msgPool pre) (initialised pre) (peerStates pre pid) init' (st , outs)
+               → StepPeer pre pid st outs
 
    -- or the peer decides to cheat.  CheatMsgConstraint ensures it cannot
    -- forge signatures by honest peers.  Cheat steps do not modify peer
    -- state: these are maintained exclusively by the implementation
    -- handlers.
    step-cheat  : ∀{pid}
-               → (fm : SentMessages → Maybe PeerState → Msg)
-               → let m = fm (msgPool pre) (Map-lookup pid (peerStates pre))
+               → (fm : SentMessages → PeerState → Msg)
+               → let m = fm (msgPool pre) (peerStates pre pid)
                   in CheatMsgConstraint (msgPool pre) m
-                   → StepPeer pre pid (Map-lookup pid (peerStates pre)) (m ∷ [])
+                   → StepPeer pre pid (peerStates pre pid) (m ∷ [])
 
  isCheat : ∀ {e pre pid ms outs} → StepPeer {e} pre pid ms outs → Set
  isCheat (step-honest _)  = ⊥
@@ -227,7 +237,7 @@ module LibraBFT.Yasm.System
  StepPeer-post : ∀{e pid st' outs}{pre : SystemState e}
                → StepPeer pre pid st' outs → SystemState e
  StepPeer-post {e} {pid} {st'} {outs} {pre} _ = record pre
-   { peerStates = Map-set pid st' (peerStates pre)
+   { peerStates = ⟦ peerStates pre , pid ← st' ⟧
    ; msgPool    = List-map (pid ,_) outs ++ msgPool pre
    }
 
@@ -236,9 +246,9 @@ module LibraBFT.Yasm.System
                         → (theStep : StepPeer pre pid st' outs)
                         → isCheat theStep
                         → peerStates (StepPeer-post theStep) ≡ peerStates pre
- cheatStepDNMPeerStates (step-cheat _ _) _ = Map-set-≡-correct
+ cheatStepDNMPeerStates {pid = pid} {pre = pre} (step-cheat _ _) _ = override≡Correct {f = peerStates pre} {pid}
 
- data Step : ∀{e e'} → SystemState e → SystemState e' → Set ℓ-EC where
+ data Step : ∀{e e'} → SystemState e → SystemState e' → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC) where
    step-epoch : ∀{e}{pre : SystemState e}
               → (𝓔 : EpochConfigFor e)
               -- TODO-3: Eventually, we'll condition this step to only be
@@ -258,19 +268,18 @@ module LibraBFT.Yasm.System
  msgs-stable (step-epoch _) m∈ = m∈
  msgs-stable (step-peer {pid = pid} {outs = outs} _) m∈ = Any-++ʳ (List-map (pid ,_) outs) m∈
 
-
- peersRemainInitialized : ∀ {ppre} {pid} {e e'} {pre : SystemState e} {post : SystemState e'}
+ peersRemainInitialized : ∀ {pid} {e e'} {pre : SystemState e} {post : SystemState e'}
                         → (theStep : Step pre post)
-                        → Map-lookup pid (peerStates pre) ≡ just ppre
-                        → ∃[ ppost ] (Map-lookup pid (peerStates post) ≡ just ppost)
- peersRemainInitialized {ppre} (step-epoch _) lkp≡ppre = ppre , lkp≡ppre
- peersRemainInitialized {ppre} {pid} (step-peer step) lkp≡ppre
+                        → initialised pre pid ≡ initd
+                        → initialised post pid ≡ initd
+ peersRemainInitialized (step-epoch _) isInitd = isInitd
+ peersRemainInitialized {pid} (step-peer step) isInitd
    with step
- ... | step-cheat _ _ = ppre , trans (cong (Map-lookup pid) Map-set-≡-correct) lkp≡ppre
+ ... | step-cheat _ _ = isInitd
  ... | step-honest {pidS} {st} {outs} stp
    with pid ≟PeerId pidS
- ...| yes refl = st , Map-set-correct
- ...| no imp = ppre , trans (sym (Map-set-target-≢ imp)) lkp≡ppre
+ ...| yes refl = isInitd
+ ...| no imp = isInitd
 
  -- not used yet, but some proofs could probably be cleaned up using this,
  -- e.g., prevVoteRnd≤-pred-step in Impl.VotesOnce
@@ -289,7 +298,7 @@ module LibraBFT.Yasm.System
 
  -- * Reflexive-Transitive Closure
 
- data Step* : ∀{e e'} → SystemState e → SystemState e' → Set ℓ-EC where
+ data Step* : ∀{e e'} → SystemState e → SystemState e' → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC) where
    step-0 : ∀{e}{pre : SystemState e}
           → Step* pre pre
 
@@ -298,7 +307,7 @@ module LibraBFT.Yasm.System
           → Step pre post
           → Step* fst post
 
- ReachableSystemState : ∀{e} → SystemState e → Set ℓ-EC
+ ReachableSystemState : ∀{e} → SystemState e → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)
  ReachableSystemState = Step* initialState
 
  Step*-mono : ∀{e e'}{st : SystemState e}{st' : SystemState e'}
@@ -341,8 +350,8 @@ module LibraBFT.Yasm.System
  ------------------------------------------
 
  -- Type synonym to express a relation over system states;
- SystemStateRel : (∀{e e'} → SystemState e → SystemState e' → Set ℓ-EC) → Set (ℓ+1 ℓ-EC)
- SystemStateRel P = ∀{e e'}{st : SystemState e}{st' : SystemState e'} → P st st' → Set ℓ-EC
+ SystemStateRel : (∀{e e'} → SystemState e → SystemState e' → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)) → Set (ℓ+1 (ℓ+1 ℓ0) ℓ⊔ ℓ+1 ℓ-EC)
+ SystemStateRel P = ∀{e e'}{st : SystemState e}{st' : SystemState e'} → P st st' → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)
 
  -- Just like Data.List.Any maps a predicate over elements to a predicate over lists,
  -- Any-step maps a relation over steps to a relation over steps in a trace.

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -241,6 +241,10 @@ module LibraBFT.Yasm.System
    ; msgPool    = List-map (pid ,_) outs ++ msgPool pre
    }
 
+ StepPeer-post-lemma : ∀{e pid st' outs}{pre : SystemState e}
+               → (pstep : StepPeer pre pid st' outs)
+               → st' ≡ peerStates (StepPeer-post pstep) pid
+ StepPeer-post-lemma pstep = sym override-target-≡
 
  cheatStepDNMPeerStates : ∀{e pid st' outs}{pre : SystemState e}
                         → (theStep : StepPeer pre pid st' outs)

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -161,7 +161,7 @@ module LibraBFT.Yasm.System
  --
  -- A system consists in a partial map from PeerId to PeerState, a pool
  -- of sent messages and a number of available epochs.
- record SystemState (e : ℕ) : Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC) where
+ record SystemState (e : ℕ) : Set ℓ-EC where
    field
      peerStates  : PeerId → PeerState
      initialised : PeerId → InitStatus
@@ -252,7 +252,7 @@ module LibraBFT.Yasm.System
                         → peerStates (StepPeer-post theStep) ≡ peerStates pre
  cheatStepDNMPeerStates {pid = pid} {pre = pre} (step-cheat _ _) _ = override≡Correct {f = peerStates pre} {pid}
 
- data Step : ∀{e e'} → SystemState e → SystemState e' → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC) where
+ data Step : ∀{e e'} → SystemState e → SystemState e' → Set ℓ-EC where
    step-epoch : ∀{e}{pre : SystemState e}
               → (𝓔 : EpochConfigFor e)
               -- TODO-3: Eventually, we'll condition this step to only be
@@ -302,7 +302,7 @@ module LibraBFT.Yasm.System
 
  -- * Reflexive-Transitive Closure
 
- data Step* : ∀{e e'} → SystemState e → SystemState e' → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC) where
+ data Step* : ∀{e e'} → SystemState e → SystemState e' → Set ℓ-EC where
    step-0 : ∀{e}{pre : SystemState e}
           → Step* pre pre
 
@@ -311,7 +311,7 @@ module LibraBFT.Yasm.System
           → Step pre post
           → Step* fst post
 
- ReachableSystemState : ∀{e} → SystemState e → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)
+ ReachableSystemState : ∀{e} → SystemState e → Set ℓ-EC
  ReachableSystemState = Step* initialState
 
  Step*-mono : ∀{e e'}{st : SystemState e}{st' : SystemState e'}
@@ -354,8 +354,8 @@ module LibraBFT.Yasm.System
  ------------------------------------------
 
  -- Type synonym to express a relation over system states;
- SystemStateRel : (∀{e e'} → SystemState e → SystemState e' → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)) → Set (ℓ+1 (ℓ+1 ℓ0) ℓ⊔ ℓ+1 ℓ-EC)
- SystemStateRel P = ∀{e e'}{st : SystemState e}{st' : SystemState e'} → P st st' → Set (ℓ+1 ℓ0 ℓ⊔ ℓ-EC)
+ SystemStateRel : (∀{e e'} → SystemState e → SystemState e' → Set (ℓ-EC)) → Set (ℓ+1 ℓ0 ℓ⊔ ℓ+1 ℓ-EC)
+ SystemStateRel P = ∀{e e'}{st : SystemState e}{st' : SystemState e'} → P st st' → Set ℓ-EC
 
  -- Just like Data.List.Any maps a predicate over elements to a predicate over lists,
  -- Any-step maps a relation over steps to a relation over steps in a trace.

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -354,7 +354,7 @@ module LibraBFT.Yasm.System
  ------------------------------------------
 
  -- Type synonym to express a relation over system states;
- SystemStateRel : (∀{e e'} → SystemState e → SystemState e' → Set (ℓ-EC)) → Set (ℓ+1 ℓ0 ℓ⊔ ℓ+1 ℓ-EC)
+ SystemStateRel : (∀{e e'} → SystemState e → SystemState e' → Set ℓ-EC) → Set (ℓ+1 ℓ-EC)
  SystemStateRel P = ∀{e e'}{st : SystemState e}{st' : SystemState e'} → P st st' → Set ℓ-EC
 
  -- Just like Data.List.Any maps a predicate over elements to a predicate over lists,

--- a/LibraBFT/Yasm/Yasm.agda
+++ b/LibraBFT/Yasm/Yasm.agda
@@ -24,3 +24,4 @@ module LibraBFT.Yasm.Yasm
  open import LibraBFT.Yasm.Base       ℓ-EC EpochConfig epochId authorsN                      public
  open import LibraBFT.Yasm.System     ℓ-EC EpochConfig epochId authorsN parms                public
  open import LibraBFT.Yasm.Properties ℓ-EC EpochConfig epochId authorsN parms senderPKOK     public
+ open import Util.FunctionOverride    PeerId _≟PeerId_                                       public

--- a/Util/FunctionOverride.agda
+++ b/Util/FunctionOverride.agda
@@ -1,0 +1,54 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+open import Axiom.Extensionality.Propositional
+open import Data.Empty
+open import Level
+open import Relation.Nullary
+open import Relation.Binary.PropositionalEquality hiding (Extensionality)
+
+module Util.FunctionOverride
+          {ℓ₁   : Level}
+          (A    : Set ℓ₁)
+          (_≟A_ : (a₁ a₂ : A) → Dec (a₁ ≡ a₂))
+          {ℓ₂ : Level}{B : Set ℓ₂}
+  where
+
+  override : (A → B) → A → B → (A → B)
+  override f p v x
+    with p ≟A x
+  ...| yes refl = v
+  ...| no  neq  = f x
+
+  syntax override m p v = ⟦ m , p ← v ⟧
+
+  postulate
+    funext : Extensionality ℓ₁ ℓ₂
+
+  override-target-≡ : ∀ {a : A}{b : B}{f}
+                    → override f a b a ≡ b
+  override-target-≡ {a}
+     with a ≟A a
+  ...| yes refl = refl
+  ...| no  neq  = ⊥-elim (neq refl)
+
+  override-target-≢ : ∀ {a a' : A}{b : B}{f}
+                    → a' ≢ a
+                    → f a' ≡ (override f a b) a'
+  override-target-≢ {a} {a'} neq
+     with a ≟A a'
+  ...| yes refl = ⊥-elim (neq refl)
+  ...| no  _    = refl
+
+  overrideAux : ∀ {f : A → B}
+              → (p a : A)
+              → override f p (f p) a ≡ f a
+  overrideAux p a
+    with p ≟A a
+  ...| no neq   = refl
+  ...| yes refl = refl
+
+  override≡Correct : ∀ {f : A → B}{p : A} → override f p (f p) ≡ f
+  override≡Correct {p = p} = funext (overrideAux p)

--- a/Util/FunctionOverride.agda
+++ b/Util/FunctionOverride.agda
@@ -24,7 +24,8 @@ module Util.FunctionOverride
 
   syntax override m p v = ⟦ m , p ← v ⟧
 
-  postulate
+  postulate -- valid assumption
+    -- TODO-2: Eliminate postulate using https://github.com/agda/cubical
     funext : Extensionality ℓ₁ ℓ₂
 
   override-target-≡ : ∀ {a : A}{b : B}{f}

--- a/Util/FunctionOverride.agda
+++ b/Util/FunctionOverride.agda
@@ -18,7 +18,7 @@ module Util.FunctionOverride
 
   override : (A → B) → A → B → (A → B)
   override f p v x
-    with p ≟A x
+     with p ≟A x
   ...| yes refl = v
   ...| no  neq  = f x
 
@@ -47,7 +47,7 @@ module Util.FunctionOverride
               → (p a : A)
               → override f p (f p) a ≡ f a
   overrideAux p a
-    with p ≟A a
+     with p ≟A a
   ...| no neq   = refl
   ...| yes refl = refl
 


### PR DESCRIPTION
This is an experimental change to our system model, in which `peerStates` becomes a total function from `PeerId` to `PeerState`, meaning that even peers that don't exist yet have a "state".

This change eliminates having to deal with `Maybe PeerState` all the time, but also we cannot prove anything about the state of an uninitialised peer and we cannot distinguish them from initialised ones.

To address this issue, we also introduce a new element to `SystemState` called `initialised`, which tracks which peers' states have been initialised.  We can then state/prove properties about initialised peer states.  An example is the (postulated, for now) `qcVotesSentB4` property, which is required to hold only for initialised peers.

There are also a few minor unrelated changes.  For one example, the bridge between the system model and our (fake) handler paired the identity of the peer taking the step and the message it is processing, which is misleading as it suggests that the first element of the pair is the sender of the message, which is incorrect.