### PR TITLE
Simplify LibraBFT.Impl.Properties.VotesOnce` inspired by alternative proof in `VotesOnceDirect`

### DIFF
--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -25,9 +25,11 @@ module LibraBFT.Impl.Consensus.RoundManager.Properties where
                       → (₋rmEC pre) ^∙ rmEpoch ≡ vm ^∙ vmVote ∙ vEpoch
   voteForCurrentEpoch (here refl) = refl
 
-  -- The quorum certificates sent in SyncInfo with votes are those from the peer state
+  -- The quorum certificates sent in SyncInfo with votes are those from the peer state.
+  -- This is no longer used because matching m∈outs parameters to here refl eliminated the need for
+  -- it, at least for our simple handler.  I'm keeping it, though, as it may be needed in future
+  -- when the real handler will be much more complicated and this proof may no longer be trivial.
   procPMCerts≡ : ∀ {ts pm pre vm αs}
                → (SendVote vm αs) ∈ LBFT-outs (processProposalMsg ts pm) pre
                → vm ^∙ vmSyncInfo ≡ SyncInfo∙new (₋rmHighestQC pre) (₋rmHighestCommitQC pre)
-  procPMCerts≡ (there x)   = ⊥-elim (¬Any[] x)  -- processProposalMsg sends only one vote
   procPMCerts≡ (here refl) = refl

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -70,9 +70,8 @@ module LibraBFT.Impl.Handle.Properties where
   -- This captures which kinds of messages are sent by handling which kind of message.  It will
   -- require additional disjuncts when we implement processVote.
   msgsToSendWereSent : ∀ {pid nm m} {st : RoundManager}
-                     → send m ∈ proj₂ (peerStepWrapper pid nm st)
-                     → send m ∈ proj₂ (peerStep pid nm 0 st)
-                     × ∃[ vm ] ∃[ pm ] (m ≡ V vm × nm ≡ P pm)
+                     → send m ∈ proj₂ (peerStep pid nm st)
+                     → ∃[ vm ] ∃[ pm ] (m ≡ V vm × nm ≡ P pm)
   msgsToSendWereSent {pid} {nm = nm} {m} {st} m∈outs
     with nm
   ...| C _ = ⊥-elim (¬Any[] m∈outs)
@@ -83,7 +82,7 @@ module LibraBFT.Impl.Handle.Properties where
        with m
   ...| P _ = ⊥-elim (P≢V (action-send-injective v∈outs))
   ...| C _ = ⊥-elim (C≢V (action-send-injective v∈outs))
-  ...| V vm rewrite sym v∈outs = here refl , vm , pm , refl , refl
+  ...| V vm rewrite sym v∈outs = vm , pm , refl , refl
 
   ----- Properties that relate handler to system state -----
 
@@ -179,7 +178,7 @@ module LibraBFT.Impl.Handle.Properties where
   newVoteSameEpochGreaterRound {pre = pre} {pid} {v = v} {m} {pk} r (step-msg {(_ , P pm)} msg∈pool pinit) ¬init hpk v⊂m m∈outs sig vnew
      rewrite pinit
      with msgsToSendWereSent {pid} {P pm} {m} {peerStates pre pid} m∈outs
-  ...| _ , vm , _ , refl , refl
+  ...| _ , vm , _ , refl
     with m∈outs
   ...| here refl
     with v⊂m

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -141,7 +141,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
   vo₁ {pid} {pk = pk} {pre = pre} r sm@(step-msg {(_ , nm)} m∈pool pidini)
       {m = m} {v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 vpb v'⊂m' m'∈pool sig' ¬init' refl rnds≡
      with msgsToSendWereSent {pid} {nm} m∈outs
-  ...| _ , vm , _ , refl , _
+  ...| _ , vm , _ , _
      with newVoteSameEpochGreaterRound r (step-msg m∈pool pidini) ¬init hpk v⊂m m∈outs sig ¬sentb4
   ...| eIds≡' , suclvr≡v'rnd , _
      -- Use unwind to find the step that first sent the signature for v', then Any-Step-elim to
@@ -175,7 +175,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
 
   vo₁ {pid} {pk = pk} {pre = pre} r sm@(step-msg m∈pool ps≡)
       {v' = v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 vpb v'⊂m' m'∈pool sig' _ refl rnds≡
-     | _ , vm , _ , refl , _
+     | _ , vm , _ , _
      | eIds≡' , suclvr≡v'rnd , _
      | mkCarrier r' mws ini vpf' preprop
      | inj₂ refl
@@ -196,7 +196,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
   vo₂ {pid = pid} {pk = pk} {pre = pre} r (step-msg {_ , nm} m∈pool pinit) {v = v} {m}
       hpk v⊂m m∈outs sig ¬init vnew vpk v'⊂m' m'∈outs sig' ¬init' v'new vpk' es≡ rnds≡
      with msgsToSendWereSent {pid} {nm} m∈outs
-  ...| _ , vm , pm , refl , refl
+  ...| _ , vm , pm , refl
     with m∈outs
   ...| here refl
     with v⊂m
@@ -212,11 +212,11 @@ module LibraBFT.Impl.Properties.VotesOnce where
 
   vo₂ {pid = pid} {pk = pk} {pre = pre} r (step-msg {_ , nm} m∈pool pinit) {v = v} {m} {v'} {m'}
       hpk v⊂m m∈outs sig ¬init vnew vpk v'⊂m' m'∈outs sig' ¬init' v'new vpk' es≡ rnds≡
-     | _ , vm , pm , refl , refl
+     | _ , vm , pm , refl
      | here refl
      | vote∈vm
      with msgsToSendWereSent {pid} {nm} {m'} {st = peerStates pre pid} m'∈outs
-  ...| _ , vm' , pm , refl , refl
+  ...| _ , vm' , pm' , refl
      with m'∈outs
   ...| here refl
      with v'⊂m'

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -197,8 +197,8 @@ module LibraBFT.Impl.Properties.VotesOnce where
       hpk v⊂m m∈outs sig ¬init vnew vpk v'⊂m' m'∈outs sig' ¬init' v'new vpk' es≡ rnds≡
      with msgsToSendWereSent {pid} {nm} m∈outs
   ...| _ , vm , pm , refl , refl
-    with proposalHandlerSentVote {pid} {0} {pm} {vm} {peerStates pre pid} m∈outs
-  ...| _ , v∈outs
+    with m∈outs
+  ...| here refl
     with v⊂m
        -- Rebuilding keeps the same signature, and the SyncInfo included with the
        -- VoteMsg sent comprises QCs from the peer's state.  Votes represented in
@@ -206,8 +206,6 @@ module LibraBFT.Impl.Properties.VotesOnce where
        -- assumption that v's signature has not been sent before.
   ...| vote∈qc {vs = vs} {qc} vs∈qc v≈rbld (inV qc∈m)
                   rewrite cong ₋vSignature v≈rbld
-                        | procPMCerts≡ {0} {pm} {peerStates pre pid} {vm} v∈outs
-                        | SendVote-inj-v (Any-singleton⁻ v∈outs)
      with qcVotesSentB4 r pinit
                         (VoteMsgQCsFromRoundManager r (step-msg m∈pool pinit) hpk v⊂m m∈outs qc∈m) vs∈qc ¬init
   ...| mws = ⊥-elim (vnew mws)
@@ -215,20 +213,16 @@ module LibraBFT.Impl.Properties.VotesOnce where
   vo₂ {pid = pid} {pk = pk} {pre = pre} r (step-msg {_ , nm} m∈pool pinit) {v = v} {m} {v'} {m'}
       hpk v⊂m m∈outs sig ¬init vnew vpk v'⊂m' m'∈outs sig' ¬init' v'new vpk' es≡ rnds≡
      | _ , vm , pm , refl , refl
-     | _ , v∈outs
+     | here refl
      | vote∈vm
      with msgsToSendWereSent {pid} {nm} {m'} {st = peerStates pre pid} m'∈outs
   ...| _ , vm' , pm , refl , refl
-    with proposalHandlerSentVote {pid} {0} {pm} {vm'} {peerStates pre pid} m'∈outs
-  ...| _ , v'∈outs
-       rewrite cong ₋vmVote (SendVote-inj-v (trans (Any-singleton⁻ v∈outs) (sym (Any-singleton⁻ v'∈outs))))
-    with v'⊂m'
+     with m'∈outs
+  ...| here refl
+     with v'⊂m'
   ...| vote∈vm = refl
   ...| vote∈qc {vs = vs} {qc} vs∈qc v≈rbld (inV qc∈m)
                   rewrite cong ₋vSignature v≈rbld
-                        | procPMCerts≡ {0} {pm} {peerStates pre pid} {vm} v∈outs
-                        | SendVote-inj-v (Any-singleton⁻ v∈outs)
-                        | cong ₋vmVote (SendVote-inj-v (trans (Any-singleton⁻ v∈outs) (sym (Any-singleton⁻ v'∈outs))))
-    with qcVotesSentB4 r pinit
+     with qcVotesSentB4 r pinit
                        (VoteMsgQCsFromRoundManager r (step-msg m∈pool pinit) hpk v'⊂m' m'∈outs qc∈m) vs∈qc ¬init'
   ...| mws = ⊥-elim (v'new mws)


### PR DESCRIPTION
Some nice simplifications enabled by @lisandrasilva's alternative proof of the same property.  Specifically, Agda can figure out that `processProposalMsg` sends only one vote, so by matching on the evidence that a vote is in the outputs of that function, we can eliminate a bunch of other reasoning about it.

Also fixed a small oversight made in response to review comments on the previous pull request.