### PR TITLE
Add decidable equality for any type with an `Encoder`, use it to implement conditional `SyncInfo` constructor and lens

### DIFF
--- a/LibraBFT/Base/ByteString.agda
+++ b/LibraBFT/Base/ByteString.agda
@@ -60,6 +60,9 @@ module LibraBFT.Base.ByteString where
   ByteString : Set
   ByteString = List (Vec Bool 8)
 
+  _≟ByteString_ : (bs1 bs2 : ByteString) → Dec (bs1 ≡ bs2)
+  _≟ByteString_ = List-≡-dec (Vec-≡-dec _≟Bool_)
+
   -- Concatenates ByteString prepending '11' to each byte.
   toBitString-pad' : ByteString → BitString
   toBitString-pad' = concat ∘ List-map (λ v → true ∷ true ∷ Vec-toList v)

--- a/LibraBFT/Base/Encode.agda
+++ b/LibraBFT/Base/Encode.agda
@@ -11,10 +11,17 @@ module LibraBFT.Base.Encode where
  -- An encoder for values of type A is
  -- an injective mapping of 'A's into 'ByteString's
  record Encoder {a}(A : Set a) : Set a where
+   constructor mkEncoder
    field
      encode     : A → ByteString
      encode-inj : ∀{a₁ a₂} → encode a₁ ≡ encode a₂ → a₁ ≡ a₂
  open Encoder {{...}} public
+
+ ≡-Encoder : ∀ {a} {A : Set a} → Encoder A → DecidableEquality A
+ ≡-Encoder (mkEncoder enc enc-inj) x y
+    with enc x ≟ByteString enc y
+ ...| yes enc≡ = yes (enc-inj enc≡)
+ ...| no  neq  = no  (⊥-elim ∘ neq ∘ cong enc)
 
  postulate  -- valid assumption
   instance

--- a/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
@@ -274,7 +274,7 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
                                     then nothing else (just highestCommitCert) }
 
   siHighestCommitCert : Lens SyncInfo QuorumCert
-  siHighestCommitCert = mkLens' (λ x → maybe id (x ^∙ siHighestQuorumCert) (₋siHighestCommitCert x))
+  siHighestCommitCert = mkLens' (λ x → fromMaybe (x ^∙ siHighestQuorumCert) (₋siHighestCommitCert x))
                                 (λ x si → record x { ₋siHighestCommitCert = just si })
 
   ----------------------

--- a/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
@@ -255,7 +255,8 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
   bRound =  bBlockData ∙ bdRound
 
   record SyncInfo : Set where
-    constructor mkSyncInfo
+    constructor mkSyncInfo -- Bare constructor to enable pattern matching against SyncInfo; "smart"
+                           -- constructor SyncInfo∙new is below
     field
       ₋siHighestQuorumCert  : QuorumCert
       ₋siHighestCommitCert  : Maybe QuorumCert

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -71,7 +71,7 @@ module LibraBFT.Impl.Properties.VotesOnceDirect where
           -- so they are the same peer
   ...| refl
      with NodeId-PK-OK-injective (vp-ec vspk) (vp-sender-ok vspk) (vp-sender-ok vspkN)
-  ...| refl rewrite eventProcessorPostSt r stPeer refl
+  ...| refl rewrite roundManagerPostSt r stPeer refl
        = let nvr = newVoteSameEpochGreaterRound r stPeer (msg⊆ msv) m∈outs (msgSigned msv) newV
          in ≡⇒≤ ((proj₂ ∘ proj₂) nvr)
 

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -322,13 +322,13 @@ module LibraBFT.Yasm.System
  ReachableSystemState : ∀{e} → SystemState e → Set ℓ-EC
  ReachableSystemState = Step* initialState
 
- eventProcessorPostSt : ∀ {pid s' s outs init'} {e} {st : SystemState e}
+ roundManagerPostSt : ∀ {pid s' s outs init'} {e} {st : SystemState e}
                       → (r : ReachableSystemState st)
                       → (stP : StepPeerState pid (availEpochs st) (msgPool st) (initialised st)
                                              (peerStates st pid) init' (s' , outs))
                       → peerStates (StepPeer-post {pre = st} (step-honest stP)) pid ≡ s
                       → s ≡ s'
- eventProcessorPostSt _ _ ps≡s = trans (sym ps≡s) override-target-≡
+ roundManagerPostSt _ _ ps≡s = trans (sym ps≡s) override-target-≡
 
  Step*-mono : ∀{e e'}{st : SystemState e}{st' : SystemState e'}
             → Step* st st' → e ≤ e'


### PR DESCRIPTION
The constructor for `SyncInfo` compares two `QuorumCert`s and constructs the `SyncInfo` dependent on the outcome.  We observe that `QuorumCert` has (postulated, for now) an injective encoding, and we can implement decidable equality for any such type.

This pull request provides support for that and then uses it to implement the constructor and lens for `SyncInfo`.  This avoids the need to manually implement decidable equality  for `QuorumCert`, `VoteData`, `BlockInfo`, `LedgerInfoWithSignatures`, etc.