### PR TITLE
parts of process vote; PendingVotesSpec (not used)

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -1,0 +1,29 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote as Vote
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Util.Crypto
+open import LibraBFT.Impl.Util.Util
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.BlockStorage.BlockStore where
+
+open RWST-do
+
+postulate
+  insertTimeoutCertificateM : TimeoutCertificate → LBFT (ErrLog ⊎ Unit)
+  getQuorumCertForBlock : HashValue → BlockStore {!!} → Maybe QuorumCert -- IMPL-TODO
+  syncInfoM : LBFT SyncInfo

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -1,0 +1,25 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote as Vote
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Util.Crypto
+open import LibraBFT.Impl.Util.Util
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.BlockStorage.SyncManager where
+
+open RWST-do
+
+postulate
+  insertQuorumCertM : QuorumCert → BlockRetriever → LBFT (ErrLog ⊎ Unit)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Vote.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Vote.agda
@@ -11,6 +11,10 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.Vote where
 
+newWithSignature : VoteData → Author → LedgerInfo → Signature → Vote
+newWithSignature voteData author ledgerInfo signature =
+   Vote∙new voteData author ledgerInfo signature nothing
+
 timeout : Vote → Timeout
 timeout v =
   Timeout∙new (v ^∙ vVoteData ∙ vdProposed ∙ biEpoch) (v ^∙ vVoteData ∙ vdProposed ∙ biRound)

--- a/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
@@ -1,0 +1,30 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Util.Util
+open import LibraBFT.Impl.OBM.Prelude
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.Liveness.ProposerElection where
+
+open RWST-do
+
+postulate
+  getValidProposer : ProposerElection → Round → Author
+
+isValidProposerM : Author → Round → LBFT Bool
+isValidProposer : ProposerElection → Author → Round → Bool
+
+isValidProposalM : Block → LBFT Bool
+isValidProposalM b = maybeS (b ^∙ bAuthor) (pure false) (λ a → isValidProposerM a (b ^∙ bRound))
+
+isValidProposerM a r = (isValidProposer <$> use lProposerElection) <*> pure a <*> pure r
+
+isValidProposer pe a r = ⌊ getValidProposer pe r ≟ℕ a ⌋

--- a/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
@@ -1,0 +1,44 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore as BlockStore
+open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote     as Vote
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Consensus.Types.PendingVotes      as PendingVotes hiding (insertVoteM)
+open import LibraBFT.Impl.OBM.Prelude
+open import LibraBFT.Impl.Util.Crypto
+open import LibraBFT.Impl.Util.Util
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.Liveness.RoundState where
+
+open RWST-do
+
+------------------------------------------------------------------------------
+
+processCertificatesM : Instant → SyncInfo → LBFT (Maybe NewRoundEvent)
+processCertificatesM now syncInfo = do
+  rshcr <- use (lRoundState ∙ rsHighestCommittedRound)
+  if-dec (syncInfo ^∙ siHighestCommitRound <? rshcr) -- TODO : define and use 'when'
+    then pure unit -- IMPL-TODO ((lRoundState ∙ rsHighestCommittedRound) :=  (syncInfo ^∙ siHighestCommitRound))
+    else pure unit
+  pure nothing
+
+------------------------------------------------------------------------------
+
+insertVoteM : Vote → ValidatorVerifier → LBFT VoteReceptionResult
+insertVoteM vote verifier = do
+  currentRound ← use (lRoundState ∙ rsCurrentRound)
+  if-dec vote ^∙ vVoteData ∙ vdProposed ∙ biRound ≟ℕ currentRound
+    then PendingVotes.insertVoteM vote verifier
+    else pure (UnexpectedRound (vote ^∙ vVoteData ∙ vdProposed ∙ biRound) currentRound)

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -3,17 +3,24 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-open import Optics.All
-open import LibraBFT.Prelude
+
 open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
 open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore   as BlockStore
+open import LibraBFT.Impl.Consensus.BlockStorage.SyncManager  as SyncManager
+open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote       as Vote
+open import LibraBFT.Impl.Consensus.Liveness.ProposerElection as ProposerElection
+open import LibraBFT.Impl.Consensus.Liveness.RoundState       as RoundState hiding (processCertificatesM)
 open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.OBM.Prelude
 open import LibraBFT.Impl.Util.Crypto
 open import LibraBFT.Impl.Util.Util
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open import LibraBFT.Prelude
+open import Optics.All
 
 
 -- This is a minimal/fake example handler that obeys the VotesOnce rule, enabling us to start
