### PR TITLE
Simplified VotesOnlyOnce property on the concrete side

### DIFF
--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -95,7 +95,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
 
   -- Any reachable state satisfies the VO rule for any epoch in the system.
   module _ {e}(st : SystemState e)(r : ReachableSystemState st)(eid : Fin e) where
-   -- Bring in 'unwind', 'ext-unforgeability' and friends
+
    open Structural sps-corr
 
    -- Bring in IntSystemState
@@ -113,14 +113,19 @@ module LibraBFT.Concrete.Properties.VotesOnce where
     -- From this point onwards, it might be easier to read this proof starting at 'voo'
     -- at the end of the file. Next, we provide an overview the proof.
     --
-    -- We wish to prove that, for any two votes v and v' cast by an honest α in the message pool of
-    -- a state st, if v and v' have equal rounds and epochs, then they vote for the same block. As
-    -- The base case and the case for a new epoch in the system are trivial.
-
-    -- Regarding the PeerStep case. The induction hypothesis tells us that the property holds in the pre-state.  Next, we reason
-    -- about the post-state.  We start by analyzing whether v and v' have been sent as outputs of
-    -- the PeerStep under scrutiny or were already in the pool before (captured by the PredStep
-    -- function).  There are four possibilities:
+    -- We wish to prove that, for any two votes v and v' cast by an honest α in the message
+    -- pool of a state st, if v and v' have equal rounds and epochs, then they vote for the
+    -- same block.
+    --
+    -- The base case and the case for a new epoch in the system are trivial. For the base case
+    -- we get to a contradiction because it's not possible to have any message in the msgpool.
+    --
+    -- Regarding the PeerStep case. The induction hypothesis tells us that the property holds
+    -- in the pre-state.  Next, we reason about the post-state.  We start by analyzing whether
+    -- v and v' have been sent as outputs of the PeerStep under scrutiny or were already in
+    -- the pool before.
+    --
+    -- There are four possibilities:
     --
     --   i) v and v' were aleady present in the msgPool before: use induction hypothesis.
     --  ii) v and v' are both in the output produced by the PeerStep under scrutiny.
@@ -133,7 +138,8 @@ module LibraBFT.Concrete.Properties.VotesOnce where
     -- signature was sent before.
     --
     -- Case (i) is trivial; cases (iii) and (iv) are symmetric and reduce to an implementation
-    -- obligation (Impl-VO1) and case (ii) reduces to a different implementation obligation (Impl-VO2).
+    -- obligation (Impl-VO1) and case (ii) reduces to a different implementation obligation
+    -- (Impl-VO2).
 
 
     VotesOnceProof :
