### PR TITLE
rename types

### DIFF
--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -9,14 +9,14 @@ open import LibraBFT.Abstract.Types
 open import LibraBFT.Abstract.Types.EpochConfig
 open        WithAbsVote
 
--- For each desired property (VotesOnce and LockedRoundRule), we have a
+-- For each desired property (VotesOnce and PreferredRoundRule), we have a
 -- module containing a Type that defines a property that an implementation
 -- should prove, and a proof that it implies the corresponding rule used by
 -- the abstract proofs.  Then, we use those proofs to instantiate thmS5,
 -- and the use thmS5 to prove a number of correctness conditions.
 --
 -- TODO-1: refactor this file to separate the definitions and proofs of
--- VotesOnce and LockedRoundRule from their use in proving the correctness
+-- VotesOnce and PreferredRoundRule from their use in proving the correctness
 -- properties.
 
 module LibraBFT.Abstract.Properties
@@ -38,7 +38,7 @@ module LibraBFT.Abstract.Properties
  module WithAssumptions {ℓ}
    (InSys                 : Record → Set ℓ)
    (votes-only-once       : VotesOnlyOnceRule InSys)
-   (locked-round-rule     : LockedRoundRule   InSys)
+   (preferred-round-rule  : PreferredRoundRule InSys)
   where
 
    open All-InSys-props InSys
@@ -50,7 +50,7 @@ module LibraBFT.Abstract.Properties
         → CommitRule rc  b
         → CommitRule rc' b'
         → NonInjective-≡ bId ⊎ ((B b) ∈RC rc' ⊎ (B b') ∈RC rc)
-   CommitsDoNotConflict = WithInvariants.thmS5 InSys votes-only-once locked-round-rule
+   CommitsDoNotConflict = WithInvariants.thmS5 InSys votes-only-once preferred-round-rule
 
    -- When we are dealing with a /Complete/ InSys predicate, we can go a few steps
    -- further and prove that commits do not conflict even if we have only partial

--- a/LibraBFT/Abstract/RecordChain/Assumptions.agda
+++ b/LibraBFT/Abstract/RecordChain/Assumptions.agda
@@ -53,13 +53,13 @@ module LibraBFT.Abstract.RecordChain.Assumptions
 
   module _ {ℓ}(InSys  : Record → Set ℓ) where
 
-   -- The locked-round-rule, or preferred-round rule (from V3 onwards) is a critical
+   -- The preferred-round rule (aka locked-round-rule) is a critical
    -- aspect of LibraBFT's correctness. It states that an honest node α will cast
-   -- votes for blocks b only if prevRound(b) ≥ locked_round(α), where locked_round(α)
+   -- votes for blocks b only if prevRound(b) ≥ preferred_round(α), where preferred_round(α)
    -- is defined as $max { round b | b is the head of a 2-chain }$.
    --
    -- Operationally, α can ensure it obeys this rule as follows: it keeps a counter
-   -- locked_round, initialized at 0 and, whenever α receives a QC q that forms a
+   -- preferred_round, initialized at 0 and, whenever α receives a QC q that forms a
    -- 2-chain:
    --
    --  Fig1
@@ -69,13 +69,13 @@ module LibraBFT.Abstract.RecordChain.Assumptions
    --                2-chain
    --
    -- it checks whether round(b₁) , which is the head of the 2-chain above,
-   -- is greater than its previously known locked_round; if so, α updates
+   -- is greater than its previously known preferred_round; if so, α updates
    -- it.  Note that α doesn't need to cast a vote in q, above, to have its
-   -- locked_round updated.  All that matters is that α has seen q.
+   -- preferred_round updated.  All that matters is that α has seen q.
    --
    -- We are encoding the rules governing Libra nodes as invariants in the
-   -- state of other nodes. Hence, the LockedRoundRule below states an invariant
-   -- on the state of β, if α respects the locked-round-rule.
+   -- state of other nodes. Hence, the PreferredRoundRule below states an invariant
+   -- on the state of β, if α respects the preferred-round-rule.
    --
    -- Let the state of β be as below, such that α did cast votes for q
    -- and q' in that order (α is honest here!):
@@ -90,20 +90,20 @@ module LibraBFT.Abstract.RecordChain.Assumptions
    --         ↖
    --           ⋯ ← b₁' ← q₁' ← b' ← q'
    --
