### PR TITLE
Enable an initial "genesis" message at system initialization, make unwind work for non-genesis messages, fix properties

### DIFF
--- a/LibraBFT/Base/PKCS.agda
+++ b/LibraBFT/Base/PKCS.agda
@@ -158,6 +158,16 @@ module LibraBFT.Base.PKCS where
  ...| no ¬Signed = ⊥-elim (¬Signed (isSigned wvs1))
  ...| yes sc = withVerSig-≡ {wvs1 = wvs1} {wvs2 = wvs2} (Signed-pi c (isSigned wvs1) (isSigned wvs2))
 
+ -- A type for expressing that a property that holds for one C holds for any other C with the same
+ -- signature.
+ SameSig⇒ : ∀ {C : Set} ⦃ ws : WithSig C ⦄ → (C → Set) → Set
+ SameSig⇒ P = ∀ {c1 c2 pk}
+              → (wvs1 : WithVerSig pk c1)
+              → (wvs2 : WithVerSig pk c2)
+              → ver-signature wvs2 ≡ ver-signature wvs1
+              → P c2
+              → P c1
+
  data SigCheckResult {C : Set} ⦃ ws : WithSig C ⦄ (pk : PK) (c : C) : Set where
    notSigned   : ¬ Signed c → SigCheckResult pk c
    checkFailed : (sc : Signed c) → verify (signableFields c) (signature c sc) pk ≡ false → SigCheckResult pk c

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -11,7 +11,7 @@ open import LibraBFT.Impl.Consensus.Types
 import      LibraBFT.Concrete.Properties.VotesOnce      as VO
 import      LibraBFT.Concrete.Properties.PreferredRound as PR
 
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP concSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 -- This module collects in one place the obligations an
 -- implementation must meet in order to enjoy the properties

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -10,7 +10,7 @@ open import LibraBFT.Impl.Base.Types
 open import LibraBFT.Impl.Consensus.Types
 open        EpochConfig
 open import LibraBFT.Concrete.System
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP concSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 -- In this module, we assume that the implementation meets its
 -- obligations, and use this assumption to prove that, in any reachable

--- a/LibraBFT/Concrete/Properties/PreferredRound.agda
+++ b/LibraBFT/Concrete/Properties/PreferredRound.agda
@@ -16,7 +16,7 @@ open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
 open import LibraBFT.Concrete.System
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP concSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 -- This module contains placeholders for the future analog of the
 -- corresponding VotesOnce property.  Defining the implementation

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -89,15 +89,16 @@ module LibraBFT.Concrete.Properties.VotesOnce where
 
  -- Next, we prove that, given the necessary obligations,
  module Proof
-   (sps-corr : StepPeerState-AllValidParts)
-   (Impl-VO1 : ImplObligation₁)
-   (Impl-VO2 : ImplObligation₂)
+   (sps-corr        : StepPeerState-AllValidParts)
+   (init-part-props : InitPartProps ℓ-RoundManager concSysParms)
+   (Impl-VO1        : ImplObligation₁)
+   (Impl-VO2        : ImplObligation₂)
    where
 
   -- Any reachable state satisfies the VO rule for any epoch in the system.
   module _ (st : SystemState)(r : ReachableSystemState st)(𝓔 : EpochConfig) where
 
-   open Structural sps-corr
+   open Structural sps-corr init-part-props
    -- Bring in IntSystemState
    open WithSPS sps-corr
    open PerState st r
@@ -151,7 +152,15 @@ module LibraBFT.Concrete.Properties.VotesOnce where
        → v ^∙ vEpoch ≡ v' ^∙ vEpoch
        → v ^∙ vRound ≡ v' ^∙ vRound
        → v ^∙ vProposedId ≡ v' ^∙ vProposedId