@@ -183,8 +189,6 @@ module LibraBFT.Concrete.Properties.VotesOnce where
     ...| inj₂ refl
       = sym (Impl-VO1 r stPeer pkH (msg⊆ msv') m'∈outs (msgSigned msv') newV' v'spk
                       (msg⊆ msb4) (msg∈pool msb4) (msgSigned msb4) (sym ep≡) (sym r≡))
-
-
 
    voo : VO.Type IntSystemState
    voo hpk refl sv refl sv' round≡

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -159,7 +159,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
     ...| msb4 | m'sb4
        with  msgSameSig msb4 | msgSameSig m'sb4
     ...| refl | refl = VotesOnceProof r pkH vv msb4 vv' m'sb4 ep≡ r≡
-    VotesOnceProof (step-s r (step-peer (step-honest stPeer))) pkH vv msv vv' msv' ep≡ r≡
+    VotesOnceProof (step-s r (step-peer stHon@(step-honest stPeer))) pkH vv msv vv' msv' ep≡ r≡
        with  msgSameSig msv | msgSameSig msv'
     ...| refl       | refl
        with sameHonestSig⇒sameVoteData pkH (msgSigned msv) vv (msgSameSig msv)
@@ -167,8 +167,8 @@ module LibraBFT.Concrete.Properties.VotesOnce where
     ...| inj₁ hb    | _         = ⊥-elim (meta-sha256-cr hb)
     ...| inj₂ refl  | inj₁ hb   = ⊥-elim (meta-sha256-cr hb)
     ...| inj₂ refl  | inj₂ refl
-       with newMsg⊎msgSentB4 r stPeer pkH (msgSigned msv) (msg⊆ msv) (msg∈pool msv)
-         | newMsg⊎msgSentB4 r stPeer pkH (msgSigned msv') (msg⊆ msv') (msg∈pool msv')
+       with newMsg⊎msgSentB4 r stHon pkH (msgSigned msv) (msg⊆ msv) (msg∈pool msv)
+          | newMsg⊎msgSentB4 r stHon pkH (msgSigned msv') (msg⊆ msv') (msg∈pool msv')
     ...| inj₂ msb4                   | inj₂ m'sb4
          = VotesOnceProof r pkH vv msb4 vv' m'sb4 ep≡ r≡
     ...| inj₁ (m∈outs , vspk , newV) | inj₁ (m'∈outs , v'spk , newV')

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -56,7 +56,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre)) → ValidSenderForPK (availEpochs pre) v pid pk
    -- And if there exists another v' that has been sent before
    → v' ⊂Msg m' → (pid' , m') ∈ (msgPool pre) → WithVerSig pk v'
-   -- If v and v' share the same epoch and iround
+   -- If v and v' share the same epoch and round
    → (v ^∙ vEpoch) ≡ (v' ^∙ vEpoch)
    → (v ^∙ vProposed ∙ biRound) ≡ (v' ^∙ vProposed ∙ biRound)
    ----------------------------------------------------------

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -43,11 +43,11 @@ module LibraBFT.Concrete.Properties.VotesOnce where
 
  ImplObligation₁ : Set₁
  ImplObligation₁ =
-   ∀{e pid pid' s' outs pk}{pre : SystemState e}
+   ∀{e pid s' outs pk}{pre : SystemState e}
    → ReachableSystemState pre
    -- For any honest call to /handle/ or /init/,
    → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
-   → ∀{v m v' m'} → Meta-Honest-PK pk
+   → ∀{v m v'} → Meta-Honest-PK pk
    -- For signed every vote v of every outputted message
    → v  ⊂Msg m  → m ∈ outs → (sig : WithVerSig pk v)
    -- If v is really new and valid
@@ -55,7 +55,8 @@ module LibraBFT.Concrete.Properties.VotesOnce where
      -- same signature, but sent by someone else.  We could prove it implies it though.
    → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre)) → ValidSenderForPK (availEpochs pre) v pid pk
    -- And if there exists another v' that has been sent before
-   → v' ⊂Msg m' → (pid' , m') ∈ (msgPool pre) → WithVerSig pk v'
+   → (sig' : WithVerSig pk v')
+   → MsgWithSig∈ pk (ver-signature sig') (msgPool pre)
    -- If v and v' share the same epoch and round
    → (v ^∙ vEpoch) ≡ (v' ^∙ vEpoch)
    → (v ^∙ vProposed ∙ biRound) ≡ (v' ^∙ vProposed ∙ biRound)
@@ -106,58 +107,18 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    open import LibraBFT.Concrete.Obligations.VotesOnce 𝓔 (ConcreteVoteEvidence 𝓔) as VO
 
    -- The VO proof is done by induction on the execution trace leading to 'st'. In
-   -- Agda, this is 'r : RechableSystemState st' above. We will use induction to
-   -- construct a predicate Pred'' below, which holds for every state on the trace.
+   -- Agda, this is 'r : RechableSystemState st' above.
 
    private
-    -- First we specify the predicate we need: it relates two votes verified
-    -- by the same public key, such that both are elements of the same message pool
-    Pred'' : PK → Vote → Vote → SentMessages → Set
-    Pred'' pk v v' pool
-      = Meta-Honest-PK pk
-      → (ver  : WithVerSig pk v)  → MsgWithSig∈ pk (ver-signature ver) pool
-      → (ver' : WithVerSig pk v') → MsgWithSig∈ pk (ver-signature ver') pool
-      → v ^∙ vEpoch ≡ v' ^∙ vEpoch
-      → v ^∙ vRound ≡ v' ^∙ vRound
-      → v ^∙ vProposedId ≡ v' ^∙ vProposedId
-
-    -- Usually, we want to universally quantify Pred'' over arbitrary votes and pks
-    Pred' : SentMessages → Set
-    Pred' pool = ∀{pk}{v v' : Vote} → Pred'' pk v v' pool
-
-    -- Finally, we state Pred' in terms of SystemSate
-    Pred : ∀{e} → SystemState e → Set
-    Pred = Pred' ∘ msgPool
-
-    -------------------
-    -- * Base Case * --
-    -------------------
-
-    -- Pred above is trivially true for the initial state: there are no messages in the pool
-    Pred₀ : Pred initialState
-    Pred₀ _ _ ()
-
-    --------------------------------------------------
-    -- * Inductive Case: New Epochs in the System * --
-    --------------------------------------------------
-
-    -- Because pushEpoch does not alter the msgPool, the proof is trivial.
-    Pred𝓔 : ∀{e}{st : SystemState e}(𝓔 : EpochConfigFor e) → Pred st → Pred (pushEpoch 𝓔 st)
-    Pred𝓔 𝓔 p = p
-
-    ----------------------------------------------
-    -- * Inductive Case: Transition by a Peer * --
-    ----------------------------------------------
 
     -- From this point onwards, it might be easier to read this proof starting at 'voo'
     -- at the end of the file. Next, we provide an overview the proof.
     --
     -- We wish to prove that, for any two votes v and v' cast by an honest α in the message pool of
     -- a state st, if v and v' have equal rounds and epochs, then they vote for the same block. As
-    -- we have seen above, the base case and the case for a new epoch in the system are
-    -- trivial. Next, we look at the PeerStep case.
-    --
-    -- The induction hypothesis tells us that the property holds in the pre-state.  Next, we reason
+    -- The base case and the case for a new epoch in the system are trivial.
+
+    -- Regarding the PeerStep case. The induction hypothesis tells us that the property holds in the pre-state.  Next, we reason
     -- about the post-state.  We start by analyzing whether v and v' have been sent as outputs of
     -- the PeerStep under scrutiny or were already in the pool before (captured by the PredStep
     -- function).  There are four possibilities:
@@ -167,213 +128,64 @@ module LibraBFT.Concrete.Properties.VotesOnce where
     -- iii) v was present before, but v' is new.
     --  iv) v' was present before, but v is new.
     --
+    -- In order to obtain this four possiblities we invoke newMsg⊎msgSent4 lemma, which
+    -- receives proof that some vote is in a message that is in the msgPool of the post state
+    -- and returns evidence that either the vote is new or that some message with the same
+    -- signature was sent before.
+    --
     -- Case (i) is trivial; cases (iii) and (iv) are symmetric and reduce to an implementation
     -- obligation (Impl-VO1) and case (ii) reduces to a different implementation obligation (Impl-VO2).
-    --
-    -- The proofs of cases (iii) and (iv) are in PredStep-wlog-ht and PredStep-wlog-ht'.  The 'ht'
-    -- suffix refers to 'Here-There' as in one vote is "here" and the other is old, or "there".  We
-    -- first analyze whether the new vote is really new or a replay; sps-cor provides us this
-    -- information.  If the new vote is, in fact, a replay of an old message, we have two old
-    -- messages and can call the induction hypothesis. If it is really new, we must rely on the
-    -- implementation obligation. But to do so, we must prove that the old vote was also sent by
-    -- the same peer.  We can see that is the case by reasoning about PK-inj and IsValidEpochMember.
-    --
-    -- Finally, the proof of case (ii) also branches on whether either of the "new" votes
-    -- are replays or are really new. In case at least one is a replay we fallback to cases (iii) and (iv)
-    -- or just call the induction hypothesis when both are replays.
-    -- When both votes are in fact new, we rely on Impl-VO2 to conclude.
-    --
-    -- In both PredSetp-wlog-ht and PredStep-wlog-hh, we must eliminate the possibility of
-    -- either vote being produced by a cheat step. This is easy because we received
-    -- a proof that the PK in question is honest, hence, it must be the case that a cheat
-    -- step is at most replaying these votes, not producing them. Producing them would
-    -- require the cheater to forge a signature. This is the purpose of the isCheat constraint.
-
-    PredStep-wlog-ht' : ∀{e pid pid' s' outs pk}{pre : SystemState e}
-            → ReachableSystemState pre
-            → Pred pre
-            → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
-            → ∀{v m v' m'}
-            → v  ⊂Msg m  → m ∈ outs
-            → v' ⊂Msg m' → (pid' , m') ∈ msgPool pre
-            → WithVerSig pk v → WithVerSig pk v' → Meta-Honest-PK pk
-            → (v ^∙ vEpoch) ≡ (v' ^∙ vEpoch)
-            → (v ^∙ vProposed ∙ biRound) ≡ (v' ^∙ vProposed ∙ biRound)
-            → (v ^∙ vProposed ∙ biId) ≡ (v' ^∙ vProposed ∙ biId)
-    PredStep-wlog-ht' {pre = pre} preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈pool ver ver' hpk eids≡ r≡
-    -- (1) The first step is branching on whether 'v' above is a /new/ vote or not.
-    -- (1.1) If it's new:
-      with sps-corr preach hpk ps m∈outs v⊂m ver
-    ...| inj₁ (vValid , vNew)
-      with honestPartValid preach hpk v'⊂m' m'∈pool ver'
-    ...| v'Old , vOldValid
-      with sameHonestSig⇒sameVoteData hpk ver' (msgSigned v'Old) (sym (msgSameSig v'Old))
-    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-    ...| inj₂ refl = Impl-VO1 preach ps hpk v⊂m m∈outs ver vNew vValid
-                       (msg⊆ v'Old) (msg∈pool v'Old)
-                       (msgSigned v'Old) eids≡ r≡
-    -- (1.1) If 'v' is not new, then there exists a msg sent with the
-    -- same signature.
-    PredStep-wlog-ht' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈pool ver ver' hpk e≡ r≡
-       | inj₂ vOld
-      with honestPartValid preach hpk v'⊂m' m'∈pool ver'
-    ...| sv' , _ = hip hpk ver vOld ver' sv' e≡ r≡
-
-    -- Here we prove a modified version of Pred'' where we assume w.l.o.g that
-    -- one vote is sent by "pstep" and another was present in the prestate.
-    PredStep-wlog-ht
-      : ∀{e pid st' outs}{pre : SystemState e}
-      → ReachableSystemState pre
-      → (pstep : StepPeer pre pid st' outs)
-      → Pred pre
-      → ∀{pk v v'}
-      -- Below is a inline expansion of "Pred'' pk v v' (msgPool (StepPeer-post pstep))",
-      -- but with the added information that one vote (v) was sent by pstep whereas the
-      -- other (v') was in the pool of the prestate.
-      → let pool = msgPool (StepPeer-post pstep)
-         in Meta-Honest-PK pk
-          → (ver  : WithVerSig pk v )(sv  : MsgWithSig∈ pk (ver-signature ver ) pool)
-          → (msgSender sv , msgWhole sv) ∈ List-map (pid ,_) outs
-          → (ver' : WithVerSig pk v')(sv' : MsgWithSig∈ pk (ver-signature ver') pool)
-          → (msgSender sv' , msgWhole sv') ∈ msgPool pre
-          → v ^∙ vEpoch ≡ v' ^∙ vEpoch
-          → v ^∙ vRound ≡ v' ^∙ vRound
-          → v ^∙ vProposedId ≡ v' ^∙ vProposedId
-    PredStep-wlog-ht preach (step-cheat fm isCheat) hip hpk ver sv (here refl) ver' sv' furtherBack' epoch≡ r≡
-      with isCheat (msg⊆ sv) (msgSigned sv)
-    ...| inj₁ abs    = ⊥-elim (hpk abs) -- The key was honest by hypothesis.
-    ...| inj₂ sentb4
-       -- the cheater replayed the message; which means the message was sent before this
-       -- step; hence, call induction hypothesis.
-      with msgSameSig sv
-    ...| refl = hip hpk ver sentb4 ver' (MsgWithSig∈-transp sv' furtherBack') epoch≡ r≡
-    PredStep-wlog-ht preach (step-honest x) hip hpk ver sv thisStep ver' sv' furtherBack' epoch≡ r≡
-      with sameHonestSig⇒sameVoteData hpk ver (msgSigned sv) (sym (msgSameSig sv))
-    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-    ...| inj₂ refl
-      with sameHonestSig⇒sameVoteData hpk ver' (msgSigned sv') (sym (msgSameSig sv'))
-    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-    ...| inj₂ refl
-       = PredStep-wlog-ht' preach hip x
-                 (msg⊆ sv) (Any-map (cong proj₂) (Any-map⁻ thisStep))
-                 (msg⊆ sv') furtherBack'
-                 (msgSigned sv) (msgSigned sv') hpk epoch≡ r≡
-
-    -- Analogous to PredStep-wlog-ht', but here we must reason about two messages that are in the
-    -- outputs of a step.
-    PredStep-hh' : ∀{e pid s' outs pk}{pre : SystemState e}
-            → ReachableSystemState pre → Pred pre
-            → StepPeerState pid (availEpochs pre) (msgPool pre) (Map-lookup pid (peerStates pre)) (s' , outs)
-            → ∀{v m v' m'}
-            → v  ⊂Msg m  → m  ∈ outs
-            → v' ⊂Msg m' → m' ∈ outs
-            → WithVerSig pk v → WithVerSig pk v' → Meta-Honest-PK pk
-            → (v ^∙ vEpoch) ≡ (v' ^∙ vEpoch)
-            → (v ^∙ vProposed ∙ biRound) ≡ (v' ^∙ vProposed ∙ biRound)
-            → (v ^∙ vProposed ∙ biId) ≡ (v' ^∙ vProposed ∙ biId)
-    -- Since the step is from an honest peer, we can check whether the messages are in fact
-    -- new or not.
-    PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
-      with sps-corr preach hpk ps m∈outs v⊂m ver | sps-corr preach hpk ps m'∈outs v'⊂m' ver'
-    -- (A) Both are old: call induction hypothesis
-    ...| inj₂ vOld            | inj₂ v'Old = hip hpk ver vOld ver' v'Old e≡ r≡
-
-    -- (B) One is new, one is old: use PredStep-wlog-ht'
-    PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
-       | inj₁ _ | inj₂ v'Old
-      with sameHonestSig⇒sameVoteData hpk ver' (msgSigned v'Old) (sym (msgSameSig v'Old))
-    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-    ...| inj₂ refl
-       = PredStep-wlog-ht' preach hip ps v⊂m m∈outs (msg⊆ v'Old) (msg∈pool v'Old) ver (msgSigned v'Old) hpk e≡ r≡
-
-    -- (C) One is old, one is new: use PredStep-wlog-ht'
-    PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
-       | inj₂ vOld            | inj₁ (v'Valid , v'New)
-      with sameHonestSig⇒sameVoteData hpk ver (msgSigned vOld) (sym (msgSameSig vOld))
-    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-    ...| inj₂ refl
-       = sym (PredStep-wlog-ht' preach hip ps v'⊂m' m'∈outs (msg⊆ vOld) (msg∈pool vOld) ver' (msgSigned vOld) hpk (sym e≡) (sym r≡))
-
-    -- (D) Finally, both votes are new in this step. The proof is then trivially
-    -- forwarded to the implementation obligation.
-    PredStep-hh' preach hip ps {v} v⊂m m∈outs v'⊂m' m'∈outs ver ver' hpk e≡ r≡
-       | inj₁ (vValid , vNew) | inj₁ (v'Valid , v'New)
-       = Impl-VO2 preach ps hpk v⊂m m∈outs ver vNew vValid v'⊂m' m'∈outs ver' v'New v'Valid e≡ r≡
-
-    PredStep-hh
-      : ∀{e pid st' outs}{pre : SystemState e}
-      → ReachableSystemState pre
-      → (pstep : StepPeer pre pid st' outs)
-      → Pred pre
-      → ∀{pk v v'}
-      → let pool = msgPool (StepPeer-post pstep)
-         in Meta-Honest-PK pk
-          → (ver  : WithVerSig pk v )(sv  : MsgWithSig∈ pk (ver-signature ver ) pool)
-          → (msgSender sv  , msgWhole sv)  ∈ List-map (pid ,_) outs
-          → (ver' : WithVerSig pk v')(sv' : MsgWithSig∈ pk (ver-signature ver') pool)
-          → (msgSender sv' , msgWhole sv') ∈ List-map (pid ,_) outs
-          → v ^∙ vEpoch ≡ v' ^∙ vEpoch
-          → v ^∙ vRound ≡ v' ^∙ vRound
-          → v ^∙ vProposedId ≡ v' ^∙ vProposedId
-    PredStep-hh preach (step-cheat fm isCheat) hip hpk ver sv (here refl) ver' sv' (here refl) epoch≡ r≡
-      with isCheat (msg⊆ sv) (msgSigned sv)
-    ...| inj₁ abs    = ⊥-elim (hpk abs) -- The key was honest by hypothesis.
-    ...| inj₂ sentb4
-      with isCheat (msg⊆ sv') (msgSigned sv')
-    ...| inj₁ abs     = ⊥-elim (hpk abs) -- The key was honest by hypothesis.
-    ...| inj₂ sentb4'
-      with msgSameSig sv | msgSameSig sv'
-    ...| refl | refl = hip hpk ver sentb4 ver' sentb4' epoch≡ r≡
-    PredStep-hh preach (step-honest x) hip hpk ver sv thisStep ver' sv' thisStep' epoch≡ r≡
-      with sameHonestSig⇒sameVoteData hpk ver (msgSigned sv) (sym (msgSameSig sv))
-    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-    ...| inj₂ refl
-      with sameHonestSig⇒sameVoteData hpk ver' (msgSigned sv') (sym (msgSameSig sv'))
-    ...| inj₁ abs  = ⊥-elim (meta-sha256-cr abs)
-    ...| inj₂ refl
-       = PredStep-hh' preach hip x
-                 (msg⊆ sv ) (Any-map (cong proj₂) (Any-map⁻ thisStep))
-                 (msg⊆ sv') (Any-map (cong proj₂) (Any-map⁻ thisStep'))
-                 (msgSigned sv) (msgSigned sv') hpk epoch≡ r≡
 
 
-    PredStep : ∀{e pid st' outs}{pre : SystemState e}
-             → ReachableSystemState pre
-             → (pstep : StepPeer pre pid st' outs)
-             → Pred pre
-             → Pred (StepPeer-post pstep)
-    PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
-    -- First we check when have the votes been sent:
-      with Any-++⁻ (List-map (pid ,_) outs) {msgPool pre} (msg∈pool sv)
-         | Any-++⁻ (List-map (pid ,_) outs) {msgPool pre} (msg∈pool sv')
-    -- (A) Neither vote has been sent by the step under scrutiny: invoke inductive hypothesis
-    ...| inj₂ furtherBack | inj₂ furtherBack'
-       = hip hpk ver  (MsgWithSig∈-transp sv furtherBack)
-                 ver' (MsgWithSig∈-transp sv' furtherBack') epoch≡ r≡
-    -- (B) One vote was cast here; the other was cast in the past.
-    PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
-       | inj₁ thisStep    | inj₂ furtherBack'
-       = PredStep-wlog-ht preach pstep hip hpk ver sv thisStep ver' sv' furtherBack' epoch≡ r≡
-    -- (C) Symmetric to (B)
-    PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
-       | inj₂ furtherBack | inj₁ thisStep'
-       = sym (PredStep-wlog-ht preach pstep hip hpk ver' sv' thisStep' ver sv furtherBack (sym epoch≡) (sym r≡))
-    -- (D) Both votes were cast here
-    PredStep {e} {pid} {st'} {outs} {pre} preach pstep hip hpk ver sv ver' sv' epoch≡ r≡
-       | inj₁ thisStep    | inj₁ thisStep'
-       = PredStep-hh preach pstep hip hpk ver sv thisStep ver' sv' thisStep' epoch≡ r≡
+    VotesOnceProof :
+       ∀ {v v' e pk} {st : SystemState e}
+       → ReachableSystemState st
+       → Meta-Honest-PK pk
+       → (vv  : WithVerSig pk v)  → MsgWithSig∈ pk (ver-signature vv) (msgPool st)
+       → (vv' : WithVerSig pk v') → MsgWithSig∈ pk (ver-signature vv') (msgPool st)
+       → v ^∙ vEpoch ≡ v' ^∙ vEpoch
+       → v ^∙ vRound ≡ v' ^∙ vRound
+       → v ^∙ vProposedId ≡ v' ^∙ vProposedId
+    VotesOnceProof step-0 _ _ msv _ _ _ _ = ⊥-elim (¬Any[] (msg∈pool msv))
+    VotesOnceProof (step-s r (step-epoch _)) pkH vv msv vv' msv' ep≡ r≡
+      = VotesOnceProof r pkH vv msv vv' msv' ep≡ r≡
+    VotesOnceProof (step-s r (step-peer cheat@(step-cheat f c))) pkH vv msv vv' msv' ep≡ r≡
+      with ¬cheatForgeNew cheat refl unit pkH msv | ¬cheatForgeNew cheat refl unit pkH msv'
+    ...| msb4 | m'sb4
+      with  msgSameSig msb4 | msgSameSig m'sb4
+    ...| refl | refl = VotesOnceProof r pkH vv msb4 vv' m'sb4 ep≡ r≡
+    VotesOnceProof (step-s r (step-peer (step-honest stPeer))) pkH vv msv vv' msv' ep≡ r≡
+        with  msgSameSig msv | msgSameSig msv'
+    ...| refl | refl
+       with sameHonestSig⇒sameVoteData pkH (msgSigned msv) vv (msgSameSig msv)
+          | sameHonestSig⇒sameVoteData pkH (msgSigned msv') vv' (msgSameSig msv')
+    ...| inj₁ hb    | _         = ⊥-elim (meta-sha256-cr hb)
+    ...| inj₂ refl  | inj₁ hb   = ⊥-elim (meta-sha256-cr hb)
+    ...| inj₂ refl  | inj₂ refl
+      with newMsg⊎msgSent4 r stPeer pkH (msgSigned msv) (msg⊆ msv) (msg∈pool msv)
+         | newMsg⊎msgSent4 r stPeer pkH (msgSigned msv') (msg⊆ msv') (msg∈pool msv')
+    ...| inj₂ msb4                   | inj₂ m'sb4
+         = VotesOnceProof r pkH vv msb4 vv' m'sb4 ep≡ r≡
+    ...| inj₁ (m∈outs , vspk , newV) | inj₁ (m'∈outs , v'spk , newV')
+      = Impl-VO2 r stPeer pkH (msg⊆ msv) m∈outs (msgSigned msv) newV vspk
+                 (msg⊆ msv') m'∈outs (msgSigned msv') newV' v'spk ep≡ r≡
+    ...| inj₁ (m∈outs , vspk , newV) | inj₂ m'sb4
+      = Impl-VO1 r stPeer pkH (msg⊆ msv) m∈outs (msgSigned msv)
+                    newV vspk vv' m'sb4 ep≡ r≡
+    ...| inj₂ msb4                   | inj₁ (m'∈outs , v'spk , newV')
+         = sym (Impl-VO1 r stPeer pkH (msg⊆ msv') m'∈outs (msgSigned msv')
+                         newV' v'spk vv msb4 (sym ep≡) (sym r≡))
+
 
    voo : VO.Type IntSystemState
    voo hpk refl sv refl sv' round≡
-     with Step*-Step-fold Pred (λ {e} {st} _ → Pred𝓔 {e} {st}) PredStep Pred₀ r
-   ...| res
-     with vmsg≈v (vmFor sv) | vmsg≈v (vmFor sv')
+      with vmsg≈v (vmFor sv) | vmsg≈v (vmFor sv')
    ...| refl | refl
-      = res hpk (vmsgSigned (vmFor sv))
-                (mkMsgWithSig∈ (nm (vmFor sv)) (cv (vmFor sv)) (cv∈nm (vmFor sv))
-                               _ (nmSentByAuth sv) (vmsgSigned (vmFor sv)) refl)
-                (vmsgSigned (vmFor sv'))
-                (mkMsgWithSig∈ (nm (vmFor sv')) (cv (vmFor sv')) (cv∈nm (vmFor sv'))
-                               _ (nmSentByAuth sv') (vmsgSigned (vmFor sv')) refl)
-                (trans (vmsgEpoch (vmFor sv)) (sym (vmsgEpoch (vmFor sv'))))
-                round≡
+       = let ver = vmsgSigned (vmFor sv)
+             mswsv = mkMsgWithSig∈ (nm (vmFor sv)) (cv (vmFor sv)) (cv∈nm (vmFor sv))
+                                    _ (nmSentByAuth sv) (vmsgSigned (vmFor sv)) refl
+             ver' = vmsgSigned (vmFor sv')
+             mswsv' = mkMsgWithSig∈ (nm (vmFor sv')) (cv (vmFor sv')) (cv∈nm (vmFor sv'))
+                                     _ (nmSentByAuth sv') (vmsgSigned (vmFor sv')) refl
+             epoch≡ = trans (vmsgEpoch (vmFor sv)) (sym (vmsgEpoch (vmFor sv')))
+         in VotesOnceProof r hpk ver mswsv ver' mswsv' epoch≡ round≡

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -155,20 +155,20 @@ module LibraBFT.Concrete.Properties.VotesOnce where
     VotesOnceProof (step-s r (step-epoch _)) pkH vv msv vv' msv' ep≡ r≡
       = VotesOnceProof r pkH vv msv vv' msv' ep≡ r≡
     VotesOnceProof (step-s r (step-peer cheat@(step-cheat f c))) pkH vv msv vv' msv' ep≡ r≡
-      with ¬cheatForgeNew cheat refl unit pkH msv | ¬cheatForgeNew cheat refl unit pkH msv'
+       with ¬cheatForgeNew cheat refl unit pkH msv | ¬cheatForgeNew cheat refl unit pkH msv'
     ...| msb4 | m'sb4
-      with  msgSameSig msb4 | msgSameSig m'sb4
+       with  msgSameSig msb4 | msgSameSig m'sb4
     ...| refl | refl = VotesOnceProof r pkH vv msb4 vv' m'sb4 ep≡ r≡
     VotesOnceProof (step-s r (step-peer (step-honest stPeer))) pkH vv msv vv' msv' ep≡ r≡
-        with  msgSameSig msv | msgSameSig msv'
+       with  msgSameSig msv | msgSameSig msv'
     ...| refl       | refl
        with sameHonestSig⇒sameVoteData pkH (msgSigned msv) vv (msgSameSig msv)
           | sameHonestSig⇒sameVoteData pkH (msgSigned msv') vv' (msgSameSig msv')
     ...| inj₁ hb    | _         = ⊥-elim (meta-sha256-cr hb)
     ...| inj₂ refl  | inj₁ hb   = ⊥-elim (meta-sha256-cr hb)
     ...| inj₂ refl  | inj₂ refl
-      with newMsg⊎msgSent4 r stPeer pkH (msgSigned msv) (msg⊆ msv) (msg∈pool msv)
-         | newMsg⊎msgSent4 r stPeer pkH (msgSigned msv') (msg⊆ msv') (msg∈pool msv')
+       with newMsg⊎msgSentB4 r stPeer pkH (msgSigned msv) (msg⊆ msv) (msg∈pool msv)
+         | newMsg⊎msgSentB4 r stPeer pkH (msgSigned msv') (msg⊆ msv') (msg∈pool msv')
     ...| inj₂ msb4                   | inj₂ m'sb4
          = VotesOnceProof r pkH vv msb4 vv' m'sb4 ep≡ r≡
     ...| inj₁ (m∈outs , vspk , newV) | inj₁ (m'∈outs , v'spk , newV')
@@ -184,7 +184,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
        | refl       | refl
        | inj₂ refl  | inj₂ refl
        | inj₂ msb4                   | inj₁ (m'∈outs , v'spk , newV')
-      with sameHonestSig⇒sameVoteData pkH (msgSigned msb4) vv (msgSameSig msb4)
+       with sameHonestSig⇒sameVoteData pkH (msgSigned msb4) vv (msgSameSig msb4)
     ...| inj₁ hb = ⊥-elim (meta-sha256-cr hb)
     ...| inj₂ refl
       = sym (Impl-VO1 r stPeer pkH (msg⊆ msv') m'∈outs (msgSigned msv') newV' v'spk

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -209,7 +209,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
   -- probably not containing Votes?
   vo₁ r (step-init _) _ _ m∈outs _ _ _ _ _ _ _ = ⊥-elim (¬Any[] m∈outs)
   vo₁ {e} {pid} {pk = pk} {pre = pre} r (step-msg m∈pool ps≡)
-      {v' = v'} hpk v⊂m m∈outs sig ¬sentb4 vpb v'⊂m' m'∈outs sig' refl rnds≡
+      {v' = v'} hpk v⊂m m∈outs sig ¬sentb4 vpb v'⊂m' m'∈pool sig' refl rnds≡
      with newVoteSameEpochGreaterRound {e} {pre} {pid = pid} r
                                        (step-msg m∈pool ps≡) ps≡ v⊂m m∈outs sig ¬sentb4
   ...| eIds≡' , suclvr≡v'rnd , _
@@ -220,7 +220,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
      with Any-Step-elim {Q = LvrCarrier pk (₋vSignature v') pre}
                         (fSE⇒rnd≤lvr {v'} hpk)
                         (Any-Step-⇒ (λ _ ivnp → isValidNewPart⇒fSE {v' = v'} hpk ivnp)
-                                    (unwind r hpk v'⊂m' m'∈outs sig'))
+                                    (unwind r hpk v'⊂m' m'∈pool sig'))
   ...| mkCarrier r' mws vpf' sndrst sndrst≡ (_ , ps≡' , preprop)
      -- The fake/trivial handler always sends a vote for its current epoch, but for a
      -- round greater than its last voted round

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -207,7 +207,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
   vo₁ : VO.ImplObligation₁
   -- Initialization doesn't send any messages at all so far.  In future it may send messages, but
   -- probably not containing Votes?
-  vo₁ r (step-init _) _ _ m∈outs _ _ _ _ _ _ _ = ⊥-elim (¬Any[] m∈outs)
+  vo₁ r (step-init _) _ _ m∈outs = ⊥-elim (¬Any[] m∈outs)
   vo₁ {e} {pid} {pk = pk} {pre = pre} r (step-msg m∈pool ps≡)
       {v' = v'} hpk v⊂m m∈outs sig ¬sentb4 vpb v'⊂m' m'∈pool sig' refl rnds≡
      with newVoteSameEpochGreaterRound {e} {pre} {pid = pid} r

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -209,7 +209,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
   -- probably not containing Votes?
   vo₁ r (step-init _) _ _ m∈outs _ _ _ _ _ _ _ = ⊥-elim (¬Any[] m∈outs)
   vo₁ {e} {pid} {pk = pk} {pre = pre} r (step-msg m∈pool ps≡)
-      {v' = v'} hpk v⊂m m∈outs sig ¬sentb4 vpb sig' msv' refl rnds≡
+      {v' = v'} hpk v⊂m m∈outs sig ¬sentb4 vpb v'⊂m' m'∈outs sig' refl rnds≡
      with newVoteSameEpochGreaterRound {e} {pre} {pid = pid} r
                                        (step-msg m∈pool ps≡) ps≡ v⊂m m∈outs sig ¬sentb4
   ...| eIds≡' , suclvr≡v'rnd , _
@@ -217,13 +217,10 @@ module LibraBFT.Impl.Properties.VotesOnce where
      -- prove that going from the poststate of that step to pre results in a state in which the
      -- round of v' is at most the last voted round recorded in the peerState of the peer that
      -- sent v'
-      with sameHonestSig⇒sameVoteData hpk (msgSigned msv') sig' (msgSameSig msv')
-  ...| inj₁ hb = ⊥-elim (PerState.meta-sha256-cr pre r hb)
-  ...| inj₂ refl
      with Any-Step-elim {Q = LvrCarrier pk (₋vSignature v') pre}
                         (fSE⇒rnd≤lvr {v'} hpk)
                         (Any-Step-⇒ (λ _ ivnp → isValidNewPart⇒fSE {v' = v'} hpk ivnp)
-                                    (unwind r hpk {!msg⊆ msv'!} {!!} {!sig!}))
+                                    (unwind r hpk v'⊂m' m'∈outs sig'))
   ...| mkCarrier r' mws vpf' sndrst sndrst≡ (_ , ps≡' , preprop)
      -- The fake/trivial handler always sends a vote for its current epoch, but for a
      -- round greater than its last voted round

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -272,7 +272,7 @@ module LibraBFT.Yasm.Properties
      ...| mws'' , vpb'' rewrite sym (msgSameSig mws) = MsgWithSig∈-++ʳ mws'' , vpb''
 
 
-     newMsg⊎msgSent4 :  ∀ {e pk v m pid sndr s' outs} {st : SystemState e}
+     newMsg⊎msgSentB4 :  ∀ {e pk v m pid sndr s' outs} {st : SystemState e}
                    → (r : ReachableSystemState st)
                    → (stP : StepPeerState pid (availEpochs st) (msgPool st)
                                           (Map-lookup pid (peerStates st)) (s' , outs))
@@ -281,15 +281,15 @@ module LibraBFT.Yasm.Properties
                    → (m ∈ outs × ValidSenderForPK (availEpochs st) v pid pk
                       × ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool st)))
                      ⊎ MsgWithSig∈ pk (ver-signature sig) (msgPool st)
-     newMsg⊎msgSent4 {_} {pk} {v} {m} {pid} {sndr} {outs = outs} r stP pkH sig v⊂m m∈post
-       with Any-++⁻ (List-map (pid ,_) outs) m∈post
+     newMsg⊎msgSentB4 {_} {pk} {v} {m} {pid} {sndr} {outs = outs} r stP pkH sig v⊂m m∈post
+        with Any-++⁻ (List-map (pid ,_) outs) m∈post
      ...| inj₂ m∈preSt = inj₂ (mkMsgWithSig∈ m v v⊂m sndr m∈preSt sig refl)
      ...| inj₁ nm∈outs
-       with Any-map (cong proj₂) (Any-map⁻ nm∈outs)
+        with Any-map (cong proj₂) (Any-map⁻ nm∈outs)
      ...| m∈outs
-       with sps-avp r pkH stP m∈outs v⊂m sig
-     ... | inj₁ newVote = inj₁ (m∈outs , newVote)
-     ... | inj₂ msb4    = inj₂ msb4
+        with sps-avp r pkH stP m∈outs v⊂m sig
+     ...| inj₁ newVote = inj₁ (m∈outs , newVote)
+     ...| inj₂ msb4    = inj₂ msb4
 
 
  -- This could potentially be more general, for example covering the whole SystemState, rather than

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -273,25 +273,31 @@ module LibraBFT.Yasm.Properties
      ...| mws'' , vpb'' rewrite sym (msgSameSig mws) = MsgWithSig∈-++ʳ mws'' , vpb''
 
 
-     newMsg⊎msgSentB4 :  ∀ {e pk v m pid sndr s' outs} {st : SystemState e}
+     newMsg⊎msgSentB4 :  ∀ {e pk v m pid sndr st' outs} {st : SystemState e}
                    → (r : ReachableSystemState st)
-                   → (stP : StepPeerState pid (availEpochs st) (msgPool st)
-                                          (Map-lookup pid (peerStates st)) (s' , outs))
+                   → (stP : StepPeer st pid st' outs)
                    → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-                   → v ⊂Msg m → (sndr , m) ∈ msgPool (StepPeer-post (step-honest stP))
+                   → v ⊂Msg m → (sndr , m) ∈ msgPool (StepPeer-post stP)
                    → (m ∈ outs × ValidSenderForPK (availEpochs st) v pid pk
                       × ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool st)))
                      ⊎ MsgWithSig∈ pk (ver-signature sig) (msgPool st)
-     newMsg⊎msgSentB4 {_} {pk} {v} {m} {pid} {sndr} {outs = outs} r stP pkH sig v⊂m m∈post
+     newMsg⊎msgSentB4 {e} {pk} {v} {m} {pid} {sndr} {_} {outs} {st} r stP pkH sig v⊂m m∈post
         with Any-++⁻ (List-map (pid ,_) outs) m∈post
      ...| inj₂ m∈preSt = inj₂ (mkMsgWithSig∈ m v v⊂m sndr m∈preSt sig refl)
      ...| inj₁ nm∈outs
         with Any-map (cong proj₂) (Any-map⁻ nm∈outs)
      ...| m∈outs
-        with sps-avp r pkH stP m∈outs v⊂m sig
+        with stP
+     ...| step-honest stH
+        with sps-avp r pkH stH m∈outs v⊂m sig
      ...| inj₁ newVote = inj₁ (m∈outs , newVote)
      ...| inj₂ msb4    = inj₂ msb4
-
+     newMsg⊎msgSentB4 {e} {pk} {v} {m} {pid} {sndr} {_} {outs} {st} r stP pkH sig v⊂m m∈post
+        | inj₁ nm∈outs
+        | here refl
+        | step-cheat fm ic
+          = let mws = mkMsgWithSig∈ m v v⊂m pid (here refl) sig refl
+            in inj₂ (¬cheatForgeNew {st = st} (step-cheat fm ic) refl unit pkH mws)
 
  -- This could potentially be more general, for example covering the whole SystemState, rather than
  -- just one peer's state.  However, this would put more burden on the user and is not required so

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -272,6 +272,26 @@ module LibraBFT.Yasm.Properties
      ...| mws'' , vpb'' rewrite sym (msgSameSig mws) = MsgWithSig∈-++ʳ mws'' , vpb''
 
 
+     newMsg⊎msgSent4 :  ∀ {e pk v m pid sndr s' outs} {st : SystemState e}
+                   → (r : ReachableSystemState st)
+                   → (stP : StepPeerState pid (availEpochs st) (msgPool st)
+                                          (Map-lookup pid (peerStates st)) (s' , outs))
+                   → Meta-Honest-PK pk → (sig : WithVerSig pk v)
+                   → v ⊂Msg m → (sndr , m) ∈ msgPool (StepPeer-post (step-honest stP))
+                   → (m ∈ outs × ValidSenderForPK (availEpochs st) v pid pk
+                      × ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool st)))
+                     ⊎ MsgWithSig∈ pk (ver-signature sig) (msgPool st)
+     newMsg⊎msgSent4 {_} {pk} {v} {m} {pid} {sndr} {outs = outs} r stP pkH sig v⊂m m∈post
+       with Any-++⁻ (List-map (pid ,_) outs) m∈post
+     ...| inj₂ m∈preSt = inj₂ (mkMsgWithSig∈ m v v⊂m sndr m∈preSt sig refl)
+     ...| inj₁ nm∈outs
+       with Any-map (cong proj₂) (Any-map⁻ nm∈outs)
+     ...| m∈outs
+       with sps-avp r pkH stP m∈outs v⊂m sig
+     ... | inj₁ newVote = inj₁ (m∈outs , newVote)
+     ... | inj₂ msb4    = inj₂ msb4
+
+
  -- This could potentially be more general, for example covering the whole SystemState, rather than
  -- just one peer's state.  However, this would put more burden on the user and is not required so
  -- far.


### PR DESCRIPTION
Managed to simplify the `VotesOnlyOnce` property on the concrete side. This property states that for any two votes `v` and `v'`, cast by an honest `α`, in the message pool of a state `st`, if `v` and `v'` have equal rounds and epochs, then they vote for the same block.
In order to achieve that we defined a new lemma called `newMsg⊎msgSent4` that for every message in the message pool of a post-state returns evidence that either is a new valid message for the peer taking the step or that some message with the same signature was sent before. Given that, to prove the `VotesOnlyOnce` property for the `StepPeerState` we just need to split the proof in 4 possibilities (as before):

- `v` and `v'` were already present in the msgPool before -> use induction hypothesis
- `v` and `v'` are both in the output produced by the `PeerStep` under scrutiny -> use `ImplObligation₂` 
- `v` was present before, but `v'` is new -> use `ImplObligation₁`
- `v'` was present before, but `v` is new -> use `ImplObligation₁`