-   -- Then, since α is honest and follows the locked-round rule, we know that
+   -- Then, since α is honest and follows the preferred-round rule, we know that
    -- round(b₂) ≤ round(b₁') because, by seeing that α voted on q, we know that α
-   -- has seen the 2-chain above, hence, α's locked_round was at least round(b₂) at
+   -- has seen the 2-chain above, hence, α's preferred_round was at least round(b₂) at
    -- the time α cast its vote for b.
    --
    -- After casting a vote for b, α cast a vote for b', which means that α must have
-   -- checked that round(b₂) ≤ prevRound(b'), as stated by the locked round rule.
+   -- checked that round(b₂) ≤ prevRound(b'), as stated by the preferred round rule.
    --
    -- The invariant below states that, since α is honest, we can trust that these
    -- checks have been performed and we can infer this information solely
    -- by seeing α has knowledge of the 2-chain in Fig2 above.
    --
-   LockedRoundRule : Set ℓ
-   LockedRoundRule
+   PreferredRoundRule : Set ℓ
+   PreferredRoundRule
      = ∀(α : Member) → Meta-Honest-Member α
      → ∀{q q'}(q∈𝓢 : InSys (Q q))(q'∈𝓢 : InSys (Q q'))
      → {rc : RecordChain (Q q)}{n : ℕ}(c3 : 𝕂-chain Contig (3 + n) rc)

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -37,7 +37,7 @@ module LibraBFT.Abstract.RecordChain.Properties
  module WithInvariants {ℓ}
    (InSys                 : Record → Set ℓ)
    (votes-only-once       : VotesOnlyOnceRule InSys)
-   (locked-round-rule     : LockedRoundRule   InSys)
+   (preferred-round-rule  : PreferredRoundRule InSys)
    where
    open All-InSys-props InSys
 
@@ -118,7 +118,7 @@ module LibraBFT.Abstract.RecordChain.Properties
       | tri< va₂<va' _ _
      with b←q'
    ...| B←Q rrr xxx
-      = locked-round-rule a honest {q₂} {q'} ex₀ ex₁ (s-chain r←b₂ P b₂←q₂ c2) a∈q₂
+      = preferred-round-rule a honest {q₂} {q'} ex₀ ex₁ (s-chain r←b₂ P b₂←q₂ c2) a∈q₂
                     (step rc' (B←Q rrr xxx)) a∈q'
                           (≤-trans (≤-reflexive (cong suc a∈q₂rnd≡))
                                    va₂<va')

--- a/LibraBFT/Abstract/Records.agda
+++ b/LibraBFT/Abstract/Records.agda
@@ -27,7 +27,7 @@ module LibraBFT.Abstract.Records
   -- UID of an abstract one; the connection between states is implicit.
   -- Our proofs all work modulo injectivity of UID anyway.
   record Block  : Set where
-    constructor mkBlock
+    constructor Block∙new
     field
       bRound   : Round
       bId      : UID
@@ -67,7 +67,7 @@ module LibraBFT.Abstract.Records
   -- A valid quorum certificate contains at least 'QuorumSize ec'
   -- votes from different authors.
   record QC : Set where
-   constructor mkQC
+   constructor QC∙new
    field
      qRound         : Round
      qCertBlockId   : UID -- this is the id for the block it certifies.

--- a/LibraBFT/Abstract/Types/EpochConfig.agda
+++ b/LibraBFT/Abstract/Types/EpochConfig.agda
@@ -27,7 +27,7 @@ module LibraBFT.Abstract.Types.EpochConfig
     constructor mkEpochConfig
     field
       genesisUID : UID
-      epochId   : EpochId
+      epoch      : Epoch
       authorsN  : ℕ
 
     -- The set of members of this epoch.
@@ -70,7 +70,7 @@ module LibraBFT.Abstract.Types.EpochConfig
   record EpochConfigFor (eid : ℕ) : Set₁ where
     field
      epochConfig : EpochConfig
-     forEpochId  : epochId epochConfig ≡ eid
+     forEpoch    : epoch epochConfig ≡ eid
 
   module WithAbsVote (𝓔 : EpochConfig) where
     -- The abstract model is connected to the implementaton by means of

--- a/LibraBFT/Abstract/Types/EpochConfig.agda
+++ b/LibraBFT/Abstract/Types/EpochConfig.agda
@@ -24,7 +24,7 @@ module LibraBFT.Abstract.Types.EpochConfig
   -- The reason for the separation is that we should be able to provide
   -- an EpochConfig from a single peer state.
   record EpochConfig : Set₁ where
-    constructor mkEpochConfig
+    constructor EpochConfig∙new
     field
       genesisUID : UID
       epoch      : Epoch
@@ -83,7 +83,7 @@ module LibraBFT.Abstract.Types.EpochConfig
     -- be something that states that we have a signature from the specified
     -- author voting for the specified block.
     record AbsVoteData : Set where
-      constructor mkAbsVoteData
+      constructor AbsVoteData∙new
       field
         abs-vRound     : Round
         abs-vMember    : EpochConfig.Member 𝓔
@@ -94,7 +94,7 @@ module LibraBFT.Abstract.Types.EpochConfig
                   → r1 ≡ r2
                   → m1 ≡ m2
                   → b1 ≡ b2
-                  → mkAbsVoteData r1 m1 b1 ≡ mkAbsVoteData r2 m2 b2
+                  → AbsVoteData∙new r1 m1 b1 ≡ AbsVoteData∙new r2 m2 b2
     AbsVoteData-η refl refl refl = refl
 
     VoteEvidence : Set₁

--- a/LibraBFT/Base/Types.agda
+++ b/LibraBFT/Base/Types.agda
@@ -12,8 +12,8 @@ open import LibraBFT.Base.Encode
 -- and some utility types
 module LibraBFT.Base.Types where
 
-  EpochId : Set
-  EpochId = ℕ
+  Epoch : Set
+  Epoch = ℕ
 
   Round : Set
   Round = ℕ
@@ -31,12 +31,12 @@ module LibraBFT.Base.Types where
   -- proofs are per-epoch so far, these are not used, but
   -- they may be in future.
   EpRound : Set
-  EpRound = EpochId × Round
+  EpRound = Epoch × Round
 
   sucr : EpRound → EpRound
   sucr (e , r) = (e , suc r)
 
-  epr-epoch : EpRound → EpochId
+  epr-epoch : EpRound → Epoch
   epr-epoch = proj₁
 
   epr-round : EpRound → Round

--- a/LibraBFT/Concrete/Intermediate.agda
+++ b/LibraBFT/Concrete/Intermediate.agda
@@ -29,7 +29,7 @@ module LibraBFT.Concrete.Intermediate
    where
    open import LibraBFT.Abstract.Abstract UID _≟UID_ NodeId 𝓔 𝓥
 
-   -- Since the invariants we want to specify (votes-once and locked-round-rule),
+   -- Since the invariants we want to specify (votes-once and preferred-round-rule),
    -- are predicates over a /System State/, we must factor out the necessary
    -- functionality.
    --

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -9,7 +9,7 @@ import      LibraBFT.Concrete.Properties.VotesOnce   as VO
 import      LibraBFT.Concrete.Properties.LockedRound as LR
 open import LibraBFT.Impl.Consensus.Types hiding (EpochConfigFor)
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysParms NodeId-PK-OK
 
 -- This module collects in one place the obligations an
 -- implementation must meet in order to enjoy the properties

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -6,7 +6,7 @@
 open import LibraBFT.Prelude
 open import LibraBFT.Concrete.System.Parameters
 import      LibraBFT.Concrete.Properties.VotesOnce   as VO
-import      LibraBFT.Concrete.Properties.LockedRound as LR
+import      LibraBFT.Concrete.Properties.PreferredRound as PR
 open import LibraBFT.Impl.Consensus.Types hiding (EpochConfigFor)
 open        EpochConfig
 open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysParms NodeId-PK-OK
@@ -27,5 +27,5 @@ module LibraBFT.Concrete.Obligations where
       vo₁ : VO.ImplObligation₁
       vo₂ : VO.ImplObligation₂
 
-      -- LockedRound:
-      lr₁ : LR.ImplObligation₁
+      -- PreferredRound:
+      pr₁ : PR.ImplObligation₁

--- a/LibraBFT/Concrete/Obligations/PreferredRound.agda
+++ b/LibraBFT/Concrete/Obligations/PreferredRound.agda
@@ -10,7 +10,7 @@ open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open        WithAbsVote
 
-module LibraBFT.Concrete.Obligations.LockedRound
+module LibraBFT.Concrete.Obligations.PreferredRound
   (𝓔 : EpochConfig)
   (𝓥 : VoteEvidence 𝓔)
   where
@@ -18,13 +18,13 @@ module LibraBFT.Concrete.Obligations.LockedRound
  open import LibraBFT.Concrete.Intermediate               𝓔 𝓥
 
  ---------------------
- -- * LockedRound * --
+ -- * PreferredRound * --
  ---------------------
 
  module _ {ℓ}(𝓢 : IntermediateSystemState ℓ) where
   open IntermediateSystemState 𝓢
 
- -- The LockedRound rule is a little more involved to be expressed in terms
+ -- The PreferredRound rule is a little more involved to be expressed in terms
  -- of /HasBeenSent/: it needs two additional pieces which are introduced
  -- next.
 
@@ -67,7 +67,7 @@ module LibraBFT.Concrete.Obligations.LockedRound
   Cand-3-chain-head-round c3cand =
     getRound (kchainBlock (suc zero) (is-2chain c3cand))
 
-  -- The locked round rule states a fact about the /previous round/
+  -- The preferred round rule states a fact about the /previous round/
   -- of a vote; that is, the round of the parent of the block
   -- being voted for; the implementation will have to
   -- show it can construct this parent.
@@ -87,7 +87,7 @@ module LibraBFT.Concrete.Obligations.LockedRound
       vpMaybeBlock : VoteParentData-BlockExt vpParent
   open VoteParentData public
 
-  -- The setup for LockedRoundRule is like thta for VotesOnce.
+  -- The setup for PreferredRoundRule is like thta for VotesOnce.
   -- Given two votes by an honest author α:
   Type : Set ℓ
   Type = ∀{α v v'}
@@ -100,7 +100,7 @@ module LibraBFT.Concrete.Obligations.LockedRound
        -- and the round of v is lower than that of v',
        → vRound v < vRound v'
        ------------------------------
-       -- then α obeyed the locked round rule:
+       -- then α obeyed the preferred round rule:
        → Σ (VoteParentData v')
            (λ vp → Cand-3-chain-head-round c2 ≤ round (vpParent vp))
 
@@ -163,8 +163,8 @@ module LibraBFT.Concrete.Obligations.LockedRound
      with bP←qP | b←q
    ...| B←Q refl refl | B←Q refl refl = inj₂ refl
 
-  -- Finally, we can prove the locked round rule from the global version;
-  proof : Type → LockedRoundRule InSys
+  -- Finally, we can prove the preferred round rule from the global version;
+  proof : Type → PreferredRoundRule InSys
   proof glob-inv α hα {q} {q'} q∈sys q'∈sys c3 va rc' va' hyp
     with ∈QC⇒HasBeenSent q∈sys  hα va
        | ∈QC⇒HasBeenSent q'∈sys hα va'

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -30,9 +30,9 @@ module LibraBFT.Concrete.Properties
     open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
     open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
     import      LibraBFT.Concrete.Obligations.VotesOnce          𝓔 (ConcreteVoteEvidence 𝓔) as VO-obl
-    import      LibraBFT.Concrete.Obligations.LockedRound        𝓔 (ConcreteVoteEvidence 𝓔) as LR-obl
+    import      LibraBFT.Concrete.Obligations.PreferredRound     𝓔 (ConcreteVoteEvidence 𝓔) as PR-obl
     open import LibraBFT.Concrete.Properties.VotesOnce                                       as VO
-    open import LibraBFT.Concrete.Properties.LockedRound                                     as LR
+    open import LibraBFT.Concrete.Properties.PreferredRound                                  as PR
 
     --------------------------------------------------------------------------------------------
     -- * A /ValidSysState/ is one in which both peer obligations are obeyed by honest peers * --
@@ -41,7 +41,7 @@ module LibraBFT.Concrete.Properties
     record ValidSysState {ℓ}(𝓢 : IntermediateSystemState ℓ) : Set (ℓ+1 ℓ0 ℓ⊔ ℓ) where
       field
         vss-votes-once   : VO-obl.Type 𝓢
-        vss-locked-round : LR-obl.Type 𝓢
+        vss-preferred-round : PR-obl.Type 𝓢
     open ValidSysState public
 
     -- TODO-2 : This should be provided as a module parameter here, and the
@@ -55,7 +55,7 @@ module LibraBFT.Concrete.Properties
     validState : ValidSysState IntSystemState
     validState = record
       { vss-votes-once   = VO.Proof.voo sps-cor vo₁ vo₂ st r eid
-      ; vss-locked-round = LR.Proof.lrr sps-cor lr₁ st r eid
+      ; vss-preferred-round = PR.Proof.prr sps-cor pr₁ st r eid
       }
 
     open IntermediateSystemState IntSystemState
@@ -75,7 +75,7 @@ module LibraBFT.Concrete.Properties
        → NonInjective-≡ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
     ConcCommitsDoNotConflict = CommitsDoNotConflict
            (VO-obl.proof IntSystemState (vss-votes-once validState))
-           (LR-obl.proof IntSystemState (vss-locked-round validState))
+           (PR-obl.proof IntSystemState (vss-preferred-round validState))
 
     module _ (∈QC⇒AllSent : Complete InSys) where
 
@@ -87,7 +87,7 @@ module LibraBFT.Concrete.Properties
         → NonInjective-≡ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
       ConcCommitsDoNotConflict' = CommitsDoNotConflict'
            (VO-obl.proof IntSystemState (vss-votes-once validState))
-           (LR-obl.proof IntSystemState (vss-locked-round validState))
+           (PR-obl.proof IntSystemState (vss-preferred-round validState))
            ∈QC⇒AllSent
 
       ConcCommitsDoNotConflict''
@@ -103,6 +103,6 @@ module LibraBFT.Concrete.Properties
                                  ⊎ Σ (RecordChain (Abs.Q q))  ((Abs.B b') ∈RC_)
       ConcCommitsDoNotConflict'' = CommitsDoNotConflict''
            (VO-obl.proof IntSystemState (vss-votes-once validState))
-           (LR-obl.proof IntSystemState (vss-locked-round validState))
+           (PR-obl.proof IntSystemState (vss-preferred-round validState))
            ∈QC⇒AllSent
 

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -9,7 +9,7 @@ open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysParms NodeId-PK-OK
 
 -- In this module, we assume that the implementation meets its
 -- obligations, and use this assumption to prove that, in any reachable

--- a/LibraBFT/Concrete/Properties/LockedRound.agda
+++ b/LibraBFT/Concrete/Properties/LockedRound.agda
@@ -15,7 +15,7 @@ open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysParms NodeId-PK-OK
 
 -- This module contains placeholders for the future analog of the
 -- corresponding VotesOnce property.  Defining the implementation

--- a/LibraBFT/Concrete/Properties/PreferredRound.agda
+++ b/LibraBFT/Concrete/Properties/PreferredRound.agda
@@ -23,7 +23,7 @@ open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysPa
 -- is a substantial undertaking.  We are working first on proving the
 -- simpler VotesOnce property to settle down the structural aspects
 -- before tackling the harder semantic issues.
-module LibraBFT.Concrete.Properties.LockedRound where
+module LibraBFT.Concrete.Properties.PreferredRound where
  -- TODO-3: define the implementation obligation
  ImplObligation₁ : Set
  ImplObligation₁ = Unit
@@ -31,9 +31,9 @@ module LibraBFT.Concrete.Properties.LockedRound where
  -- Next, we prove that given the necessary obligations,
  module Proof
    (sps-corr : StepPeerState-AllValidParts)
-   (Impl-LR1 : ImplObligation₁)
+   (Impl-PR1 : ImplObligation₁)
    where
-  -- Any reachable state satisfies the LR rule for any epoch in the system.
+  -- Any reachable state satisfies the PR rule for any epoch in the system.
   module _ {e}(st : SystemState e)(r : ReachableSystemState st)(eid : Fin e) where
    -- Bring in 'unwind', 'ext-unforgeability' and friends
    open Structural sps-corr
@@ -42,7 +42,7 @@ module LibraBFT.Concrete.Properties.LockedRound where
    open import LibraBFT.Concrete.System sps-corr
    open        PerState st r
    open        PerEpoch eid
-   open import LibraBFT.Concrete.Obligations.LockedRound 𝓔 (ConcreteVoteEvidence 𝓔) as LR
+   open import LibraBFT.Concrete.Obligations.PreferredRound 𝓔 (ConcreteVoteEvidence 𝓔) as PR
 
    postulate  -- TODO-3: prove it
-     lrr : LR.Type IntSystemState
+     prr : PR.Type IntSystemState

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -16,7 +16,7 @@ open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysParms NodeId-PK-OK
 
 -- In this module, we define two "implementation obligations"
 -- (ImplObligationᵢ for i ∈ {1 , 2}), which are predicates over

--- a/LibraBFT/Concrete/Records.agda
+++ b/LibraBFT/Concrete/Records.agda
@@ -98,4 +98,4 @@ module LibraBFT.Concrete.Records (𝓔 : EpochConfig) where
  -- sm.
  data _α-Sent_ (r : Abs.Record) (sm : List (NodeId × NetworkMsg)) : Set where
    i  : r ≡ Abs.I → r α-Sent sm
-   ws : ∀ {p nm} → getEpoch nm ≡ epochId → (p , nm) ∈ sm → r α-∈NM nm → r α-Sent sm
+   ws : ∀ {p nm} → getEpoch nm ≡ epoch → (p , nm) ∈ sm → r α-∈NM nm → r α-Sent sm

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -16,7 +16,7 @@ open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysParms NodeId-PK-OK
 
 -- This module defines an abstract system state given a reachable
 -- concrete system state.
@@ -24,7 +24,7 @@ open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSys
 -- An implementation must prove that, if one of its handlers sends a
 -- message that contains a vote and is signed by a public key pk, then
 -- either the vote's author is the peer executing the handler, the
--- epochId is in range, the peer is a member of the epoch, and its key
+-- epoch is in range, the peer is a member of the epoch, and its key
 -- in that epoch is pk; or, a message with the same signature has been
 -- sent before.  This is represented by StepPeerState-AllValidParts.
 module LibraBFT.Concrete.System (sps-corr : StepPeerState-AllValidParts) where
@@ -111,7 +111,7 @@ module LibraBFT.Concrete.System (sps-corr : StepPeerState-AllValidParts) where
        vmsgMember    : EpochConfig.Member 𝓔
        vmsgSigned    : WithVerSig (getPubKey 𝓔 vmsgMember) cv
        vmsg≈v        : α-ValidVote 𝓔 cv vmsgMember ≡ v
-       vmsgEpoch     : cv ^∙ vEpoch ≡ epochId 𝓔
+       vmsgEpoch     : cv ^∙ vEpoch ≡ epoch 𝓔
    open ∃VoteMsgFor public
 
    record ∃VoteMsgSentFor (sm : SentMessages)(v : Abs.Vote) : Set where

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -11,7 +11,7 @@ open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Handle sha256 sha256-cr
 open        EpochConfig
-open import LibraBFT.Yasm.Base (ℓ+1 0ℓ) EpochConfig epochId authorsN
+open import LibraBFT.Yasm.Base (ℓ+1 0ℓ) EpochConfig epoch authorsN
 
 -- In this module, we instantiate the system model with parameters to
 -- model a system using the simple implementation model we have so

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -15,7 +15,7 @@ open import LibraBFT.Yasm.Base (ℓ+1 0ℓ) EpochConfig epoch authorsN
 
 -- In this module, we instantiate the system model with parameters to
 -- model a system using the simple implementation model we have so
--- far, which aims to obey the VotesOnceRule, but not LockedRoundRule
+-- far, which aims to obey the VotesOnceRule, but not PreferredRoundRule
 -- yet.  This will evolve as we build out a model of a real
 -- implementation.
 

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -35,7 +35,7 @@ module LibraBFT.Impl.Consensus.RoundManager
   fakeAuthor : Author
   fakeAuthor = 0
 
-  fakeBlockInfo : EpochId → Round → ProposalMsg → BlockInfo
+  fakeBlockInfo : Epoch → Round → ProposalMsg → BlockInfo
   fakeBlockInfo eid rnd pm = BlockInfo∙new eid rnd (pm ^∙ pmProposal ∙ bId)
 
   fakeLedgerInfo : BlockInfo → ProposalMsg → LedgerInfo
@@ -49,7 +49,7 @@ module LibraBFT.Impl.Consensus.RoundManager
   processProposalMsg inst pm = do
     st ← get
     let 𝓔  = α-EC ((₋rmEC st) , (₋rmEC-correct st))
-        ix = EpochConfig.epochId 𝓔
+        ix = EpochConfig.epoch 𝓔
         rm  = ₋rmEC st
         rmw = ₋rmWithEC st
         rmc = ₋rmEC-correct st

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -36,10 +36,10 @@ module LibraBFT.Impl.Consensus.RoundManager
   fakeAuthor = 0
 
   fakeBlockInfo : EpochId → Round → ProposalMsg → BlockInfo
-  fakeBlockInfo eid rnd pm = mkBlockInfo eid rnd (pm ^∙ pmProposal ∙ bId)
+  fakeBlockInfo eid rnd pm = BlockInfo∙new eid rnd (pm ^∙ pmProposal ∙ bId)
 
   fakeLedgerInfo : BlockInfo → ProposalMsg → LedgerInfo
-  fakeLedgerInfo bi pm = mkLedgerInfo bi (pm ^∙ pmProposal ∙ bId)
+  fakeLedgerInfo bi pm = LedgerInfo∙new bi (pm ^∙ pmProposal ∙ bId)
 
   postulate
     fakeSK  : SK
@@ -55,13 +55,14 @@ module LibraBFT.Impl.Consensus.RoundManager
         rmc = ₋rmEC-correct st
         bt = rmw ^∙ (lBlockTree 𝓔)
         nr = suc ((₋rmEC st) ^∙ rmLastVotedRound)
-        uv = mkVote (mkVoteData (fakeBlockInfo ix nr pm) (fakeBlockInfo ix 0 pm))
+        uv = Vote∙new
+                    (VoteData∙new (fakeBlockInfo ix nr pm) (fakeBlockInfo ix 0 pm))
                     fakeAuthor
                     (fakeLedgerInfo (fakeBlockInfo ix nr pm) pm)
                     fakeSig
                     (₋bSignature (₋pmProposal pm))
         sv =  record uv { ₋vSignature = sign ⦃ sig-Vote ⦄ uv fakeSK}
-        si = mkSyncInfo (₋btHighestQuorumCert bt) (₋btHighestCommitCert bt)
+        si = SyncInfo∙new (₋btHighestQuorumCert bt) (₋btHighestCommitCert bt)
         rm' = rm [ rmLastVotedRound := nr ]
         rmc2 = RoundManagerEC-correct-≡ (₋rmEC st) rm' refl rmc
         st' = record st { ₋rmEC         = rm'
@@ -69,7 +70,7 @@ module LibraBFT.Impl.Consensus.RoundManager
                         ; ₋rmWithEC     = subst RoundManagerWithEC (α-EC-≡ rm rm' refl refl rmc) rmw
                         }
     put st'
-    tell1 (SendVote (mkVoteMsg sv si) (fakeAuthor ∷ []))
+    tell1 (SendVote (VoteMsg∙new sv si) (fakeAuthor ∷ []))
     pure unit
 
   processVote : Instant → VoteMsg → LBFT Unit

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -26,6 +26,6 @@ module LibraBFT.Impl.Consensus.RoundManager.Properties
   -- The quorum certificates sent in SyncInfo with votes are those from the peer state
   procPMCerts≡ : ∀ {ts pm pre vm αs}
                → (SendVote vm αs) ∈ LBFT-outs (processProposalMsg ts pm) pre
-               → vm ^∙ vmSyncInfo ≡ mkSyncInfo (₋rmHighestQC pre) (₋rmHighestCommitQC pre)
+               → vm ^∙ vmSyncInfo ≡ SyncInfo∙new (₋rmHighestQC pre) (₋rmHighestCommitQC pre)
   procPMCerts≡ (there x)   = ⊥-elim (¬Any[] x)  -- processProposalMsg sends only one vote
   procPMCerts≡ (here refl) = refl

--- a/LibraBFT/Impl/Consensus/Types.agda
+++ b/LibraBFT/Impl/Consensus/Types.agda
@@ -46,10 +46,10 @@ module LibraBFT.Impl.Consensus.Types where
     (rmSafetyRules ∷ rmValidators ∷ [])
 
   rmEpoch : Lens RoundManagerEC EpochId
-  rmEpoch = rmSafetyRules ∙ srPersistentStorage ∙ psEpoch
+  rmEpoch = rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch
 
   rmLastVotedRound : Lens RoundManagerEC Round
-  rmLastVotedRound = rmSafetyRules ∙ srPersistentStorage ∙ psLastVotedRound
+  rmLastVotedRound = rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdLastVotedRound
 
   -- We need enough authors to withstand the desired number of
   -- byzantine failures.  We enforce this with a predicate over

--- a/LibraBFT/Impl/Consensus/Types.agda
+++ b/LibraBFT/Impl/Consensus/Types.agda
@@ -45,7 +45,7 @@ module LibraBFT.Impl.Consensus.Types where
   unquoteDecl rmSafetyRules rmValidators = mkLens (quote RoundManagerEC)
     (rmSafetyRules ∷ rmValidators ∷ [])
 
-  rmEpoch : Lens RoundManagerEC EpochId
+  rmEpoch : Lens RoundManagerEC Epoch
   rmEpoch = rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch
 
   rmLastVotedRound : Lens RoundManagerEC Round

--- a/LibraBFT/Impl/Consensus/Types.agda
+++ b/LibraBFT/Impl/Consensus/Types.agda
@@ -37,7 +37,7 @@ module LibraBFT.Impl.Consensus.Types where
   -- The parts of the state of a peer that are used to
   -- define the EpochConfig are the SafetyRules and ValidatorVerifier:
   record RoundManagerEC : Set where
-    constructor mkRoundManagerPreEC
+    constructor RoundManagerPreEC∙new
     field
       ₋rmSafetyRules  : SafetyRules
       ₋rmValidators   : ValidatorVerifier
@@ -77,7 +77,7 @@ module LibraBFT.Impl.Consensus.Types where
     let numAuthors = kvm-size (rmec ^∙ rmValidators ∙ vvAddressToValidatorInfo)
         qsize      = rmec ^∙ rmValidators ∙ vvQuorumVotingPower
         bizF       = numAuthors ∸ qsize
-     in (mkEpochConfig {! someHash?!}
+     in (EpochConfig∙new {! someHash?!}
                 (rmec ^∙ rmEpoch) numAuthors {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!})
 
   postulate
@@ -95,7 +95,7 @@ module LibraBFT.Impl.Consensus.Types where
   -- that are used to make an EpochConfig versus those that
   -- use an EpochConfig.
   record RoundManager : Set where
-    constructor mkRoundManager
+    constructor RoundManager∙new
     field
       ₋rmEC           : RoundManagerEC
       ₋rmEC-correct   : RoundManagerEC-correct ₋rmEC
@@ -113,13 +113,13 @@ module LibraBFT.Impl.Consensus.Types where
 
   rmHighestQC : Lens RoundManager QuorumCert
   rmHighestQC = mkLens' ₋rmHighestQC
-                        (λ (mkRoundManager ec ecc (mkRoundManagerWithEC (mkBlockStore bsInner))) qc
-                          → mkRoundManager ec ecc (mkRoundManagerWithEC (mkBlockStore (record bsInner {₋btHighestQuorumCert = qc}))))
+                        (λ (RoundManager∙new ec ecc (RoundManagerWithEC∙new (BlockStore∙new bsInner))) qc
+                          → RoundManager∙new ec ecc (RoundManagerWithEC∙new (BlockStore∙new (record bsInner {₋btHighestQuorumCert = qc}))))
 
   ₋rmHighestCommitQC : (rm : RoundManager) → QuorumCert
   ₋rmHighestCommitQC rm = ₋btHighestCommitCert ((₋rmWithEC rm) ^∙ (lBlockTree (α-EC-RM rm)))
 
   rmHighestCommitQC : Lens RoundManager QuorumCert
   rmHighestCommitQC = mkLens' ₋rmHighestCommitQC
-                        (λ (mkRoundManager ec ecc (mkRoundManagerWithEC (mkBlockStore bsInner))) qc
-                          → mkRoundManager ec ecc (mkRoundManagerWithEC (mkBlockStore (record bsInner {₋btHighestCommitCert = qc}))))
+                        (λ (RoundManager∙new ec ecc (RoundManagerWithEC∙new (BlockStore∙new bsInner))) qc
+                          → RoundManager∙new ec ecc (RoundManagerWithEC∙new (BlockStore∙new (record bsInner {₋btHighestCommitCert = qc}))))

--- a/LibraBFT/Impl/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochDep.agda
@@ -73,7 +73,7 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   --  iv) Coherence of 'vdParent' field with the above record chain.
   --
   record IsValidVote (v : Vote) : Set where
-    constructor mkIsValidVote
+    constructor IsValidVote∙new
     inductive
     field
       ₋ivvMember   : Member
@@ -99,9 +99,9 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   -- and blocks will be given in LibraBFT.Concrete.Records, since those are
   -- more involved functions.
   α-ValidVote : (v : Vote) → Member → AbsVoteData
-  α-ValidVote v mbr = mkAbsVoteData (v ^∙ vProposed ∙ biRound)
-                                     mbr
-                                     (v ^∙ vProposed ∙ biId)
+  α-ValidVote v mbr = AbsVoteData∙new (v ^∙ vProposed ∙ biRound)
+                                      mbr
+                                      (v ^∙ vProposed ∙ biId)
 
   -- α-ValidVote is the same for two votes that have the same vAuthor, vdProposed and vOrder
   α-ValidVote-≡ : ∀ {cv v'} {m : Member}
@@ -113,7 +113,7 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   -- Finally; evidence for some abstract vote consists of a concrete valid vote
   -- that is coherent with the abstract vote data.
   record ConcreteVoteEvidence vd where
-    constructor mkCVE
+    constructor CVE∙new
     inductive
     field
       ₋cveVote        : Vote
@@ -142,7 +142,7 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   -- A block tree depends on a epoch config but works regardlesss of which
   -- EpochConfig we have.
   record BlockTree : Set where
-    constructor mkBlockTree
+    constructor BlockTree∙new
     field
       ₋btIdToBlock               : KVMap HashValue LinkableBlock
       ₋btRootId                  : HashValue
@@ -163,7 +163,7 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
               btMaxPrunedBlocksInMem ∷ btIdToQuorumCert ∷ [])
 
   record BlockStore : Set where
-    constructor mkBlockStore
+    constructor BlockStore∙new
     field
       ₋bsInner         : BlockTree
       -- bsStateComputer : StateComputer
@@ -177,7 +177,7 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   -- they care about yet.
   --
   record RoundManagerWithEC : Set where
-    constructor mkRoundManagerWithEC
+    constructor RoundManagerWithEC∙new
     field
       ₋epBlockStore   : BlockStore
   open RoundManagerWithEC public

--- a/LibraBFT/Impl/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochDep.agda
@@ -91,8 +91,8 @@ module LibraBFT.Impl.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
       ₋ivvCoherent : VoteCoherence v ₋ivvBlock
 
       -- Finally, the vote is for the correct epoch
-      ₋ivvEpoch    : v ^∙ vEpoch ≡ epochId
-      ₋ivvEpoch2   : v ^∙ vParent ∙ biEpoch ≡ epochId  -- Not needed?
+      ₋ivvEpoch    : v ^∙ vEpoch ≡ epoch
+      ₋ivvEpoch2   : v ^∙ vParent ∙ biEpoch ≡ epoch  -- Not needed?
   open IsValidVote public
 
   -- A valid vote can be directly mapped to an AbsVoteData. Abstraction of QCs

--- a/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
@@ -257,7 +257,7 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
              (siHighestQuorumCert ∷ siHighestCommitCert ∷ [])
   postulate instance enc-SyncInfo : Encoder SyncInfo
 
-  {- TODO-HC how do if-then-else and equality check?
+  {- TODO-1 how do if-then-else and equality check?
   SyncInfo∙new : QuorumCert → QuorumCert → SyncInfo
   SyncInfo∙new highestQuorumCert highestCommitCert =
     record { ₋siHighestQuorumCert = highestQuorumCert

--- a/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
@@ -47,7 +47,7 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
   record BlockInfo : Set where
     constructor BlockInfo∙new
     field
-      ₋biEpoch : EpochId
+      ₋biEpoch : Epoch
       ₋biRound : Round
       ₋biId    : HashValue
       -- This has more fields...
@@ -136,7 +136,7 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
   vProposedId : Lens Vote Hash
   vProposedId = vVoteData ∙ vdProposed ∙ biId
 
-  vEpoch : Lens Vote EpochId
+  vEpoch : Lens Vote Epoch
   vEpoch = vVoteData ∙ vdProposed ∙ biEpoch
 
   vRound : Lens Vote Round
@@ -202,7 +202,7 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
   record BlockData : Set where
     constructor BlockData∙new
     field
-      ₋bdEpoch      : EpochId
+      ₋bdEpoch      : Epoch
       ₋bdRound      : Round
       -- QUESTION: How do we represent a block that extends the
       -- genesis block, which doesn't come with a QC.  Maybe the
@@ -303,14 +303,14 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
   record CommitMsg : Set where
     constructor CommitMsg∙new
     field
-      ₋cEpochId : EpochId
+      ₋cEpoch   : Epoch
       ₋cAuthor  : NodeId
       ₋cRound   : Round
       ₋cCert    : QuorumCert  -- We assume for now that a CommitMsg contains the QuorumCert of the head of the 3-chain
       ₋cSigMB   : Maybe Signature
   open CommitMsg public
-  unquoteDecl cEpochId   cAuthor   cRound   cCert   cSigMB = mkLens (quote CommitMsg)
-             (cEpochId ∷ cAuthor ∷ cRound ∷ cCert ∷ cSigMB ∷ [])
+  unquoteDecl cEpoch   cAuthor   cRound   cCert   cSigMB = mkLens (quote CommitMsg)
+             (cEpoch ∷ cAuthor ∷ cRound ∷ cCert ∷ cSigMB ∷ [])
   postulate instance enc-CommitMsg : Encoder CommitMsg
 
   record LastVoteInfo : Set where
@@ -377,7 +377,7 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
   record SafetyData : Set where
     constructor SafetyData∙new
     field
-      :sdEpoch          : EpochId
+      :sdEpoch          : Epoch
       :sdLastVotedRound : Round
       :sdPreferredRound : Round
       :sdLastVote       : Maybe Vote

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -24,7 +24,7 @@ open import LibraBFT.Impl.Properties.Aux  -- TODO-1: maybe Aux properties should
 open import LibraBFT.Concrete.System impl-sps-avp
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysParms NodeId-PK-OK
 open        Structural impl-sps-avp
 
 module LibraBFT.Impl.Handle.Properties

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -79,7 +79,7 @@ module LibraBFT.Impl.Handle.Properties
                  → initialised st pid ≡ initd
                  → ps ≡ peerStates st pid
                  → q QC∈VoteMsg vm
-                 → vm ^∙ vmSyncInfo ≡ mkSyncInfo (ps ^∙ rmHighestQC) (ps ^∙ rmHighestCommitQC)
+                 → vm ^∙ vmSyncInfo ≡ SyncInfo∙new (ps ^∙ rmHighestQC) (ps ^∙ rmHighestCommitQC)
                  → vs ∈ qcVotes q
                  → MsgWithSig∈ pk (proj₂ vs) (msgPool st)
 

--- a/LibraBFT/Impl/NetworkMsg.agda
+++ b/LibraBFT/Impl/NetworkMsg.agda
@@ -62,10 +62,10 @@ module LibraBFT.Impl.NetworkMsg where
             → qc QC∈NM nm
             → v ⊂Msg nm
 
-  getEpoch : NetworkMsg → EpochId
+  getEpoch : NetworkMsg → Epoch
   getEpoch (P p) = p ^∙ pmProposal ∙ bBlockData ∙ bdEpoch
   getEpoch (V (VoteMsg∙new v _)) = v ^∙ vEpoch
-  getEpoch (C c) = c ^∙ cEpochId
+  getEpoch (C c) = c ^∙ cEpoch
 
   -- Get the message's author, if it has one.  Note that ProposalMsgs don't necessarily have
   -- authors; we care about the (honesty of) the author only for Proposals, not NilBlocks and
@@ -115,7 +115,7 @@ module LibraBFT.Impl.NetworkMsg where
       ; Signed-pi      = Signed-pi-CommitMsg
       ; isSigned?      = λ c → Maybe-Any-dec (λ _ → yes tt) (c ^∙ cSigMB)
       ; signature      = λ { _ prf → to-witness prf }
-      ; signableFields = λ c → concat ( encode  (c ^∙ cEpochId)
+      ; signableFields = λ c → concat ( encode  (c ^∙ cEpoch)
                                       ∷ encode  (c ^∙ cAuthor)
                                       ∷ encode  (c ^∙ cRound)
                                       ∷ encode  (c ^∙ cCert)

--- a/LibraBFT/Impl/NetworkMsg.agda
+++ b/LibraBFT/Impl/NetworkMsg.agda
@@ -55,7 +55,7 @@ module LibraBFT.Impl.NetworkMsg where
 
   data _⊂Msg_ (v : Vote) : NetworkMsg → Set where
     vote∈vm : ∀ {si}
-            → v ⊂Msg (V (mkVoteMsg v si))
+            → v ⊂Msg (V (VoteMsg∙new v si))
     vote∈qc : ∀ {vs} {qc : QuorumCert} {nm}
             → vs ∈ qcVotes qc
             → rebuildVote qc vs ≈Vote v
@@ -64,7 +64,7 @@ module LibraBFT.Impl.NetworkMsg where
 
   getEpoch : NetworkMsg → EpochId
   getEpoch (P p) = p ^∙ pmProposal ∙ bBlockData ∙ bdEpoch
-  getEpoch (V (mkVoteMsg v _)) = v ^∙ vEpoch
+  getEpoch (V (VoteMsg∙new v _)) = v ^∙ vEpoch
   getEpoch (C c) = c ^∙ cEpochId
 
   -- Get the message's author, if it has one.  Note that ProposalMsgs don't necessarily have
@@ -86,7 +86,7 @@ module LibraBFT.Impl.NetworkMsg where
   Signed-pi-CommitMsg : (c : CommitMsg)
                       → (is1 is2 : (Is-just ∘ ₋cSigMB) c)
                       → is1 ≡ is2
-  Signed-pi-CommitMsg (mkCommitMsg _ _ _ _ .(just _)) (just _) (just _) = cong just refl
+  Signed-pi-CommitMsg (CommitMsg∙new _ _ _ _ .(just _)) (just _) (just _) = cong just refl
 
   instance
    -- A proposal message might carry a signature inside the block it

--- a/LibraBFT/Impl/Properties.agda
+++ b/LibraBFT/Impl/Properties.agda
@@ -11,7 +11,7 @@ open import LibraBFT.Concrete.System.Parameters
 -- "implementation" into the structure required by Concrete.Properties.
 open import LibraBFT.Impl.Properties.Aux
 import      LibraBFT.Impl.Properties.VotesOnce   as VO
-import      LibraBFT.Impl.Properties.LockedRound as LR
+import      LibraBFT.Impl.Properties.PreferredRound as PR
 open import LibraBFT.Concrete.Obligations
 open import LibraBFT.Concrete.System impl-sps-avp
 
@@ -20,4 +20,4 @@ module LibraBFT.Impl.Properties where
   theImplObligations = record { sps-cor = impl-sps-avp
                               ; vo₁     = VO.vo₁
                               ; vo₂     = VO.vo₂
-                              ; lr₁     = LR.lr₁ }
+                              ; pr₁     = PR.pr₁ }

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -12,7 +12,7 @@ open import LibraBFT.Impl.Consensus.Types
 open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysParms NodeId-PK-OK
 
 -- In this module, we will prove a structural property that any new signed message produced by an
 -- honest handler from a reachable state correctly identifies the sender, and is for a valid epoch

--- a/LibraBFT/Impl/Properties/PreferredRound.agda
+++ b/LibraBFT/Impl/Properties/PreferredRound.agda
@@ -4,13 +4,13 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
-import      LibraBFT.Concrete.Properties.LockedRound as LR
+import      LibraBFT.Concrete.Properties.PreferredRound as PR
 
 open import LibraBFT.Concrete.Obligations
 
--- In this module, we (will) prove the implementation obligation for the LockedRound rule.
+-- In this module, we (will) prove the implementation obligation for the PreferredRound rule.
 
-module LibraBFT.Impl.Properties.LockedRound where
+module LibraBFT.Impl.Properties.PreferredRound where
 
   postulate  -- TODO-3 : prove.  Note that this is a substantial
              -- undertaking that should not be started before we have
@@ -19,4 +19,4 @@ module LibraBFT.Impl.Properties.LockedRound where
              -- implementation (perhaps some incremental extension of
              -- our current fake/simple implementaion) that we can
              -- reasonably hope actually ensures the property!
-    lr₁ : LR.ImplObligation₁
+    pr₁ : PR.ImplObligation₁

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -27,7 +27,7 @@ open import LibraBFT.Impl.Util.Util
 open import LibraBFT.Concrete.System impl-sps-avp
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysParms NodeId-PK-OK
 open        Structural impl-sps-avp
 
 -- In this module, we prove the two implementation obligations for the VotesOnce rule.  Note
@@ -220,7 +220,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
      with sameHonestSig⇒sameVoteData hpk (msgSigned mws) sig' (msgSameSig mws)
   ...| inj₁ hb = ⊥-elim (PerState.meta-sha256-cr pre r hb)
   ...| inj₂ refl
-     -- Both votes have the same epochID, therefore same EpochConfig
+     -- Both votes have the same epoch, therefore same EpochConfig
      with sameEpoch⇒sameEC vpb vpf' refl
                     -- Both peers are allowed to sign for the same PK, so they are the same peer
   ...| refl rewrite NodeId-PK-OK-injective (vp-ec vpb) (vp-sender-ok vpb) (vp-sender-ok vpf')

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -21,7 +21,7 @@ open import LibraBFT.Impl.Properties.Aux
 open import LibraBFT.Concrete.System impl-sps-avp
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epochId authorsN ConcSysParms NodeId-PK-OK
+open import LibraBFT.Yasm.Yasm (ℓ+1 0ℓ) EpochConfig epoch authorsN ConcSysParms NodeId-PK-OK
 open        Structural impl-sps-avp
 open import LibraBFT.Impl.Properties.VotesOnce
 

--- a/LibraBFT/Impl/Util/Crypto.agda
+++ b/LibraBFT/Impl/Util/Crypto.agda
@@ -29,7 +29,7 @@ module LibraBFT.Impl.Util.Crypto where
   open WithCryptoHash sha256 sha256-cr
 
   blockInfoBSList : BlockInfo → List ByteString
-  blockInfoBSList (mkBlockInfo epoch round id) = encode epoch ∷ encode round ∷ encode id ∷ []
+  blockInfoBSList (BlockInfo∙new epoch round id) = encode epoch ∷ encode round ∷ encode id ∷ []
 
   hashBI : BlockInfo → HashValue
   hashBI = sha256 ∘ bs-concat ∘ blockInfoBSList
@@ -43,7 +43,7 @@ module LibraBFT.Impl.Util.Crypto where
                                  (encode-inj (proj₁ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective final))))))))
 
   voteDataHashList : VoteData → List Hash
-  voteDataHashList (mkVoteData proposed parent) =
+  voteDataHashList (VoteData∙new proposed parent) =
     hProposed ∷ hParent ∷ []
    where
     hProposed = hashBI proposed
@@ -90,11 +90,11 @@ module LibraBFT.Impl.Util.Crypto where
   ...| inj₂ prop≡ | inj₂ par≡ = inj₂ (VoteData-η prop≡ par≡)
 
   hashLI : LedgerInfo → HashValue
-  hashLI (mkLedgerInfo commitInfo consensusDataHash) =
+  hashLI (LedgerInfo∙new commitInfo consensusDataHash) =
     hash-concat (hashBI commitInfo ∷ consensusDataHash ∷ [])
 
   hashLI-inj : ∀ {li1 li2} → hashLI li1 ≡ hashLI li2 → NonInjective-≡ sha256 ⊎ li1 ≡ li2
-  hashLI-inj {mkLedgerInfo ci1 cd1} {mkLedgerInfo ci2 cd2} prf
+  hashLI-inj {LedgerInfo∙new ci1 cd1} {LedgerInfo∙new ci2 cd2} prf
      with hash-concat-inj {hashBI ci1 ∷ cd1 ∷ []} {hashBI ci2 ∷ cd2 ∷ []} prf
   ...| inj₁ hb      = inj₁ hb
   ...| inj₂ li1≡li2
@@ -108,7 +108,7 @@ module LibraBFT.Impl.Util.Crypto where
      = inj₂ (LedgerInfo-η cis≡ cdh≡)
 
   constructLI : Vote → LedgerInfo
-  constructLI v = mkLedgerInfo (₋liCommitInfo (₋vLedgerInfo v)) (hashVD (₋vVoteData v))
+  constructLI v = LedgerInfo∙new (₋liCommitInfo (₋vLedgerInfo v)) (hashVD (₋vVoteData v))
 
   hashVote : Vote → HashValue
   hashVote = hashLI ∘ constructLI
@@ -138,7 +138,7 @@ module LibraBFT.Impl.Util.Crypto where
   Signed-pi-Blk : (b : Block)
                 → (is1 is2 : (Is-just ∘ ₋bSignature) b)
                 → is1 ≡ is2
-  Signed-pi-Blk (mkBlock _ _ .(just _)) (just _) (just _) = cong just refl
+  Signed-pi-Blk (Block∙new _ _ .(just _)) (just _) (just _) = cong just refl
 
   -- A Block might carry a signature
   instance

--- a/LibraBFT/Yasm/AvailableEpochs.agda
+++ b/LibraBFT/Yasm/AvailableEpochs.agda
@@ -15,10 +15,10 @@ module LibraBFT.Yasm.AvailableEpochs
    (NodeId      : Set)
    (ℓ-EC        : Level)
    (EpochConfig : Set ℓ-EC)
-   (epochId     : EpochConfig → ℕ)
+   (epoch       : EpochConfig → ℕ)
    (authorsN    : EpochConfig → ℕ)
  where
- open import LibraBFT.Yasm.Base ℓ-EC EpochConfig epochId authorsN
+ open import LibraBFT.Yasm.Base ℓ-EC EpochConfig epoch authorsN
 
  fin-lower-toℕ : ∀{e}(i : Fin (suc e))(prf : e ≢ toℕ i) → toℕ (Fin.lower₁ i prf) ≡ toℕ i
  fin-lower-toℕ {zero} zero prf = ⊥-elim (prf refl)

--- a/LibraBFT/Yasm/Base.agda
+++ b/LibraBFT/Yasm/Base.agda
@@ -11,20 +11,20 @@ open import LibraBFT.Base.PKCS
 module LibraBFT.Yasm.Base
   (ℓ-EC        : Level)
   (EpochConfig : Set ℓ-EC)
-  (epochId     : EpochConfig → ℕ)
+  (epoch       : EpochConfig → ℕ)
   (authorsN    : EpochConfig → ℕ)
  where
 
- EpochId : Set
- EpochId = ℕ
+ Epoch : Set
+ Epoch = ℕ
 
  Member : EpochConfig → Set
  Member = Fin ∘ authorsN
 
- record EpochConfigFor (eid : EpochId) : Set ℓ-EC where
+ record EpochConfigFor (eid : Epoch) : Set ℓ-EC where
    field
     epochConfig : EpochConfig
-    forEpochId  : epochId epochConfig ≡ eid
+    forEpoch    : epoch epochConfig ≡ eid
 
  -- Our system is configured through a value of type
  -- SystemParameters where we specify:
@@ -45,7 +45,7 @@ module LibraBFT.Yasm.Base
     _⊂Msg_       : Part → Msg → Set
 
     -- Finally, messages must carry an epoch id and might have an author
-    part-epoch  : Part → EpochId
+    part-epoch  : Part → Epoch
 
     -- Initializes a potentially-empty state with an EpochConfig
     init : PeerId → EpochConfig → PeerState → PeerState × List Msg

--- a/LibraBFT/Yasm/Properties.agda
+++ b/LibraBFT/Yasm/Properties.agda
@@ -16,9 +16,9 @@ import      LibraBFT.Yasm.Base as LYB
 module LibraBFT.Yasm.Properties
    (ℓ-EC        : Level)
    (EpochConfig : Set ℓ-EC)
-   (epochId     : EpochConfig → EpochId)
+   (epoch       : EpochConfig → Epoch)
    (authorsN    : EpochConfig → ℕ)
-   (parms       : LYB.SystemParameters ℓ-EC EpochConfig epochId authorsN)
+   (parms       : LYB.SystemParameters ℓ-EC EpochConfig epoch authorsN)
    -- In addition to the parameters used by the rest of the system model, this module
    -- needs to relate Members to PKs and PeerIds, so that StepPeerState-AllValidParts
    -- can be defined.  This enables the application to prove that honest peers sign
@@ -27,12 +27,12 @@ module LibraBFT.Yasm.Properties
    (senderPKOK  : (ec : EpochConfig) → PK → LYB.SystemParameters.PeerId parms → Set)
   where
  open LYB.SystemParameters parms
- open import LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epochId authorsN
+ open import LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epoch authorsN
              using (AvailableEpochs) renaming (lookup'' to EC-lookup)
- import      LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epochId authorsN
+ import      LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epoch authorsN
              as AE
- open import LibraBFT.Yasm.Base   ℓ-EC EpochConfig epochId authorsN
- open import LibraBFT.Yasm.System ℓ-EC EpochConfig epochId authorsN parms
+ open import LibraBFT.Yasm.Base   ℓ-EC EpochConfig epoch authorsN
+ open import LibraBFT.Yasm.System ℓ-EC EpochConfig epoch authorsN parms
  open import Util.FunctionOverride PeerId _≟PeerId_
 
  -- A ValidPartForPK collects the assumptions about what a /part/ in the outputs of an honest verifier

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -20,20 +20,20 @@ import      LibraBFT.Yasm.Base as LYB
 module LibraBFT.Yasm.System
    (ℓ-EC        : Level)
    (EpochConfig : Set ℓ-EC)
-   (epochId     : EpochConfig → EpochId)
+   (epoch       : EpochConfig → Epoch)
    (authorsN    : EpochConfig → ℕ)
-   (parms : LYB.SystemParameters ℓ-EC EpochConfig epochId authorsN)
+   (parms : LYB.SystemParameters ℓ-EC EpochConfig epoch authorsN)
  where
 
  data InitStatus : Set where
    uninitd : InitStatus
    initd   : InitStatus
 
- open import LibraBFT.Yasm.Base            ℓ-EC EpochConfig epochId authorsN
+ open import LibraBFT.Yasm.Base            ℓ-EC EpochConfig epoch authorsN
  open SystemParameters parms
- open import LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epochId authorsN
+ open import LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epoch authorsN
              using (AvailableEpochs) renaming (lookup'' to EC-lookup)
- import LibraBFT.Yasm.AvailableEpochs      PeerId ℓ-EC EpochConfig epochId authorsN as AE
+ import LibraBFT.Yasm.AvailableEpochs      PeerId ℓ-EC EpochConfig epoch authorsN as AE
  open import Util.FunctionOverride PeerId _≟PeerId_
 
  open import LibraBFT.Base.PKCS

--- a/LibraBFT/Yasm/Yasm.agda
+++ b/LibraBFT/Yasm/Yasm.agda
@@ -13,15 +13,15 @@ import      LibraBFT.Yasm.Base as LYB
 module LibraBFT.Yasm.Yasm
    (ℓ-EC        : Level)
    (EpochConfig : Set ℓ-EC)
-   (epochId     : EpochConfig → EpochId)
+   (epoch       : EpochConfig → Epoch)
    (authorsN    : EpochConfig → ℕ)
-   (parms       : LYB.SystemParameters ℓ-EC EpochConfig epochId authorsN)
+   (parms       : LYB.SystemParameters ℓ-EC EpochConfig epoch authorsN)
    (senderPKOK  : (ec : EpochConfig) → PK → LYB.SystemParameters.PeerId parms → Set)
   where
  open LYB.SystemParameters parms
- open import LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epochId authorsN
+ open import LibraBFT.Yasm.AvailableEpochs PeerId ℓ-EC EpochConfig epoch authorsN
              using (AvailableEpochs) renaming (lookup' to EC-lookup; lookup'' to EC-lookup') public
- open import LibraBFT.Yasm.Base       ℓ-EC EpochConfig epochId authorsN                      public
- open import LibraBFT.Yasm.System     ℓ-EC EpochConfig epochId authorsN parms                public
- open import LibraBFT.Yasm.Properties ℓ-EC EpochConfig epochId authorsN parms senderPKOK     public
+ open import LibraBFT.Yasm.Base       ℓ-EC EpochConfig epoch authorsN                      public
+ open import LibraBFT.Yasm.System     ℓ-EC EpochConfig epoch authorsN parms                public
+ open import LibraBFT.Yasm.Properties ℓ-EC EpochConfig epoch authorsN parms senderPKOK     public
  open import Util.FunctionOverride    PeerId _≟PeerId_                                       public


### PR DESCRIPTION
```
rename :
- LockedRound       -> PreferredRound
- EpochId           -> Epoch
- PersistentStorage -> PersistentSafetyStorage
- ProcessedVMOutput -> StateComputeResult

Note: when renaming, variables and acronyms were renamed consistently also.

refactored stuff from
- Persistent[Saftey]Storage to SafetyData

change constructor names
- mk* -> *.new (e.g., mkBlock -> Block.new where the '.' is a solid bullet)
```
