### PR TITLE
Define implementation obligations for `PreferredRound` rule

### DIFF
--- a/LibraBFT/Abstract/Types/EpochConfig.agda
+++ b/LibraBFT/Abstract/Types/EpochConfig.agda
@@ -65,6 +65,12 @@ module LibraBFT.Abstract.Types.EpochConfig
                   → toNodeId 𝓔₁ mbr₁ ≡ toNodeId 𝓔₂ mbr₂
   PK-inj-same-ECs {𝓔₁} refl pks≡ = cong (toNodeId 𝓔₁) (PK-inj 𝓔₁ pks≡)
 
+  EC-member-cast : ∀ {𝓔₁ 𝓔₂ : EpochConfig}
+                 → 𝓔₁ ≡ 𝓔₂
+                 → Member 𝓔₁
+                 → Member 𝓔₂
+  EC-member-cast refl m = m
+
   module _ (ec : EpochConfig) where
     NodeId-PK-OK : PK → NodeId → Set
     NodeId-PK-OK pk pid = ∃[ m ] (toNodeId ec m ≡ pid × getPubKey ec m ≡ pk)

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -26,8 +26,8 @@ module LibraBFT.Concrete.Obligations (𝓔 : EpochConfig) where
       -- Semantic obligations:
       --
       -- VotesOnce:
-      vo₁ : VO.ImplObligation₁
-      vo₂ : VO.ImplObligation₂
+      vo₁ : VO.ImplObligation₁ 𝓔
+      vo₂ : VO.ImplObligation₂ 𝓔
 
       -- PreferredRound:
       pr₁ : PR.ImplObligation₁ 𝓔

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -17,7 +17,7 @@ open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSig
 -- implementation must meet in order to enjoy the properties
 -- proved in Abstract.Properties.
 
-module LibraBFT.Concrete.Obligations where
+module LibraBFT.Concrete.Obligations (𝓔 : EpochConfig) where
   record ImplObligations : Set (ℓ+1 ℓ-RoundManager) where
     field
       -- Structural obligations:
@@ -30,4 +30,4 @@ module LibraBFT.Concrete.Obligations where
       vo₂ : VO.ImplObligation₂
 
       -- PreferredRound:
-      pr₁ : PR.ImplObligation₁
+      pr₁ : PR.ImplObligation₁ 𝓔

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -31,3 +31,4 @@ module LibraBFT.Concrete.Obligations (𝓔 : EpochConfig) where
 
       -- PreferredRound:
       pr₁ : PR.ImplObligation₁ 𝓔
+      pr₂ : PR.ImplObligation₂ 𝓔

--- a/LibraBFT/Concrete/Obligations/PreferredRound.agda
+++ b/LibraBFT/Concrete/Obligations/PreferredRound.agda
@@ -52,6 +52,7 @@ module LibraBFT.Concrete.Obligations.PreferredRound
   open voteExtends
 
   record Cand-3-chain-vote (v : Vote) : Set where
+    constructor mkCand3chainvote
     field
       votesForB : voteExtends v
       qc        : QC

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -54,7 +54,7 @@ module LibraBFT.Concrete.Properties
 
     validState : ValidSysState intSystemState
     validState = record
-      { vss-votes-once      = VO.Proof.voo   sps-cor vo₁ vo₂ st r 𝓔
+      { vss-votes-once      = VO.Proof.voo 𝓔 sps-cor vo₁ vo₂ st r
       ; vss-preferred-round = PR.Proof.prr 𝓔 sps-cor pr₁ pr₂ st r
       }
 

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -54,8 +54,8 @@ module LibraBFT.Concrete.Properties
 
     validState : ValidSysState intSystemState
     validState = record
-      { vss-votes-once      = VO.Proof.voo sps-cor vo₁ vo₂ st r 𝓔
-      ; vss-preferred-round = PR.Proof.prr 𝓔 sps-cor pr₁     st r 𝓔
+      { vss-votes-once      = VO.Proof.voo   sps-cor vo₁ vo₂ st r 𝓔
+      ; vss-preferred-round = PR.Proof.prr 𝓔 sps-cor pr₁     st r
       }
 
     open IntermediateSystemState intSystemState

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -55,7 +55,7 @@ module LibraBFT.Concrete.Properties
     validState : ValidSysState intSystemState
     validState = record
       { vss-votes-once      = VO.Proof.voo   sps-cor vo₁ vo₂ st r 𝓔
-      ; vss-preferred-round = PR.Proof.prr 𝓔 sps-cor pr₁     st r
+      ; vss-preferred-round = PR.Proof.prr 𝓔 sps-cor pr₁ pr₂ st r
       }
 
     open IntermediateSystemState intSystemState

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -18,10 +18,10 @@ open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSig
 -- conditions proved in Abstract.Properties.  It can be extended to other
 -- properties later.
 module LibraBFT.Concrete.Properties
-         (impl-correct : ImplObligations)
          (st : SystemState)
          (r : ReachableSystemState st)
-         (𝓔 : EpochConfig)
+         (𝓔 : EpochConfig) 
+         (impl-correct : ImplObligations 𝓔)
          where
     open        ImplObligations impl-correct
     open        PerState st r
@@ -55,7 +55,7 @@ module LibraBFT.Concrete.Properties
     validState : ValidSysState intSystemState
     validState = record
       { vss-votes-once      = VO.Proof.voo sps-cor vo₁ vo₂ st r 𝓔
-      ; vss-preferred-round = PR.Proof.prr sps-cor pr₁     st r 𝓔
+      ; vss-preferred-round = PR.Proof.prr 𝓔 sps-cor pr₁     st r 𝓔
       }
 
     open IntermediateSystemState intSystemState

--- a/LibraBFT/Concrete/Properties/PreferredRound.agda
+++ b/LibraBFT/Concrete/Properties/PreferredRound.agda
@@ -28,6 +28,8 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
  import      LibraBFT.Abstract.Records UID _≟UID_ NodeId 𝓔 as Abs
  open import LibraBFT.Concrete.Obligations.PreferredRound 𝓔 (ConcreteVoteEvidence 𝓔)
  open WithAbsVote 𝓔
+ open PeerCanSignForPK
+ open PeerCanSignForPKinEpoch
 
  -- As with VotesOnce, we will have two implementation obligations, one for when v is sent by the
  -- step and v' has been sent before, and one for when both are sent by the step.
@@ -46,15 +48,15 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
    → (sig : WithVerSig pk v) → ¬ (∈GenInfo (ver-signature sig))
    -- If v is really new and valid
    → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre))