@@ -24,48 +31,126 @@ open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
 module LibraBFT.Impl.Consensus.RoundManager where
 
-  open RWST-do
+open RWST-do
 
-  processCommitM : LedgerInfoWithSignatures → LBFT (List ExecutedBlock)
-  processCommitM finalityProof = pure []
+processCommitM : LedgerInfoWithSignatures → LBFT (List ExecutedBlock)
+processCommitM finalityProof = pure []
 
-  fakeAuthor : Author
-  fakeAuthor = 0
+fakeAuthor : Author
+fakeAuthor = 0
 
-  fakeBlockInfo : Epoch → Round → ProposalMsg → BlockInfo
-  fakeBlockInfo eid rnd pm = BlockInfo∙new eid rnd (pm ^∙ pmProposal ∙ bId)
+fakeBlockInfo : Epoch → Round → ProposalMsg → BlockInfo
+fakeBlockInfo eid rnd pm = BlockInfo∙new eid rnd (pm ^∙ pmProposal ∙ bId)
 
-  fakeLedgerInfo : BlockInfo → ProposalMsg → LedgerInfo
-  fakeLedgerInfo bi pm = LedgerInfo∙new bi (pm ^∙ pmProposal ∙ bId)
+fakeLedgerInfo : BlockInfo → ProposalMsg → LedgerInfo
+fakeLedgerInfo bi pm = LedgerInfo∙new bi (pm ^∙ pmProposal ∙ bId)
 
-  postulate -- TODO-1: these are temporary scaffolding for the fake implementation
-    fakeSK  : SK
-    fakeSig : Signature
+postulate -- TODO-1: these are temporary scaffolding for the fake implementation
+  fakeSK  : SK
+  fakeSig : Signature
 