-    VotesOnceProof step-0 _ _ msv _ _ _ _ = ⊥-elim (¬Any[] (msg∈pool msv))
+    VotesOnceProof {v} {v'} {_} {st} step-0 pkH vv mws vv' mws' _ _
+       with sameHonestSig⇒sameVoteData pkH (msgSigned mws ) vv  (msgSameSig mws )
+          | sameHonestSig⇒sameVoteData pkH (msgSigned mws') vv' (msgSameSig mws')
+    ...| inj₁ hb   | _       = ⊥-elim (meta-sha256-cr hb)
+    ...| inj₂ refl | inj₁ hb = ⊥-elim (meta-sha256-cr hb)
+    ...| inj₂ refl | inj₂ refl
+       with cong proj₂ (sym (Any-singleton⁻ (msg∈pool mws )))
+          | cong proj₂ (sym (Any-singleton⁻ (msg∈pool mws')))
+    ...| refl | refl = genVotesNoConflict (msg⊆ mws) (msgSigned mws) (msg⊆ mws') (msgSigned mws')
     VotesOnceProof (step-s r (step-peer cheat@(step-cheat c))) pkH vv msv vv' msv' eid≡ r≡
        with ¬cheatForgeNew cheat refl unit pkH msv | ¬cheatForgeNew cheat refl unit pkH msv'
     ...| msb4 | m'sb4

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -17,7 +17,7 @@ open import LibraBFT.Impl.Handle sha256 sha256-cr
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Concrete.System
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP concSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 -- In this module, we define two "implementation obligations"
 -- (ImplObligationᵢ for i ∈ {1 , 2}), which are predicates over

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -26,7 +26,7 @@ module LibraBFT.Concrete.System where
  ℓ-VSFP = 1ℓ ℓ⊔ ℓ-RoundManager
 
  open import LibraBFT.Yasm.Base
- import      LibraBFT.Yasm.System ℓ-RoundManager ℓ-VSFP ConcSysParms as LYS
+ import      LibraBFT.Yasm.System ℓ-RoundManager ℓ-VSFP concSysParms as LYS
 
  -- What EpochConfigs are known in the system?  For now, only the initial one.  Later, we will add
  -- knowledge of subsequent EpochConfigs known via EpochChangeProofs.
@@ -54,7 +54,7 @@ module LibraBFT.Concrete.System where
  PeerCanSignForPK-stable : LYS.ValidSenderForPK-stable-type PeerCanSignForPK
  PeerCanSignForPK-stable _ _ (mkPCS4PK 𝓔₁ 𝓔id≡₁ (inGenInfo refl) mbr₁ nid≡₁ pk≡₁) = (mkPCS4PK 𝓔₁ 𝓔id≡₁ (inGenInfo refl) mbr₁ nid≡₁ pk≡₁)
 
- open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK
+ open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP concSysParms PeerCanSignForPK
                                                                   (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
  -- An implementation must prove that, if one of its handlers sends a

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -31,6 +31,10 @@ module LibraBFT.Concrete.System where
  -- What EpochConfigs are known in the system?  For now, only the initial one.  Later, we will add
  -- knowledge of subsequent EpochConfigs known via EpochChangeProofs.
  data EpochConfig∈Sys (st : LYS.SystemState) (𝓔 : EpochConfig) : Set ℓ-EC where
+   -- This constructor may not be needed because the implementation generates and stores an
+   -- EpochChangeProof from genesis information upon initialization, which means we can use the
+   -- inECP constructor (note that we only need EpochConfig∈Sys to hold in the peer step's post
+   -- state.
    inGenInfo : init-EC genInfo ≡ 𝓔 → EpochConfig∈Sys st 𝓔
    -- inECP  : ∀ {ecp} → ecp ECP∈Sys st → verify-ECP ecp 𝓔 → EpochConfig∈Sys
 

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -25,13 +25,17 @@ module LibraBFT.Concrete.System.Parameters where
  concSysParms = mkSysParms
                  NodeId
                  _≟NodeId_
-                 GenesisInfo
-                 genInfo
                  RoundManager
-                 initRM
                  NetworkMsg
                  Vote
                  sig-Vote
                  _⊂Msg_
+                 initRM
+                 genesisMsg
+                 initialisingNode
                  initialRoundManagerAndMessages
                  peerStepWrapper
+
+
+ concInitParts : InitPartProps concSysParms
+ concInitParts = mkInitPartProps GenInfoP genInfoP genInfoPSameSig

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -20,8 +20,9 @@ open import LibraBFT.Yasm.Base ℓ-RoundManager
 -- implementation.
 
 module LibraBFT.Concrete.System.Parameters where
- ConcSysParms : SystemParameters
- ConcSysParms = mkSysParms
+
+ concSysParms : SystemParameters
+ concSysParms = mkSysParms
                  NodeId
                  _≟NodeId_
                  GenesisInfo

--- a/LibraBFT/Impl/Consensus/Types.agda
+++ b/LibraBFT/Impl/Consensus/Types.agda
@@ -34,19 +34,28 @@ module LibraBFT.Impl.Consensus.Types where
   open import LibraBFT.Impl.Consensus.Types.EpochIndep       public
   open import LibraBFT.Impl.Consensus.Types.EpochDep         public
 
+  record EpochState : Set where
+    constructor EpochState∙new
+    field
+      ₋esEpoch    : Epoch
+      ₋esVerifier : ValidatorVerifier
+  open EpochState public
+  unquoteDecl esEpoch esVerifier = mkLens (quote EpochState)
+    (esEpoch ∷ esVerifier ∷ [])
+
   -- The parts of the state of a peer that are used to
   -- define the EpochConfig are the SafetyRules and ValidatorVerifier:
   record RoundManagerEC : Set where
     constructor RoundManagerEC∙new
     field
+      ₋rmEpochState   : EpochState
       ₋rmSafetyRules  : SafetyRules
-      ₋rmValidators   : ValidatorVerifier
   open RoundManagerEC public
-  unquoteDecl rmSafetyRules rmValidators = mkLens (quote RoundManagerEC)
-    (rmSafetyRules ∷ rmValidators ∷ [])
+  unquoteDecl rmEpochState rmSafetyRules = mkLens (quote RoundManagerEC)
+    (rmEpochState ∷ rmSafetyRules ∷ [])
 
   rmEpoch : Lens RoundManagerEC Epoch
-  rmEpoch = rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch
+  rmEpoch = rmEpochState ∙ esEpoch
 
   rmLastVotedRound : Lens RoundManagerEC Round
   rmLastVotedRound = rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdLastVotedRound
@@ -56,14 +65,14 @@ module LibraBFT.Impl.Consensus.Types where
   -- 'RoundManagerEC'.
   RoundManagerEC-correct : RoundManagerEC → Set
   RoundManagerEC-correct rmec =
-    let numAuthors = kvm-size (rmec ^∙ rmValidators ∙ vvAddressToValidatorInfo)
-        qsize      = rmec ^∙ rmValidators ∙ vvQuorumVotingPower
+    let numAuthors = kvm-size (rmec ^∙ rmEpochState ∙ esVerifier ∙ vvAddressToValidatorInfo)
+        qsize      = rmec ^∙ rmEpochState ∙ esVerifier ∙ vvQuorumVotingPower
         bizF       = numAuthors ∸ qsize
      in suc (3 * bizF) ≤ numAuthors
 
   RoundManagerEC-correct-≡ : (rmec1 : RoundManagerEC)
                              → (rmec2 : RoundManagerEC)
-                             → (rmec1 ^∙ rmValidators) ≡ (rmec2 ^∙ rmValidators)
+                             → (rmec1 ^∙ rmEpochState ∙ esVerifier) ≡ (rmec2 ^∙ rmEpochState ∙ esVerifier)
                              → RoundManagerEC-correct rmec1
                              → RoundManagerEC-correct rmec2
   RoundManagerEC-correct-≡ rmec1 rmec2 refl = id
@@ -74,8 +83,8 @@ module LibraBFT.Impl.Consensus.Types where
   -- TODO-2: update and complete when definitions are updated to more recent version
   α-EC : Σ RoundManagerEC RoundManagerEC-correct → EpochConfig
   α-EC (rmec , ok) =
-    let numAuthors = kvm-size (rmec ^∙ rmValidators ∙ vvAddressToValidatorInfo)
-        qsize      = rmec ^∙ rmValidators ∙ vvQuorumVotingPower
+    let numAuthors = kvm-size (rmec ^∙ rmEpochState ∙ esVerifier ∙ vvAddressToValidatorInfo)
+        qsize      = rmec ^∙ rmEpochState ∙ esVerifier ∙ vvQuorumVotingPower
         bizF       = numAuthors ∸ qsize
      in (EpochConfig∙new {! someHash?!}
                 (rmec ^∙ rmEpoch) numAuthors {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!})
@@ -83,8 +92,8 @@ module LibraBFT.Impl.Consensus.Types where
   postulate
     α-EC-≡ : (rmec1  : RoundManagerEC)
            → (rmec2  : RoundManagerEC)
-           → (vals≡  : rmec1 ^∙ rmValidators ≡ rmec2 ^∙ rmValidators)
-           →           rmec1 ^∙ rmEpoch      ≡ rmec2 ^∙ rmEpoch
+           → (vals≡  : rmec1 ^∙ rmEpochState ∙ esVerifier ≡ rmec2 ^∙ rmEpochState ∙ esVerifier)
+           →           rmec1 ^∙ rmEpoch                   ≡ rmec2 ^∙ rmEpoch
            → (rmec1-corr : RoundManagerEC-correct rmec1)
            → α-EC (rmec1 , rmec1-corr) ≡ α-EC (rmec2 , RoundManagerEC-correct-≡ rmec1 rmec2 vals≡ rmec1-corr)
   {-

--- a/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/Impl/Consensus/Types/EpochIndep.agda
@@ -324,6 +324,22 @@ module LibraBFT.Impl.Consensus.Types.EpochIndep where
              (cmEpoch ∷ cmAuthor ∷ cmRound ∷ cmCert ∷ cmSigMB ∷ [])
   postulate instance enc-CommitMsg : Encoder CommitMsg
 
+  record GenesisInfo : Set where
+    constructor mkGenInfo
+    field
+      -- Nodes, PKs for initial epoch
+      -- Faults to tolerate (or quorum size?)
+      -- TODO: in the real implementation, a QuorumCert is derived from the genesis information, not stored directly there
+      ₋genQC     : QuorumCert            -- We use the same genesis QC for both highestQC and
+                                         -- highestCommitCert.
+  open GenesisInfo public
+
+  record GenesisMsg : Set where
+    constructor GenesisMsg∙new
+    field
+      ₋gmGenInfo : GenesisInfo
+  open GenesisMsg public
+
   record LastVoteInfo : Set where
     constructor LastVoteInfo∙new
     field

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -57,7 +57,7 @@ module LibraBFT.Impl.Handle
                       (₋rmSafetyRules (₋rmEC fakeRM)))
 
  initRMEC : RoundManagerEC
- initRMEC = RoundManagerEC∙new initSR (initVV genInfo)
+ initRMEC = RoundManagerEC∙new (EpochState∙new 1 (initVV genInfo)) initSR
 
  postulate -- TODO-2 : prove these once initRMEC is defined directly
    init-EC-epoch-1  : epoch (init-EC genInfo) ≡ 1
@@ -104,7 +104,7 @@ module LibraBFT.Impl.Handle
  outputToActions : RoundManager → Output → List (Action NetworkMsg)
  outputToActions rm (BroadcastProposal p) = List-map (const (Action.send (P p)))
                                                      (List-map proj₁
-                                                               (kvm-toList (:vvAddressToValidatorInfo (₋rmValidators (₋rmEC rm)))))
+                                                               (kvm-toList (:vvAddressToValidatorInfo (₋esVerifier (₋rmEpochState (₋rmEC rm))))))
  outputToActions _  (LogErr x)            = []
  outputToActions _  (SendVote v toList)   = List-map (const (Action.send (V v))) toList
 

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -28,6 +28,12 @@ module LibraBFT.Impl.Handle
 
  open EpochConfig
 
+ postulate -- valid assumption (that genesis information is sent by someone)
+   initialisingNode : NodeId
+
+ GenInfoP : Vote → Set
+ GenInfoP v = v ^∙ vRound ≡ 0
+
  postulate -- valid assumption
    -- We postulate the existence of GenesisInfo known to all
    genInfo : GenesisInfo
@@ -35,14 +41,15 @@ module LibraBFT.Impl.Handle
  genesisMsg : NetworkMsg
  genesisMsg = G (GenesisMsg∙new genInfo)
 
- postulate -- valid assumption (that genesis information is sent by someone)
-   initialisingNode : NodeId
-
- GenInfoP : Vote → Set
- GenInfoP v = v ^∙ vRound ≡ 0
-
  postulate -- valid assumption (that votes in genesis information are for round zero)
    genInfoP : ∀ {v} → v ⊂Msg genesisMsg → GenInfoP v
+
+ postulate -- valid assumption (that votes signed for the same PK in genesis information do not
+           -- conflict; generally there will be only one per PK anyway)
+   genVotesNoConflict : ∀ {v v' pk}
+                      → v  ⊂Msg genesisMsg → WithVerSig pk v
+                      → v' ⊂Msg genesisMsg → WithVerSig pk v'
+                      → v ^∙ vProposedId ≡ v' ^∙ vProposedId
 
  postulate -- TODO-2 : prove it using sameHonestSig⇒SameVoteDate
    genInfoPSameSig : SameSig⇒ ⦃ sig-Vote ⦄ GenInfoP

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -24,8 +24,7 @@ open import LibraBFT.Impl.Properties.Aux  -- TODO-1: maybe Aux properties should
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
-open        Structural impl-sps-avp
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP concSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 module LibraBFT.Impl.Handle.Properties
   (hash    : BitString → Hash)

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -107,3 +107,4 @@ module LibraBFT.Impl.Handle.Properties
   ...| P p = refl
   ...| V v = refl
   ...| C c = refl
+  ...| G g = refl

--- a/LibraBFT/Impl/Properties/Aux.agda
+++ b/LibraBFT/Impl/Properties/Aux.agda
@@ -13,7 +13,7 @@ open import LibraBFT.Impl.NetworkMsg
 open import LibraBFT.Impl.Util.Crypto
 open        EpochConfig
 open import LibraBFT.Concrete.System
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP concSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 -- In this module, we will prove a structural property that any new signed message produced by an
 -- honest handler from a reachable state correctly identifies the sender, and is for a valid epoch

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -27,7 +27,7 @@ open import LibraBFT.Impl.Util.Util
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP concSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 open        WithSPS impl-sps-avp
 open        Structural impl-sps-avp
 

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -48,7 +48,7 @@ open import LibraBFT.Impl.Properties.Aux
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP concSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 open        WithSPS impl-sps-avp
 open        Structural impl-sps-avp
 open import LibraBFT.Impl.Properties.VotesOnce

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -50,7 +50,7 @@ open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
 open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP concSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 open        WithSPS impl-sps-avp
-open        Structural impl-sps-avp
+open        Structural impl-sps-avp concInitParts
 open import LibraBFT.Impl.Properties.VotesOnce
 
 -- In this module, we (will) prove the two implementation obligations for the VotesOnce rule.  Note

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -171,7 +171,7 @@ module LibraBFT.Yasm.System
  initialState = record
    { peerStates  = const initPS
    ; initialised = const uninitd
-   ; msgPool     = []
+   ; msgPool     = (initMsgSndr , initMsg) ∷ []
    }
 
  -- * Small Step Semantics
@@ -189,7 +189,7 @@ module LibraBFT.Yasm.System
                     (PeerState × List Msg) → Set where
    -- An uninitialized peer can be initialized
    step-init : peerInits pid ≡ uninitd
-             → StepPeerState pid pool peerInits ps (init pid genInfo)
+             → StepPeerState pid pool peerInits ps (initPeer pid (initMsgSndr , initMsg))
 
    -- The peer processes a message in the pool
    step-msg  : ∀{m}


### PR DESCRIPTION
In this pull request, we model the initial distribution of some information to all participants by making the system model accept an initial message that is placed in the message pool in the initial state.  This ensures that the model allows cheat steps to send messages with signatures that can be derived from this initial information.

One consequence is that we cannot `unwind` a message containing parts from `GenesisInfo` because they are not introduced by any step.  This is handled by introducing properties about initial vs. non-initial parts (in our case, `Vote`s represented in the `GenesisInfo` are all for round 0, while new `Vote`s sent by peer steps are always for non-zero rounds.

We also postulate/prove various `GenesisInfo` for the (still fake) implementation model and properties about it required to make all the proofs go through, and then do so.

I have also experimented with an alternative in which the system model accepts a separate `GenesisInfo` type, which requires changing `CheatConstraint` to reflect that cheats can behave in this way.  The two approaches turn out to be fairly similar, although I have not completed the latter (yet?).  I am sharing this one for comments and feedback.

One downside of this approach is that it is no longer the case that the initial message pool is empty, which means some `step-0` cases require proofs that didn't before.  The alternative approach would instead result in additional cases for cheat steps, saying that the part was in the `GenesisInfo`, which will then have to be eliminated as contradictions.  In hindsight, that may be preferable because the (new) `step-0` proofs require reasoning about `msgPool initialState`.