-   → (𝓔s≡ : PeerCanSignForPK.𝓔 pcs4 ≡ 𝓔)
+   → (𝓔s≡ : pcs4𝓔 pcs4 ≡ 𝓔)
    -- And if there exists another v' that has been sent before
    → v' ⊂Msg m' → (pid' , m') ∈ (msgPool pre)
    → (sig' : WithVerSig pk v') → ¬ (∈GenInfo (ver-signature sig'))
    -- If v and v' share the same epoch and round
    → v ^∙ vEpoch ≡ v' ^∙ vEpoch
    → v ^∙ vRound < v' ^∙ vRound
-   → α-ValidVote 𝓔 v  (EC-member-cast 𝓔s≡ (PeerCanSignForPK.mbr pcs4)) ≡ vabs
-   → α-ValidVote 𝓔 v' (EC-member-cast 𝓔s≡ (PeerCanSignForPK.mbr pcs4)) ≡ v'abs
+   → α-ValidVote 𝓔 v  (EC-member-cast 𝓔s≡ (PeerCanSignForPKinEpoch.mbr (pcs4in𝓔 pcs4))) ≡ vabs
+   → α-ValidVote 𝓔 v' (EC-member-cast 𝓔s≡ (mbr (pcs4in𝓔 pcs4))) ≡ v'abs
    → (c2 : Cand-3-chain-vote (PerState.PerEpoch.intSystemState pre r 𝓔) vabs)
    → Σ (VoteParentData (PerState.PerEpoch.intSystemState pre r 𝓔) v'abs)
            (λ vp → Cand-3-chain-head-round

--- a/LibraBFT/Concrete/Properties/PreferredRound.agda
+++ b/LibraBFT/Concrete/Properties/PreferredRound.agda
@@ -69,7 +69,7 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
    (Impl-PR1 : ImplObligation₁)
    where
   -- Any reachable state satisfies the PR rule for any epoch in the system.
-  module _ (st : SystemState)(r : ReachableSystemState st)(𝓔 : EpochConfig) where
+  module _ (st : SystemState)(r : ReachableSystemState st) where
    -- Bring in 'unwind', 'ext-unforgeability' and friends
    open Structural sps-corr
    -- Bring in intSystemState
@@ -77,5 +77,6 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
    open        PerEpoch 𝓔
    open import LibraBFT.Concrete.Obligations.PreferredRound 𝓔 (ConcreteVoteEvidence 𝓔) as PR
 
-   postulate  -- TODO-3: prove it
+   postulate
      prr : PR.Type intSystemState
+   -- prr honα refl sv refl sv' c2 round< = {!!}

--- a/LibraBFT/Concrete/Properties/PreferredRound.agda
+++ b/LibraBFT/Concrete/Properties/PreferredRound.agda
@@ -90,8 +90,9 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
    → v' ⊂Msg m'  → send m' ∈ outs
    → (sig' : WithVerSig pk v') → ¬ (∈GenInfo (ver-signature sig'))
    → ¬ (MsgWithSig∈ pk (ver-signature sig') (msgPool pre))
-   -- If v and v' share the same epoch and round
+   -- If v and v' share the same epoch
    → v ^∙ vEpoch ≡ v' ^∙ vEpoch
+   -- and v is for a smaller round
    → v ^∙ vRound < v' ^∙ vRound
    → toNodeId 𝓔 mbr ≡ pid
    → α-ValidVote 𝓔 v  mbr ≡ vabs
@@ -102,7 +103,9 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
            (λ vp → Cand-3-chain-head-round intSys c2
                    ≤ Abs.round (vpParent vp))
 
-  -- Next, we prove that given the necessary obligations,
+ -- Next, we prove that given the necessary obligations, we can prove the type required (by
+ -- LibraBFT.Concrete.Obligations.PreferredRound.proof) to prove the type needed by the abstract
+ -- proofs for the preferred round rule.
  module Proof
    (sps-corr : StepPeerState-AllValidParts)
    (Impl-PR1 : ImplObligation₁)

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -35,7 +35,7 @@ open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSig
 -- sent by honest peers in the implementation, then the implemenation
 -- satisfies the LibraBFT.Abstract.Properties.VotesOnce invariant.
 
-module LibraBFT.Concrete.Properties.VotesOnce where
+module LibraBFT.Concrete.Properties.VotesOnce (𝓔 : EpochConfig) where
  -- TODO-3: This may not be the best way to state the implementation obligation.  Why not reduce
  -- this as much as possible before giving the obligation to the implementation?  For example, this
  -- will still require the implementation to deal with hash collisons (v and v' could be different,
@@ -99,7 +99,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    where
 
   -- Any reachable state satisfies the VO rule for any epoch in the system.
-  module _ (st : SystemState)(r : ReachableSystemState st)(𝓔 : EpochConfig) where
+  module _ (st : SystemState)(r : ReachableSystemState st) where
 
    open Structural sps-corr
    -- Bring in intSystemState

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -54,7 +54,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
    → v  ⊂Msg m  → send m ∈ outs
    → (sig : WithVerSig pk v) → ¬ (∈GenInfo (ver-signature sig))
    -- If v is really new and valid
-   → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre)) → PeerCanSignForPK (StepPeer-post {pre = pre} (step-honest sps)) v pid pk
+   → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre))
    -- And if there exists another v' that has been sent before
    → v' ⊂Msg m' → (pid' , m') ∈ (msgPool pre)
    → (sig' : WithVerSig pk v') → ¬ (∈GenInfo (ver-signature sig'))
@@ -193,7 +193,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
        with sameSig⇒sameVoteData (msgSigned m'sb4) vv' (msgSameSig m'sb4)
     ...| inj₁ hb   = ⊥-elim (meta-sha256-cr hb)
     ...| inj₂ refl rewrite sym (msgSameSig msv')
-      = Impl-VO1 r stPeer pkH (msg⊆ msv) m∈outs (msgSigned msv) ¬init newV vspk
+      = Impl-VO1 r stPeer pkH (msg⊆ msv) m∈outs (msgSigned msv) ¬init newV
                  (msg⊆ m'sb4) (msg∈pool m'sb4) (msgSigned m'sb4) (¬subst ¬init' (msgSameSig m'sb4)) eid≡ r≡
 
     VotesOnceProof (step-s r theStep) pkH vv msv vv' msv' eid≡ r≡
@@ -205,7 +205,7 @@ module LibraBFT.Concrete.Properties.VotesOnce where
        with sameSig⇒sameVoteData (msgSigned msb4) vv (msgSameSig msb4)
     ...| inj₁ hb = ⊥-elim (meta-sha256-cr hb)
     ...| inj₂ refl
-      = sym (Impl-VO1 r stPeer pkH (msg⊆ msv') m'∈outs (msgSigned msv') ¬init' newV' v'spk
+      = sym (Impl-VO1 r stPeer pkH (msg⊆ msv') m'∈outs (msgSigned msv') ¬init' newV'
                       (msg⊆ msb4) (msg∈pool msb4) (msgSigned msb4) (¬subst ¬init (msgSameSig msb4)) (sym eid≡) (sym r≡))
 
    voo : VO.Type intSystemState

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -18,7 +18,6 @@ open import LibraBFT.Impl.Handle.Properties
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Concrete.System
 open        EpochConfig
-open import LibraBFT.Yasm.Types
 open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 -- In this module, we define two "implementation obligations"

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -35,6 +35,14 @@ open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSig
 -- sent by honest peers in the implementation, then the implemenation
 -- satisfies the LibraBFT.Abstract.Properties.VotesOnce invariant.
 
+-- It is not actually necessary to provide an EpochConfig to define
+-- these implementation obligations, but it is needed below to state
+-- the goal of the proof (voo).  In contrast, the PreferredRound rule
+-- requires and EpochConfig to state the obligations, because they
+-- are defined in terms of abstract Records, which are defined for an
+-- EpochConfig.  We introduce the EpochConfig at the top of this
+-- module for consistency with the PreferredRound rule so that the
+-- order of parameters to invoke the respective proofs is consistent.
 module LibraBFT.Concrete.Properties.VotesOnce (𝓔 : EpochConfig) where
  -- TODO-3: This may not be the best way to state the implementation obligation.  Why not reduce
  -- this as much as possible before giving the obligation to the implementation?  For example, this

--- a/LibraBFT/Concrete/Records.agda
+++ b/LibraBFT/Concrete/Records.agda
@@ -75,7 +75,7 @@ module LibraBFT.Concrete.Records (𝓔 : EpochConfig) where
    { qCertBlockId = qc ^∙ qcVoteData ∙ vdProposed ∙ biId
    ; qRound       = qc ^∙ qcVoteData ∙ vdProposed ∙ biRound
    ; qVotes       = All-reduce (α-Vote qc valid) All-self
-   ; qVotes-C1    = {! MetaIsValidQC.₋ivqcMetaIsQuorum valid!}
+   ; qVotes-C1    = subst IsQuorum {!!} (MetaIsValidQC.₋ivqcMetaIsQuorum valid) 
    ; qVotes-C2    = All-reduce⁺ (α-Vote qc valid) (λ _ → refl) All-self
    ; qVotes-C3    = All-reduce⁺ (α-Vote qc valid) (λ _ → refl) All-self
    ; qVotes-C4    = All-reduce⁺ (α-Vote qc valid) (α-Vote-evidence qc valid) All-self

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -50,20 +50,29 @@ module LibraBFT.Concrete.System.Parameters where
 
  -- A peer pid can sign a new message for a given PK if pid is the owner of a PK in a known
  -- EpochConfig.
- record PeerCanSignForPK (st : SystemState) (v : Vote) (pid : NodeId) (pk : PK) : Set ℓ-VSFP where
-   constructor mkPCS4PK
+ record PeerCanSignForPKinEpoch (st : SystemState) (v : Vote) (pid : NodeId) (pk : PK)
+                                (𝓔 : EpochConfig) (𝓔inSys : EpochConfig∈Sys st 𝓔)
+                                : Set ℓ-VSFP where
+   constructor mkPCS4PKin𝓔
    field
-     𝓔       : EpochConfig
      𝓔id≡    : epoch 𝓔 ≡ v ^∙ vEpoch
-     𝓔inSys  : EpochConfig∈Sys st 𝓔
      mbr      : Member 𝓔
      nid≡     : toNodeId  𝓔 mbr ≡ pid
      pk≡      : getPubKey 𝓔 mbr ≡ pk
+ open PeerCanSignForPKinEpoch
+
+ record PeerCanSignForPK (st : SystemState) (v : Vote) (pid : NodeId) (pk : PK) : Set ℓ-VSFP where
+   constructor mkPCS4PK
+   field
+     pcs4𝓔     : EpochConfig
+     pcs4𝓔∈Sys : EpochConfig∈Sys st pcs4𝓔
+     pcs4in𝓔   : PeerCanSignForPKinEpoch st v pid pk pcs4𝓔 pcs4𝓔∈Sys
  open PeerCanSignForPK
 
- PCS4PK⇒NodeId-PK-OK : ∀ {st v pid pk} → (pcs : PeerCanSignForPK st v pid pk) → NodeId-PK-OK (𝓔 pcs) pk pid
- PCS4PK⇒NodeId-PK-OK (mkPCS4PK _ _ _ mbr n≡ pk≡) = mbr , n≡ , pk≡
+ PCS4PK⇒NodeId-PK-OK : ∀ {st v pid pk 𝓔 𝓔∈Sys} → (pcs : PeerCanSignForPKinEpoch st v pid pk 𝓔 𝓔∈Sys) → NodeId-PK-OK 𝓔 pk pid
+ PCS4PK⇒NodeId-PK-OK (mkPCS4PKin𝓔 _ mbr n≡ pk≡) = mbr , n≡ , pk≡
 
  -- This is super simple for now because the only known EpochConfig is dervied from genInfo, which is not state-dependent
  PeerCanSignForPK-stable : ValidSenderForPK-stable-type PeerCanSignForPK
- PeerCanSignForPK-stable _ _ (mkPCS4PK 𝓔₁ 𝓔id≡₁ (inGenInfo refl) mbr₁ nid≡₁ pk≡₁) = (mkPCS4PK 𝓔₁ 𝓔id≡₁ (inGenInfo refl) mbr₁ nid≡₁ pk≡₁)
+ PeerCanSignForPK-stable _ _ (mkPCS4PK 𝓔₁ (inGenInfo refl) (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁)) =
+                             (mkPCS4PK 𝓔₁ (inGenInfo refl) (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁))

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -76,3 +76,10 @@ module LibraBFT.Concrete.System.Parameters where
  PeerCanSignForPK-stable : ValidSenderForPK-stable-type PeerCanSignForPK
  PeerCanSignForPK-stable _ _ (mkPCS4PK 𝓔₁ (inGenInfo refl) (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁)) =
                              (mkPCS4PK 𝓔₁ (inGenInfo refl) (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁))
+
+ peerCanSignEp≡ : ∀ {pid v v' pk s'}
+                → PeerCanSignForPK s' v pid pk
+                → v ^∙ vEpoch ≡ v' ^∙ vEpoch
+                → PeerCanSignForPK s' v' pid pk
+ peerCanSignEp≡ (mkPCS4PK 𝓔₁ 𝓔inSys₁ (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁)) refl
+   = (mkPCS4PK 𝓔₁ 𝓔inSys₁ (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁))

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -24,7 +24,6 @@ open import LibraBFT.Impl.Util.Util
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Types
 open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 module LibraBFT.Impl.Handle.Properties where
@@ -110,12 +109,11 @@ module LibraBFT.Impl.Handle.Properties where
    -- epoch changes require proof of committing an epoch-changing transaction.
   availEpochsConsistent :
      ∀{pid pid' v v' pk}{st : SystemState}
-     → ReachableSystemState st
      → (pkvpf  : PeerCanSignForPK st v  pid  pk)
      → (pkvpf' : PeerCanSignForPK st v' pid' pk)
      → PeerCanSignForPK.𝓔 pkvpf ≡ PeerCanSignForPK.𝓔 pkvpf'
-  availEpochsConsistent r (mkPCS4PK _ _ (inGenInfo refl) _ _ _)
-                          (mkPCS4PK _ _ (inGenInfo refl) _ _ _) = refl
+  availEpochsConsistent (mkPCS4PK _ _ (inGenInfo refl) _ _ _)
+                        (mkPCS4PK _ _ (inGenInfo refl) _ _ _) = refl
 
   -- Always true, so far, as no epoch changes.
   noEpochIdChangeYet : ∀ {pre : SystemState}{pid}{ppre ppost msgs}

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -105,16 +105,17 @@ module LibraBFT.Impl.Handle.Properties where
                  → ¬ (∈GenInfo (proj₂ vs))
                  → MsgWithSig∈ pk (proj₂ vs) (msgPool st)
 
-   -- We can prove this easily because we don't yet do epoch changes,
-   -- so only the initial EC is relevant.  Later, this will require us to use the fact that
-   -- epoch changes require proof of committing an epoch-changing transaction.
+  -- We can prove this easily because we don't yet do epoch changes,
+  -- so only the initial EC is relevant.  Later, this will require us to use the fact that
+  -- epoch changes require proof of committing an epoch-changing transaction.
   availEpochsConsistent :
      ∀{pid pid' v v' pk}{st : SystemState}
      → (pkvpf  : PeerCanSignForPK st v  pid  pk)
      → (pkvpf' : PeerCanSignForPK st v' pid' pk)
+     → v ^∙ vEpoch ≡ v' ^∙ vEpoch
      → pcs4𝓔 pkvpf ≡ pcs4𝓔 pkvpf'
   availEpochsConsistent (mkPCS4PK _ (inGenInfo refl) _)
-                        (mkPCS4PK _ (inGenInfo refl) _) = refl
+                        (mkPCS4PK _ (inGenInfo refl) _) refl = refl
 
   -- Always true, so far, as no epoch changes.
   noEpochIdChangeYet : ∀ {pre : SystemState}{pid}{ppre ppost msgs}

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -23,6 +23,7 @@ open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Util.Util
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
+open        PeerCanSignForPK
 open        EpochConfig
 open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
@@ -59,7 +60,7 @@ module LibraBFT.Impl.Handle.Properties where
      | vote∈vm {si}
      with MsgWithSig∈? {pk} {ver-signature ver} {msgPool st}
   ...| yes msg∈ = inj₂ msg∈
-  ...| no  msg∉ = inj₁ ( mkPCS4PK {! !} {!!} (inGenInfo refl) {!!} {!!} {!!}
+  ...| no  msg∉ = inj₁ ( mkPCS4PK {!!} (inGenInfo refl) {!!}
        -- The implementation will need to provide evidence that the peer is a member of
        -- the epoch of the message it's sending and that it is assigned pk for that epoch.
                         , msg∉)
@@ -111,9 +112,9 @@ module LibraBFT.Impl.Handle.Properties where
      ∀{pid pid' v v' pk}{st : SystemState}
      → (pkvpf  : PeerCanSignForPK st v  pid  pk)
      → (pkvpf' : PeerCanSignForPK st v' pid' pk)
-     → PeerCanSignForPK.𝓔 pkvpf ≡ PeerCanSignForPK.𝓔 pkvpf'
-  availEpochsConsistent (mkPCS4PK _ _ (inGenInfo refl) _ _ _)
-                        (mkPCS4PK _ _ (inGenInfo refl) _ _ _) = refl
+     → pcs4𝓔 pkvpf ≡ pcs4𝓔 pkvpf'
+  availEpochsConsistent (mkPCS4PK _ (inGenInfo refl) _)
+                        (mkPCS4PK _ (inGenInfo refl) _) = refl
 
   -- Always true, so far, as no epoch changes.
   noEpochIdChangeYet : ∀ {pre : SystemState}{pid}{ppre ppost msgs}

--- a/LibraBFT/Impl/Properties.agda
+++ b/LibraBFT/Impl/Properties.agda
@@ -9,15 +9,17 @@ open import LibraBFT.Concrete.System.Parameters
 
 -- This module collects the implementation obligations for our (fake/simple, for now)
 -- "implementation" into the structure required by Concrete.Properties.
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Impl.Handle.Properties
 import      LibraBFT.Impl.Properties.VotesOnce   as VO
 import      LibraBFT.Impl.Properties.PreferredRound as PR
 open import LibraBFT.Concrete.Obligations
 open import LibraBFT.Concrete.System
 
-module LibraBFT.Impl.Properties where
-  theImplObligations : ImplObligations
+module LibraBFT.Impl.Properties (𝓔 : EpochConfig) where
+  theImplObligations : ImplObligations 𝓔
   theImplObligations = record { sps-cor = impl-sps-avp
                               ; vo₁     = VO.vo₁
                               ; vo₂     = VO.vo₂
-                              ; pr₁     = PR.pr₁ }
+                              ; pr₁     = PR.pr₁ 𝓔}

--- a/LibraBFT/Impl/Properties.agda
+++ b/LibraBFT/Impl/Properties.agda
@@ -20,8 +20,8 @@ open import LibraBFT.Concrete.System
 module LibraBFT.Impl.Properties (𝓔 : EpochConfig) where
   theImplObligations : ImplObligations 𝓔
   theImplObligations = record { sps-cor = impl-sps-avp
-                              ; vo₁     = VO.vo₁
-                              ; vo₂     = VO.vo₂
+                              ; vo₁     = VO.vo₁ 𝓔
+                              ; vo₂     = VO.vo₂ 𝓔
                               ; pr₁     = PR.pr₁ 𝓔
                               ; pr₂     = PR.pr₂ 𝓔
                               }

--- a/LibraBFT/Impl/Properties.agda
+++ b/LibraBFT/Impl/Properties.agda
@@ -22,4 +22,6 @@ module LibraBFT.Impl.Properties (𝓔 : EpochConfig) where
   theImplObligations = record { sps-cor = impl-sps-avp
                               ; vo₁     = VO.vo₁
                               ; vo₂     = VO.vo₂
-                              ; pr₁     = PR.pr₁ 𝓔}
+                              ; pr₁     = PR.pr₁ 𝓔
+                              ; pr₂     = PR.pr₂ 𝓔
+                              }

--- a/LibraBFT/Impl/Properties/PreferredRound.agda
+++ b/LibraBFT/Impl/Properties/PreferredRound.agda
@@ -22,3 +22,4 @@ module LibraBFT.Impl.Properties.PreferredRound (𝓔 : EpochConfig) where
              -- our current fake/simple implementaion) that we can
              -- reasonably hope actually ensures the property!
     pr₁ : PR.ImplObligation₁ 𝓔
+    pr₂ : PR.ImplObligation₂ 𝓔

--- a/LibraBFT/Impl/Properties/PreferredRound.agda
+++ b/LibraBFT/Impl/Properties/PreferredRound.agda
@@ -4,13 +4,15 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Prelude
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 import      LibraBFT.Concrete.Properties.PreferredRound as PR
 
 open import LibraBFT.Concrete.Obligations
 
 -- In this module, we (will) prove the implementation obligation for the PreferredRound rule.
 
-module LibraBFT.Impl.Properties.PreferredRound where
+module LibraBFT.Impl.Properties.PreferredRound (𝓔 : EpochConfig) where
 
   postulate  -- TODO-3 : prove.  Note that this is a substantial
              -- undertaking that should not be started before we have
@@ -19,4 +21,4 @@ module LibraBFT.Impl.Properties.PreferredRound where
              -- implementation (perhaps some incremental extension of
              -- our current fake/simple implementaion) that we can
              -- reasonably hope actually ensures the property!
-    pr₁ : PR.ImplObligation₁
+    pr₁ : PR.ImplObligation₁ 𝓔

--- a/LibraBFT/Impl/Properties/PreferredRound.agda
+++ b/LibraBFT/Impl/Properties/PreferredRound.agda
@@ -5,8 +5,15 @@
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.Impl.Base.Types
-open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 import      LibraBFT.Concrete.Properties.PreferredRound as PR
+open import LibraBFT.Concrete.System
+open import LibraBFT.Concrete.System.Parameters
+
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Handle
+open import LibraBFT.Impl.Handle.Properties
+open        Structural impl-sps-avp
 
 open import LibraBFT.Concrete.Obligations
 
@@ -22,4 +29,23 @@ module LibraBFT.Impl.Properties.PreferredRound (𝓔 : EpochConfig) where
              -- our current fake/simple implementaion) that we can
              -- reasonably hope actually ensures the property!
     pr₁ : PR.ImplObligation₁ 𝓔
-    pr₂ : PR.ImplObligation₂ 𝓔
+
+  --TODO-2: This proof is highly redundant with vo₁, some refactoring may be in order
+  pr₂ : PR.ImplObligation₂ 𝓔
+  pr₂ {pk = pk} {st} r stMsg@(step-msg {_ , P m} m∈pool psI) pkH v⊂m m∈outs sig ¬gen vnew v'⊂m' m'∈outs sig' ¬gen' v'new refl vround< refl refl refl c2
+     with m∈outs | m'∈outs
+  ...| here refl | here refl
+     with v⊂m                          | v'⊂m'
+  ...| vote∈vm                         | vote∈vm = ⊥-elim (<⇒≢ vround< refl) -- Only one VoteMsg is
+                                                                             -- sent, so the votes
+                                                                             -- must be the same,
+                                                                             -- contradicting
+                                                                             -- vround<
+  ...| vote∈vm                         | vote∈qc vs∈qc' v≈rbld' (inV qc∈m')
+       rewrite cong ₋vSignature v≈rbld'
+       = let qc∈rm' = VoteMsgQCsFromRoundManager r stMsg pkH v'⊂m' (here refl) qc∈m'
+         in ⊥-elim (v'new (qcVotesSentB4 r psI qc∈rm' vs∈qc' ¬gen'))
+  ...| vote∈qc vs∈qc v≈rbld (inV qc∈m) | _
+       rewrite cong ₋vSignature v≈rbld
+       = let qc∈rm = VoteMsgQCsFromRoundManager r stMsg pkH v⊂m (here refl) qc∈m
+         in ⊥-elim (vnew (qcVotesSentB4 r psI qc∈rm vs∈qc ¬gen))

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -139,7 +139,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
   -- required here.  In future it may send messages, but any verifiable Signatures for honest PKs
   -- they contain will be from GenesisInfo.
   vo₁ {pid} {pk = pk} {pre = pre} r sm@(step-msg {(_ , nm)} m∈pool pidini)
-      {m = m} {v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 vpb v'⊂m' m'∈pool sig' ¬init' refl rnds≡
+      {m = m} {v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 v'⊂m' m'∈pool sig' ¬init' refl rnds≡
      with msgsToSendWereSent {pid} {nm} m∈outs
   ...| _ , vm , _ , _
      with newVoteSameEpochGreaterRound r (step-msg m∈pool pidini) ¬init hpk v⊂m m∈outs sig ¬sentb4
@@ -159,12 +159,15 @@ module LibraBFT.Impl.Properties.VotesOnce where
   ...| inj₁ hb = ⊥-elim (PerState.meta-sha256-cr pre r hb)
   ...| inj₂ refl
      with msgSender mws ≟NodeId pid
-  ...| no neq =
+  ...| no neq
      -- We know that *after* the step, pid can sign v (vpb is about the post-state).  For v', we
      -- know it about state "pre"; we transport this to the post-state using
      -- PeerCanSignForPK-Stable.  Because EpochConfigs known in a system state are consistent with
      -- each other (i.e., trivially, for now because only the initial EpochConfig is known), we can
      -- use PK-inj to contradict the assumption that v and v' were sent by different peers (neq).
+     with impl-sps-avp r hpk sm m∈outs v⊂m sig ¬init
+  ...| inj₂ sentb4 = ⊥-elim (¬sentb4 sentb4)
+  ...| inj₁ (vpb , _) =
      let theStep = step-peer (step-honest sm)
          vpf''   = PeerCanSignForPK-stable r theStep vpf'
          𝓔s≡     = availEpochsConsistent {pid} {msgSender mws} vpb vpf''
@@ -174,7 +177,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
                             (nid≡ (pcs4in𝓔 vpb))))
 
   vo₁ {pid} {pk = pk} {pre = pre} r sm@(step-msg m∈pool ps≡)
-      {v' = v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 vpb v'⊂m' m'∈pool sig' _ refl rnds≡
+      {v' = v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 v'⊂m' m'∈pool sig' _ refl rnds≡
      | _ , vm , _ , _
      | eIds≡' , suclvr≡v'rnd , _
      | mkCarrier r' mws ini vpf' preprop

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -53,6 +53,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
                          × LvrCarrier pk (₋vSignature v') (StepPeer-post pstep)
                          )
   open PeerCanSignForPK
+  open PeerCanSignForPKinEpoch
 
   isValidNewPart⇒fSE : ∀ {pk v'}{pre : SystemState} {post : SystemState} {theStep : Step pre post}
                      → Meta-Honest-PK pk
@@ -166,11 +167,11 @@ module LibraBFT.Impl.Properties.VotesOnce where
      -- use PK-inj to contradict the assumption that v and v' were sent by different peers (neq).
      let theStep = step-peer (step-honest sm)
          vpf''   = PeerCanSignForPK-stable r theStep vpf'
-         𝓔s≡     = availEpochsConsistent {pid} {msgSender mws} (step-s r theStep) vpb vpf''
-     in  ⊥-elim (neq (trans (trans (sym (nid≡ vpf''))
+         𝓔s≡     = availEpochsConsistent {pid} {msgSender mws} vpb vpf''
+     in  ⊥-elim (neq (trans (trans (sym (nid≡ (pcs4in𝓔 vpf'')))
                                    (PK-inj-same-ECs (sym 𝓔s≡)
-                                                    (trans (pk≡ vpf'') (sym (pk≡ vpb)))))
-                            (nid≡ vpb)))
+                                                    (trans (pk≡ (pcs4in𝓔 vpf'')) (sym (pk≡ (pcs4in𝓔 vpb))))))
+                            (nid≡ (pcs4in𝓔 vpb))))
 
   vo₁ {pid} {pk = pk} {pre = pre} r sm@(step-msg m∈pool ps≡)
       {v' = v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 vpb v'⊂m' m'∈pool sig' _ refl rnds≡

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -170,7 +170,7 @@ module LibraBFT.Impl.Properties.VotesOnce (𝓔 : EpochConfig) where
   ...| inj₁ (vpb , _) =
      let theStep = step-peer (step-honest sm)
          vpf''   = PeerCanSignForPK-stable r theStep vpf'
-         𝓔s≡     = availEpochsConsistent {pid} {msgSender mws} vpb vpf''
+         𝓔s≡     = availEpochsConsistent {pid} {msgSender mws} vpb vpf'' refl
      in  ⊥-elim (neq (trans (trans (sym (nid≡ (pcs4in𝓔 vpf'')))
                                    (PK-inj-same-ECs (sym 𝓔s≡)
                                                     (trans (pk≡ (pcs4in𝓔 vpf'')) (sym (pk≡ (pcs4in𝓔 vpb))))))

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -80,9 +80,9 @@ module LibraBFT.Impl.Properties.VotesOnce (𝓔 : EpochConfig) where
   ...| nm∈outs , refl
      with hstep
   ...| step-msg {_ , P m} m∈pool ini
-     with impl-sps-avp {m = msgWhole mws} r hpk hstep nm∈outs (msg⊆ mws) (msgSigned mws) (transp-¬∈GenInfo₁ ¬init mws )
-  ...| inj₂ sentb4 rewrite msgSameSig mws = ⊥-elim (¬sentb4 sentb4)
-  ...| inj₁ (vpk' , _)
+     with ⊎-elimʳ (¬subst ¬sentb4 (msgSameSig mws))
+                  (impl-sps-avp {m = msgWhole mws} r hpk hstep nm∈outs (msg⊆ mws) (msgSigned mws) (transp-¬∈GenInfo₁ ¬init mws))
+  ...| (vpk' , _)
      with noEpochIdChangeYet {ppre = peerStates pre β} r refl hstep ini
   ...| eids≡
      with newVoteSameEpochGreaterRound r hstep (¬subst ¬init (msgSameSig mws)) hpk (msg⊆ mws) nm∈outs (msgSigned mws)
@@ -159,16 +159,14 @@ module LibraBFT.Impl.Properties.VotesOnce (𝓔 : EpochConfig) where
   ...| inj₁ hb = ⊥-elim (PerState.meta-sha256-cr pre r hb)
   ...| inj₂ refl
      with msgSender mws ≟NodeId pid
-  ...| no neq
+  ...| no neq =
      -- We know that *after* the step, pid can sign v (vpb is about the post-state).  For v', we
      -- know it about state "pre"; we transport this to the post-state using
      -- PeerCanSignForPK-Stable.  Because EpochConfigs known in a system state are consistent with
      -- each other (i.e., trivially, for now because only the initial EpochConfig is known), we can
      -- use PK-inj to contradict the assumption that v and v' were sent by different peers (neq).
-     with impl-sps-avp r hpk sm m∈outs v⊂m sig ¬init
-  ...| inj₂ sentb4 = ⊥-elim (¬sentb4 sentb4)
-  ...| inj₁ (vpb , _) =
-     let theStep = step-peer (step-honest sm)
+     let vpb     = proj₁ (⊎-elimʳ ¬sentb4 (impl-sps-avp r hpk sm m∈outs v⊂m sig ¬init))
+         theStep = step-peer (step-honest sm)
          vpf''   = PeerCanSignForPK-stable r theStep vpf'
          𝓔s≡     = availEpochsConsistent {pid} {msgSender mws} vpb vpf'' refl
      in  ⊥-elim (neq (trans (trans (sym (nid≡ (pcs4in𝓔 vpf'')))

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -34,7 +34,7 @@ open        Structural impl-sps-avp
 -- implementation (or some variant on it) and streamline the proof before we proceed to tackle more
 -- ambitious properties.
 
-module LibraBFT.Impl.Properties.VotesOnce where
+module LibraBFT.Impl.Properties.VotesOnce (𝓔 : EpochConfig) where
 
   -- This is the information we can establish about the state after the first time a signature is
   -- sent, and that we can carry forward to subsequent states, so we can use it to prove
@@ -134,7 +134,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
               → LvrCarrier pk (signature v' unit) final
   fSE⇒rnd≤lvr hpk {theStep = step-peer (step-honest _)} (_ , _ , lvrc) step* = LvrCarrier-transp* lvrc step*
 
-  vo₁ : VO.ImplObligation₁
+  vo₁ : VO.ImplObligation₁ 𝓔
   -- Initialization doesn't send any messages at all so far; Agda figures that out so no proof
   -- required here.  In future it may send messages, but any verifiable Signatures for honest PKs
   -- they contain will be from GenesisInfo.
@@ -195,7 +195,7 @@ module LibraBFT.Impl.Properties.VotesOnce where
   -- TODO-1: This proof should be refactored to reduce redundant reasoning about the two votes.  The
   -- newVoteSameEpochGreaterRound property uses similar reasoning.
 
-  vo₂ : VO.ImplObligation₂
+  vo₂ : VO.ImplObligation₂ 𝓔
   vo₂ {pid = pid} {pk = pk} {pre = pre} r (step-msg {_ , nm} m∈pool pinit) {v = v} {m}
       hpk v⊂m m∈outs sig ¬init vnew vpk v'⊂m' m'∈outs sig' ¬init' v'new vpk' es≡ rnds≡
      with msgsToSendWereSent {pid} {nm} m∈outs

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -28,7 +28,7 @@ open import LibraBFT.Impl.Properties.VotesOnce
 -- LibraBFT.Impl.Properties.VotesOnce, which is based on unwind, this proof is done
 -- inductively on the ReachableSystemState.
 
-module LibraBFT.Impl.Properties.VotesOnceDirect where
+module LibraBFT.Impl.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
 
 
   newVoteEpoch≡⇒Round≡ : ∀ {st : SystemState}{pid s' outs v m pk}
@@ -215,7 +215,7 @@ module LibraBFT.Impl.Properties.VotesOnceDirect where
   ...| no  pid≢ = ⊥-elim (pid≢ (peerCanSignPK-Inj step pkH vspk vspkN refl))
 
 
-  votesOnce₁ : VO.ImplObligation₁
+  votesOnce₁ : VO.ImplObligation₁ 𝓔
   votesOnce₁ {pid' = pid'} r stMsg@(step-msg {_ , P m} m∈pool psI) {v' = v'} {m' = m'}
              pkH v⊂m (here refl) sv ¬gen ¬msb v'⊂m' m'∈pool sv' ¬gen' eid≡ r≡
      with v⊂m
@@ -235,7 +235,7 @@ module LibraBFT.Impl.Properties.VotesOnceDirect where
      = let qc∈rm = VoteMsgQCsFromRoundManager r stMsg pkH v⊂m (here refl) qc∈m
        in ⊥-elim (¬msb (qcVotesSentB4 r psI qc∈rm vs∈qc ¬gen))
 
-  votesOnce₂ : VO.ImplObligation₂
+  votesOnce₂ : VO.ImplObligation₂ 𝓔
   votesOnce₂ {pk = pk} {st} r stMsg@(step-msg {_ , P m} m∈pool psI) pkH v⊂m m∈outs sig ¬gen vnew
              vpk v'⊂m' m'∈outs sig' ¬gen' v'new vpk' es≡ rnds≡
      with m∈outs | m'∈outs

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -217,15 +217,21 @@ module LibraBFT.Impl.Properties.VotesOnceDirect where
 
   votesOnce₁ : VO.ImplObligation₁
   votesOnce₁ {pid' = pid'} r stMsg@(step-msg {_ , P m} m∈pool psI) {v' = v'} {m' = m'}
-             pkH v⊂m (here refl) sv ¬gen ¬msb vspkv v'⊂m' m'∈pool sv' ¬gen' eid≡ r≡
+             pkH v⊂m (here refl) sv ¬gen ¬msb v'⊂m' m'∈pool sv' ¬gen' eid≡ r≡
      with v⊂m
-  ...| vote∈vm = let m'mwsb = mkMsgWithSig∈ m' v' v'⊂m' pid' m'∈pool sv' refl
+  ...| vote∈vm
+     with impl-sps-avp r pkH stMsg (here refl) v⊂m sv ¬gen
+  ...| inj₂ sentb4 = ⊥-elim (¬msb sentb4)
+  ...| inj₁ (vspkv , _) =
+                 let m'mwsb = mkMsgWithSig∈ m' v' v'⊂m' pid' m'∈pool sv' refl
                      vspkv' = peerCanSignEp≡ {v' = v'} vspkv eid≡
                      step   = step-peer (step-honest stMsg)
                      vspre' = peerCanSign-Msb4 r step vspkv' pkH sv' m'mwsb
                      rv'<rv = oldVoteRound≤lvr r pkH sv' ¬gen' m'mwsb vspre' eid≡
                  in ⊥-elim (<⇒≢ (s≤s rv'<rv) (sym r≡))
-  ...| vote∈qc vs∈qc v≈rbld (inV qc∈m) rewrite cong ₋vSignature v≈rbld
+  votesOnce₁ {pid' = pid'} r stMsg@(step-msg {_ , P m} m∈pool psI) {v' = v'} {m' = m'}
+             pkH v⊂m (here refl) sv ¬gen ¬msb v'⊂m' m'∈pool sv' ¬gen' eid≡ r≡
+     | vote∈qc vs∈qc v≈rbld (inV qc∈m) rewrite cong ₋vSignature v≈rbld
      = let qc∈rm = VoteMsgQCsFromRoundManager r stMsg pkH v⊂m (here refl) qc∈m
        in ⊥-elim (¬msb (qcVotesSentB4 r psI qc∈rm vs∈qc ¬gen))
 

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -60,8 +60,8 @@ module LibraBFT.Impl.Properties.VotesOnceDirect where
                  → PeerCanSignForPK s' v pid pk
                  → v ^∙ vEpoch ≡ v' ^∙ vEpoch
                  → PeerCanSignForPK s' v' pid pk
-  peerCanSignEp≡ (mkPCS4PK 𝓔₁ 𝓔id≡₁ 𝓔inSys₁ mbr₁ nid≡₁ pk≡₁) refl
-    = (mkPCS4PK 𝓔₁ 𝓔id≡₁ 𝓔inSys₁ mbr₁ nid≡₁ pk≡₁)
+  peerCanSignEp≡ (mkPCS4PK 𝓔₁ 𝓔inSys₁ (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁)) refl
+    = (mkPCS4PK 𝓔₁ 𝓔inSys₁ (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁))
 
   MsgWithSig⇒ValidSenderInitialised : ∀ {st v pk}
                                     → ReachableSystemState st
@@ -104,8 +104,8 @@ module LibraBFT.Impl.Properties.VotesOnceDirect where
                    → Meta-Honest-PK pk → (sig : WithVerSig pk v)
                    → MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
                    → PeerCanSignForPK pre v pid pk
-  peerCanSign-Msb4 r step (mkPCS4PK 𝓔₁ 𝓔id≡₁ (inGenInfo refl) mbr₁ nid≡₁ pk≡₁) pkH sig msv
-    = mkPCS4PK 𝓔₁ 𝓔id≡₁ (inGenInfo refl) mbr₁ nid≡₁ pk≡₁
+  peerCanSign-Msb4 r step (mkPCS4PK 𝓔₁ (inGenInfo refl) (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁)) pkH sig msv
+    = mkPCS4PK 𝓔₁ (inGenInfo refl) (mkPCS4PKin𝓔 𝓔id≡₁  mbr₁ nid≡₁ pk≡₁)
 
   peerCanSignPK-Inj :  ∀ {pid pid' pk v v'}{st : SystemState}
                     → ReachableSystemState st
@@ -115,9 +115,9 @@ module LibraBFT.Impl.Properties.VotesOnceDirect where
                     → v ^∙ vEpoch ≡ v' ^∙ vEpoch
                     → pid ≡ pid'
   peerCanSignPK-Inj {pid} {pid'} r pkH pcs' pcs eid≡
-     with availEpochsConsistent r pcs' pcs
+     with availEpochsConsistent pcs' pcs
   ...| refl
-     with NodeId-PK-OK-injective (𝓔 pcs) (PCS4PK⇒NodeId-PK-OK pcs) (PCS4PK⇒NodeId-PK-OK pcs')
+     with NodeId-PK-OK-injective (pcs4𝓔 pcs) (PCS4PK⇒NodeId-PK-OK (pcs4in𝓔 pcs)) (PCS4PK⇒NodeId-PK-OK (pcs4in𝓔 pcs'))
   ...| refl = refl
 
 

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -114,8 +114,8 @@ module LibraBFT.Impl.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                     → PeerCanSignForPK st v pid pk
                     → v ^∙ vEpoch ≡ v' ^∙ vEpoch
                     → pid ≡ pid'
-  peerCanSignPK-Inj {pid} {pid'} r pkH pcs' pcs eid≡
-     with availEpochsConsistent pcs' pcs
+  peerCanSignPK-Inj {pid} {pid'} r pkH pcs' pcs refl
+     with availEpochsConsistent pcs' pcs refl
   ...| refl
      with NodeId-PK-OK-injective (pcs4𝓔 pcs) (PCS4PK⇒NodeId-PK-OK (pcs4in𝓔 pcs)) (PCS4PK⇒NodeId-PK-OK (pcs4in𝓔 pcs'))
   ...| refl = refl

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -56,13 +56,6 @@ module LibraBFT.Impl.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                    → PeerCanSignForPK s' v pid pk
   peerCanSignSameS pcs refl = pcs
 
-  peerCanSignEp≡ : ∀ {pid v v' pk s'}
-                 → PeerCanSignForPK s' v pid pk
-                 → v ^∙ vEpoch ≡ v' ^∙ vEpoch
-                 → PeerCanSignForPK s' v' pid pk
-  peerCanSignEp≡ (mkPCS4PK 𝓔₁ 𝓔inSys₁ (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁)) refl
-    = (mkPCS4PK 𝓔₁ 𝓔inSys₁ (mkPCS4PKin𝓔 𝓔id≡₁ mbr₁ nid≡₁ pk≡₁))
-
   MsgWithSig⇒ValidSenderInitialised : ∀ {st v pk}
                                     → ReachableSystemState st
                                     → Meta-Honest-PK pk → (sig : WithVerSig pk v)

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -20,7 +20,6 @@ open import LibraBFT.Impl.Handle.Properties
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open        EpochConfig
-open import LibraBFT.Yasm.Types
 open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 open        Structural impl-sps-avp
 open import LibraBFT.Impl.Properties.VotesOnce

--- a/LibraBFT/Impl/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/Impl/Properties/VotesOnceDirect.agda
@@ -212,21 +212,18 @@ module LibraBFT.Impl.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
   votesOnce₁ {pid' = pid'} r stMsg@(step-msg {_ , P m} m∈pool psI) {v' = v'} {m' = m'}
              pkH v⊂m (here refl) sv ¬gen ¬msb v'⊂m' m'∈pool sv' ¬gen' eid≡ r≡
      with v⊂m
+  ...| vote∈qc vs∈qc v≈rbld (inV qc∈m) rewrite cong ₋vSignature v≈rbld
+     = let qc∈rm = VoteMsgQCsFromRoundManager r stMsg pkH v⊂m (here refl) qc∈m
+       in ⊥-elim (¬msb (qcVotesSentB4 r psI qc∈rm vs∈qc ¬gen))
   ...| vote∈vm
-     with impl-sps-avp r pkH stMsg (here refl) v⊂m sv ¬gen
-  ...| inj₂ sentb4 = ⊥-elim (¬msb sentb4)
-  ...| inj₁ (vspkv , _) =
+     with ⊎-elimʳ ¬msb (impl-sps-avp r pkH stMsg (here refl) v⊂m sv ¬gen)
+  ...| (vspkv , _) =
                  let m'mwsb = mkMsgWithSig∈ m' v' v'⊂m' pid' m'∈pool sv' refl
                      vspkv' = peerCanSignEp≡ {v' = v'} vspkv eid≡
                      step   = step-peer (step-honest stMsg)
                      vspre' = peerCanSign-Msb4 r step vspkv' pkH sv' m'mwsb
                      rv'<rv = oldVoteRound≤lvr r pkH sv' ¬gen' m'mwsb vspre' eid≡
                  in ⊥-elim (<⇒≢ (s≤s rv'<rv) (sym r≡))
-  votesOnce₁ {pid' = pid'} r stMsg@(step-msg {_ , P m} m∈pool psI) {v' = v'} {m' = m'}
-             pkH v⊂m (here refl) sv ¬gen ¬msb v'⊂m' m'∈pool sv' ¬gen' eid≡ r≡
-     | vote∈qc vs∈qc v≈rbld (inV qc∈m) rewrite cong ₋vSignature v≈rbld
-     = let qc∈rm = VoteMsgQCsFromRoundManager r stMsg pkH v⊂m (here refl) qc∈m
-       in ⊥-elim (¬msb (qcVotesSentB4 r psI qc∈rm vs∈qc ¬gen))
 
   votesOnce₂ : VO.ImplObligation₂ 𝓔
   votesOnce₂ {pk = pk} {st} r stMsg@(step-msg {_ , P m} m∈pool psI) pkH v⊂m m∈outs sig ¬gen vnew

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -100,6 +100,15 @@ module LibraBFT.Lemmas where
  _ : Maybe-map toℕ (List-index _≟_ 4 (nats 4)) ≡ nothing
  _ = refl
 
+ -- TODO-2: There's probably something equivalent in the standard library
+ ⊎-elimˡ : ∀ {ℓ₀ ℓ₁}{A₀ : Set ℓ₀}{A₁ : Set ℓ₁} → ¬ A₀ → A₀ ⊎ A₁ → A₁
+ ⊎-elimˡ _  (inj₂ a) = a
+ ⊎-elimˡ ¬a (inj₁ a) = ⊥-elim (¬a a)
+
+ ⊎-elimʳ : ∀ {ℓ₀ ℓ₁}{A₀ : Set ℓ₀}{A₁ : Set ℓ₁} → ¬ A₁ → A₀ ⊎ A₁ → A₀
+ ⊎-elimʳ _  (inj₁ a) = a
+ ⊎-elimʳ ¬a (inj₂ a) = ⊥-elim (¬a a)
+
  allDistinct : ∀ {A : Set} → List A → Set
  allDistinct l = ∀ (i j : Σ ℕ (_< length l)) →
                    proj₁ i ≡ proj₁ j

--- a/LibraBFT/Yasm/Yasm.agda
+++ b/LibraBFT/Yasm/Yasm.agda
@@ -20,6 +20,7 @@ module LibraBFT.Yasm.Yasm
   where
  open LYB.SystemParameters parms
  open import LibraBFT.Yasm.Base                                                                        public
+ open import LibraBFT.Yasm.Types                                                                       public
  open import LibraBFT.Yasm.System     ℓ-PeerState ℓ-VSFP parms                                          public
  open import LibraBFT.Yasm.Properties ℓ-PeerState ℓ-VSFP parms ValidSenderForPK ValidSenderForPK-stable public
  open import Util.FunctionOverride    PeerId _≟PeerId_                                                 public


### PR DESCRIPTION

- The main purpose of this pull request is to define the implementation obligations related to the `PreferredRound` rule (`LibraBFT.Concrete.Properties.PreferredRound`), so that, assuming an implementation complies with these obligations, we can prove `LibraBFT.Concrete.Obligations.PreferredRound.Type` for our intermediate system state, and we have already proved (`LibraBFT.Concrete.Obligations.PreferredRound.proof`) that this implies the corresponding assumption made by the abstract proofs.
- The new implementation obligations refer to structures such as `Cand-3-chain-vote` and `VoteParentData`, which are in terms of abstract `Record`s and therefore require an `EpochConfig`, which is introduced as a module parameter.  For consistency, the `VoteOnce` obligations now similarly receive an `EpochConfig` module parameter, although this is not strictly required.
- When defining the `PreferredRound` obligations using the the `VotesOnce` ones as a starting point, I noticed that the `PeerCanSignForPK` arguments were not actually needed (because the proof can use `impl-sps-avp` to get them based on other arguments), so I eliminated them.  Before realising this, however, I had some pain with these arguments, which was eased by refactoring `PeerCanSignFor`.  Even though I eliminated these arguments, I kept the refactoring as I think it may be helpful anyway.  I also left a trivial function `EC-member-cast` that I proved while struggling with the `PeerCanSignForPK` arguments before eliminating them, and similarly have left this even though it is not used now.
- As a sanity check, I started the proof in `LibraBFT.Impl.Properties.PreferredRound`, proving `PR.ImplObligation₂` using a proof almost identical to the corresponding one for `VotesOnce` (and left a `TODO` to refactor).  Note that our fake implementation does not comply with `PR.ImplObligation₁`, so nobody should try to prove that it does.  We will be working soon on a more realistic model that does comply.
- And a few minor things:
  - Fixed `availEpochsConsistent` to require the epoch IDs of the votes in question to be equal, otherwise the property will not hold in future when we introduce epoch changes.
  - Introduced `⊎-elimʳ` of type `¬ A₁ → A₀ ⊎ A₁ → A₀` (and its symmetric counterpart) and used it to streamline some proofs
  - Moved some properties to more appropriate places
  - Made `Yasm.Yasm` export `Yasm.Types` so it does not need to be explicitly imported everywhere.