-  processProposalMsg : Instant → ProposalMsg → LBFT Unit
-  processProposalMsg inst pm = do
-    st ← get
-    xx ← use rmHighestQC   -- Not used; just a demonstration that our RoundManager-specific "use" works
-    modify' rmHighestQC xx -- Similarly for modify'
-    let RoundManager∙new rm rmc rmw = st
-        𝓔  = α-EC (rm , rmc)
-        e  = rm ^∙ rmEpoch
-        nr = suc (rm ^∙ rmLastVotedRound)
-        uv = Vote∙new
-                    (VoteData∙new (fakeBlockInfo e nr pm) (fakeBlockInfo e 0 pm))
-                    fakeAuthor
-                    (fakeLedgerInfo (fakeBlockInfo e nr pm) pm)
-                    fakeSig
-                    nothing
-        sv = record uv { ₋vSignature = sign ⦃ sig-Vote ⦄ uv fakeSK}
-        bt = rmw ^∙ (lBlockTree 𝓔)
-        si = SyncInfo∙new (₋btHighestQuorumCert bt) (₋btHighestCommitCert bt)
-        rm' = rm [ rmLastVotedRound := nr ]
-        st' = RoundManager∙new rm' (RoundManagerEC-correct-≡ (₋rmEC st) rm' refl rmc)
-                                   (subst RoundManagerWithEC (α-EC-≡ rm rm' refl refl rmc) rmw)
-    put st'
-    tell1 (SendVote (VoteMsg∙new sv si) (fakeAuthor ∷ []))
-    pure unit
+processProposalMsg : Instant → ProposalMsg → LBFT Unit
+processProposalMsg inst pm = do
+  st ← get
+  xx ← use rmHighestQC   -- Not used; just a demonstration that our RoundManager-specific "use" works
+  modify' rmHighestQC xx -- Similarly for modify'
+  let RoundManager∙new rm rmc rmw = st
+      𝓔  = α-EC (rm , rmc)
+      e  = rm ^∙ rmEpoch
+      nr = suc (rm ^∙ rmLastVotedRound)
+      uv = Vote∙new
+                  (VoteData∙new (fakeBlockInfo e nr pm) (fakeBlockInfo e 0 pm))
+                  fakeAuthor
+                  (fakeLedgerInfo (fakeBlockInfo e nr pm) pm)
+                  fakeSig
+                  nothing
+      sv = record uv { ₋vSignature = sign ⦃ sig-Vote ⦄ uv fakeSK}
+      bt = rmw ^∙ (lBlockTree 𝓔)
+      si = SyncInfo∙new (₋btHighestQuorumCert bt) (₋btHighestCommitCert bt)
+      rm' = rm [ rmLastVotedRound := nr ]
+      st' = RoundManager∙new rm' (RoundManagerEC-correct-≡ (₋rmEC st) rm' refl rmc)
+                                 (subst RoundManagerWithEC (α-EC-≡ rm rm' refl refl rmc) rmw)
+  put st'
+  tell1 (SendVote (VoteMsg∙new sv si) (fakeAuthor ∷ []))
+  pure unit
 
-  processVote : Instant → VoteMsg → LBFT Unit
-  processVote now msg = pure unit
+processVote : Instant → VoteMsg → LBFT Unit
+processVote now msg = pure unit
+
+------------------------------------------------------------------------------
+
+processNewRoundEventM : Instant → NewRoundEvent → LBFT Unit
+processNewRoundEventM now nre = pure unit
+
+------------------------------------------------------------------------------
+
+processCertificatesM : Instant → LBFT Unit
+processCertificatesM now = do
+  syncInfo ← BlockStore.syncInfoM
+  maybeSMP (RoundState.processCertificatesM now syncInfo) unit (processNewRoundEventM now)
+
+------------------------------------------------------------------------------
+processVoteM     : Instant → Vote                → LBFT Unit
+addVoteM         : Instant → Vote                → LBFT Unit
+newQcAggregatedM : Instant → QuorumCert → Author → LBFT Unit
+newTcAggregatedM : Instant → TimeoutCertificate  → LBFT Unit
+
+processVoteMsgM : Instant → VoteMsg → LBFT Unit
+processVoteMsgM now voteMsg = do
+  -- TODO ensureRoundAndSyncUp
+  processVoteM now (voteMsg ^∙ vmVote)
+
+processVoteM now vote =
+  if not (Vote.isTimeout vote)
+  then (do
+    let nextRound = vote ^∙ vVoteData ∙ vdProposed ∙ biRound + 1
+    -- IMPL-TODO pgAuthor
+    -- v ← ProposerElection.isValidProposer <$> (use lProposerElection
+    --                                      <*> use (lRoundManager.pgAuthor) <*> pure nextRound)
+    let v = true
+    if v then continue else pure unit)
+  else
+    continue
+ where
+  continue : LBFT Unit
+  continue = do
+    let blockId = vote ^∙ vVoteData ∙ vdProposed ∙ biId
+    s ← get
+    let bs = ₋epBlockStore (₋rmWithEC s)
+    if true -- (is-just (BlockStore.getQuorumCertForBlock blockId {!!})) -- IMPL-TODO
+      then pure unit
+      else addVoteM now vote
+
+addVoteM now vote = do
+  s ← get
+  let bs = ₋epBlockStore (₋rmWithEC s)
+  {- IMPL-TODO make this commented code work then remove the 'continue' after the comment
+  maybeS nothing (bs ^∙ bsHighestTimeoutCert) continue λ tc →
+    if-dec vote ^∙ vRound =? tc ^∙ tcRound
+    then pure unit
+    else continue
+  -}
+  continue
+ where
+  continue : LBFT Unit
+  continue = do
+    rm ← get
+    let verifier = ₋esVerifier (₋rmEpochState (₋rmEC rm))
+    r ← RoundState.insertVoteM vote verifier
+    case r of λ where
+      (NewQuorumCertificate qc) →
+        newQcAggregatedM now qc (vote ^∙ vAuthor)
+      (NewTimeoutCertificate tc) →
+        newTcAggregatedM now tc
+      _ →
+        pure unit
+
+newQcAggregatedM now qc a =
+  SyncManager.insertQuorumCertM qc (BlockRetriever∙new now a) >>= λ where
+    (inj₁ e)    → pure unit -- TODO : Haskell logs err and returns ().  Do we need to return error?
+    (inj₂ unit) → processCertificatesM now
+
+newTcAggregatedM now tc =
+  BlockStore.insertTimeoutCertificateM tc >>= λ where
+    (inj₁ e)    → pure unit -- TODO : Haskell logs err and returns ().  Do we need to return error?
+    (inj₂ unit) → processCertificatesM now

--- a/LibraBFT/Impl/Consensus/Types.agda
+++ b/LibraBFT/Impl/Consensus/Types.agda
@@ -1,17 +1,18 @@
-{-# OPTIONS --allow-unsolved-metas #-}
-
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
 
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import Optics.All
-open import LibraBFT.Prelude
-open import LibraBFT.Base.PKCS
+{-# OPTIONS --allow-unsolved-metas #-}
+
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap as KVMap
+open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
+open import LibraBFT.Prelude
+open import Optics.All
+------------------------------------------------------------------------------
 open import Data.String using (String)
 
 -- This module defines types for an out-of-date implementation, based

--- a/LibraBFT/Impl/Consensus/Types/PendingVotesSpec.agda
+++ b/LibraBFT/Impl/Consensus/Types/PendingVotesSpec.agda
@@ -1,0 +1,82 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.KVMap                                       as Map
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Consensus.ConsensusTypes.TimeoutCertificate as TimeoutCertificate
+open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote               as Vote
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Consensus.Types.PendingVotes                as PendingVotes
+open import LibraBFT.Impl.Handle                                      as Handle
+open import LibraBFT.Impl.Types.CryptoProxies                         as CryptoProxies
+open import LibraBFT.Impl.Types.LedgerInfoWithSignatures              as LedgerInfoWithSignatures
+open import LibraBFT.Impl.Types.ValidatorSigner                       as ValidatorSigner
+open import LibraBFT.Impl.Types.ValidatorVerifier                     as ValidatorVerifier
+open import LibraBFT.Impl.Util.Crypto
+open import LibraBFT.Impl.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+------------------------------------------------------------------------------
+open import Data.Fin as Fin
+open import Data.Vec as Vec using (Vec; lookup)
+
+module LibraBFT.Impl.Consensus.Types.PendingVotesSpec where
+
+open RWST-do
+
+gs : ∀ {A : Set} {n : ℕ} → Vec A n → Fin n → A
+gs = Vec.lookup
+
+mkVote : ∀ {n : ℕ}
+       → (Fin n → (LedgerInfo × VoteData))
+       → Vec ValidatorSigner n
+       → Fin n
+       → Maybe LedgerInfo
+       → (LedgerInfo × HashValue × Vote × HashValue)
+mkVote randomLiVd signers i mli =
+  let (li , voteData) = randomLiVd i
+      hli             = hashLI li
+      voteRoundAuthor = voteNew voteData (gs signers i ^∙ vsAuthor) li (gs signers i)
+      hvli            = hashLI (voteRoundAuthor ^∙ vLedgerInfo)
+   in (li , hli , voteRoundAuthor , hvli)
+ where
+  voteNew : VoteData → Author → LedgerInfo → ValidatorSigner → Vote
+  voteNew voteData author ledgerInfoPlaceholder validatorSigner =
+    let li        = record ledgerInfoPlaceholder { ₋liConsensusDataHash = hashVD voteData }
+        signature = ValidatorSigner.sign validatorSigner li
+     in Vote.newWithSignature voteData author li signature
+
+iv : Vote → LBFT VoteReceptionResult
+iv v = do
+  s ← get
+  let vv = rmGetEpochState s ^∙ esVerifier
+  PendingVotes.insertVoteM v vv
+
+{-
+TODO : prove
+Given a RoundManager that has
+- an EpochState with a ValidatorVerifier with
+  - 4 validators
+  - ₋vvQuorumVotingPower of 3
+- a RoundState that has a PendingVotes with
+  - empty maps
+  - nothing TC
+Execution
+- creates a non-timeout Vote and inserts it
+Expect
+- state
+  - PendingVotes pvAuthorToVote to have that author/vote
+  - PendingVOtes pvLiDigestToVotes to have digest to LIWS with author's signature
+- the output to be 'QCVoteAdded 1'
+-}
+test-LBFT-PendingVotes-QC-aggregation-expect-QCVoteAdded-1
+  : ∀ {n : ℕ}
+  → Fin n -- TODO : want to create inside the function, not pass in
+  → Vec ValidatorSigner n
+  → (Fin n → (LedgerInfo × VoteData))
+  → LBFT VoteReceptionResult
+test-LBFT-PendingVotes-QC-aggregation-expect-QCVoteAdded-1 n signers randomLiVd = do
+  let (li0 , _hli0 , voteRound1Author0 , _hvli0) = mkVote randomLiVd signers n nothing
+  iv voteRound1Author0

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -77,14 +77,18 @@ module LibraBFT.Impl.Handle where
                 (over (srPersistentStorage ∙ pssSafetyData ∙ sdLastVotedRound) (const 0)
                       (₋rmSafetyRules (₋rmEC fakeRM)))
 
+ -- TODO-1: Implement this.
+ initPE : ProposerElection
+ initPE = obm-dangerous-magic!
+
  initPV : PendingVotes
  initPV = PendingVotes∙new KVMap.empty nothing KVMap.empty
 
  initRS : RoundState
- initRS = RoundState∙new 0 initPV nothing
+ initRS = RoundState∙new 0 0 initPV nothing
 
  initRMEC : RoundManagerEC
- initRMEC = RoundManagerEC∙new (EpochState∙new 1 (initVV genInfo)) initRS initSR
+ initRMEC = RoundManagerEC∙new (EpochState∙new 1 (initVV genInfo)) initRS initPE initSR false
 
  postulate -- TODO-2 : prove these once initRMEC is defined directly
    init-EC-epoch-1  : epoch (init-EC genInfo) ≡ 1
@@ -118,7 +122,7 @@ module LibraBFT.Impl.Handle where
  outputToActions : RoundManager → Output → List (LYT.Action NetworkMsg)
  outputToActions rm (BroadcastProposal p) = List-map (const (LYT.send (P p)))
                                                      (List-map proj₁
-                                                               (kvm-toList (-vvAddressToValidatorInfo (₋esVerifier (₋rmEpochState (₋rmEC rm))))))
+                                                               (kvm-toList (₋vvAddressToValidatorInfo (₋esVerifier (₋rmEpochState (₋rmEC rm))))))
  outputToActions _  (LogErr x)            = []
  outputToActions _  (SendVote v toList)   = List-map (const (LYT.send (V v))) toList
 

--- a/LibraBFT/Impl/OBM/Prelude.agda
+++ b/LibraBFT/Impl/OBM/Prelude.agda
@@ -1,0 +1,42 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Base.Types
+open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore as BlockStore
+open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote as Vote
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Util.Crypto
+open import LibraBFT.Impl.Util.Util
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.OBM.Prelude where
+
+open RWST-do
+
+maybeS   : ∀ {a b : Set} →       Maybe a  →      b → (a →      b) →      b
+maybeSM  : ∀ {a b : Set} → LBFT (Maybe a) → LBFT b → (a → LBFT b) → LBFT b
+maybeSMP : ∀ {a b : Set} → LBFT (Maybe a) →      b → (a → LBFT b) → LBFT b
+
+-- maybeS(wap)
+maybeS    ma  b f = maybe′ (const b) b ma
+-- maybeS(wap)M(onad)
+maybeSM  mma mb f = do
+  ma ← mma
+  case ma of λ where
+    nothing →  mb
+    (just j) → f j
+-- maybeS(wap)M(onad)P(ure) -- just wraps default in 'pure'
+maybeSMP mma  b f = do
+  ma ← mma
+  case ma of λ where
+    nothing  → pure b
+    (just j) → f j

--- a/LibraBFT/Impl/Types/ValidatorSigner.agda
+++ b/LibraBFT/Impl/Types/ValidatorSigner.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.KVMap as Map
+open import LibraBFT.Impl.Consensus.Types
+open import LibraBFT.Impl.Types.LedgerInfoWithSignatures as LedgerInfoWithSignatures
+open import LibraBFT.Prelude
+open import LibraBFT.Base.PKCS as PKCS hiding (sign)
+open import Optics.All
+
+module LibraBFT.Impl.Types.ValidatorSigner where
+
+sign : ∀ {A : Set} → ValidatorSigner → A → Signature
+sign = {!!}

--- a/LibraBFT/Impl/Util/RWST.agda
+++ b/LibraBFT/Impl/Util/RWST.agda
@@ -118,6 +118,13 @@ module LibraBFT.Impl.Util.RWST (ℓ-State : Level) where
     _<$>_ : (A → B) → RWST Ev Wr St A → RWST Ev Wr St B
     _<$>_ = RWST-map
 
+    infixl 4 _<*>_
+    _<*>_ : RWST Ev Wr St (A → B) → RWST Ev Wr St A → RWST Ev Wr St B
+    fs <*> xs = do
+      f ← fs
+      x ← xs
+      pure (f x)
+
   private
     ex₀ : RWST ℕ Wr (Lift ℓ-State ℕ) ℕ
     ex₀ = do


### PR DESCRIPTION
Signed-off-by: Harold Carr harold.carr@oracle.com

This contains an incomplete implementation of `RoundManager.processVoteMsgM`.
If it is needed before I am available again, go ahead and complete it.  Otherwise, it is fine to leave it as is.

There are places in this request that have `IMPL-TODO` - it would be good to have feedback/fixes for those places.