### PR TITLE
Refactor so we can use different implementation handlers (e.g. fake and real) with the same underlying types

### DIFF
--- a/LibraBFT/Concrete/Intermediate.agda
+++ b/LibraBFT/Concrete/Intermediate.agda
@@ -7,16 +7,7 @@
 -- of a system state.  The goal is to enable proving for a particular implementation
 -- the properties required to provide to Abstract.Properties in order to get the high
 -- level correctness conditions, while moving the obligations for the implementation
--- closer to notions more directly provable for an implementation.  However, as our
--- experience has developed with this, it seems that this was not a very effective
--- choice, as it leaves too much burden on the implementation (e.g., proving
--- ∈QC⇒HasBeenSent). Therefore, ...
---
--- TODO-3: Revisit assumptions of the IntermediateSystemState to enable more proof work
--- to be done under Concrete, which can be used by multiple implementations.  As it
--- currently stands, we have specific notions under LibraBFT.Impl that possibly should
--- be provided as module parameters to LibraBFT.Concrete (including IsValidVote and
--- α-ValidVote)
+-- closer to notions more directly provable for an implementation.
 
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.Prelude

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -4,20 +4,27 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-import      LibraBFT.Concrete.Properties.VotesOnce      as VO
-import      LibraBFT.Concrete.Properties.PreferredRound as PR
+open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Concrete.System
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
-
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Yasm.Base
 
 -- This module collects in one place the obligations an
 -- implementation must meet in order to enjoy the properties
 -- proved in Abstract.Properties.
 
-module LibraBFT.Concrete.Obligations (𝓔 : EpochConfig) where
+module LibraBFT.Concrete.Obligations (iiah : SystemInitAndHandlers ℓ-RoundManager ConcSysParms) (𝓔 : EpochConfig) where
+  import      LibraBFT.Concrete.Properties.PreferredRound iiah as PR
+  import      LibraBFT.Concrete.Properties.VotesOnce      iiah as VO
+
+  open        SystemTypeParameters ConcSysParms
+  open        SystemInitAndHandlers iiah
+  open        ParamsWithInitAndHandlers iiah
+  open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms iiah
+                                 PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+
   record ImplObligations : Set (ℓ+1 ℓ-RoundManager) where
     field
       -- Structural obligations:
@@ -26,6 +33,11 @@ module LibraBFT.Concrete.Obligations (𝓔 : EpochConfig) where
       -- Semantic obligations:
       --
       -- VotesOnce:
+
+      gvc  : VO.ImplObl-genVotesConsistent 𝓔
+      gvr  : VO.ImplObl-genVotesRound≡0 𝓔
+      v≢0  : VO.ImplObl-NewVoteSignedAndRound≢0 𝓔
+      ∈GI? : (sig : Signature) → Dec (∈GenInfo genInfo sig)
       vo₁ : VO.ImplObligation₁ 𝓔
       vo₂ : VO.ImplObligation₂ 𝓔
 

--- a/LibraBFT/Concrete/Properties/PreferredRound.agda
+++ b/LibraBFT/Concrete/Properties/PreferredRound.agda
@@ -9,16 +9,15 @@ open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Hash
-open import LibraBFT.ImplFake.Handle
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
+open import LibraBFT.Yasm.Base
 open import Optics.All
 
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 -- This module contains placeholders for the future analog of the
 -- corresponding VotesOnce property.  Defining the implementation
@@ -26,12 +25,18 @@ open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSig
 -- is a substantial undertaking.  We are working first on proving the
 -- simpler VotesOnce property to settle down the structural aspects
 -- before tackling the harder semantic issues.
-module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
+module LibraBFT.Concrete.Properties.PreferredRound (iiah : SystemInitAndHandlers ℓ-RoundManager ConcSysParms) (𝓔 : EpochConfig) where
  import      LibraBFT.Abstract.Records UID _≟UID_ NodeId  𝓔 (ConcreteVoteEvidence 𝓔) as Abs
  open import LibraBFT.Concrete.Obligations.PreferredRound 𝓔 (ConcreteVoteEvidence 𝓔)
- open WithAbsVote 𝓔
+
+ open        SystemTypeParameters ConcSysParms
+ open        SystemInitAndHandlers iiah
+ open        ParamsWithInitAndHandlers iiah
+ open import LibraBFT.ImplShared.Util.HashCollisions iiah
+ open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms iiah PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
  open PeerCanSignForPK
  open PeerCanSignForPKinEpoch
+ open WithAbsVote 𝓔
 
  -- As with VotesOnce, we will have two implementation obligations, one for when v is sent by the
  -- step and v' has been sent before, and one for when both are sent by the step.
@@ -49,12 +54,12 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
    → Meta-Honest-PK pk
    -- For signed every vote v of every outputted message
    → v  ⊂Msg m  → send m ∈ outs
-   → (sig : WithVerSig pk v) → ¬ (∈GenInfo (ver-signature sig))
+   → (sig : WithVerSig pk v) → ¬ (∈GenInfo genInfo (ver-signature sig))
    -- If v is really new and valid
    → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre))
    -- And if there exists another v' that has been sent before
    → v' ⊂Msg m' → (pid' , m') ∈ (msgPool pre)
-   → (sig' : WithVerSig pk v') → ¬ (∈GenInfo (ver-signature sig'))
+   → (sig' : WithVerSig pk v') → ¬ (∈GenInfo genInfo (ver-signature sig'))
    -- If v and v' share the same epoch
    → v ^∙ vEpoch ≡ v' ^∙ vEpoch
    -- and v is for a smaller round
@@ -64,7 +69,7 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
    -- and vabs* are the abstract Votes for v and v'
    → α-ValidVote 𝓔 v  mbr ≡ vabs
    → α-ValidVote 𝓔 v' mbr ≡ v'abs
-   → let intSys = PerState.PerEpoch.intSystemState pre r 𝓔 in
+   → let intSys = PerState.PerEpoch.intSystemState pre 𝓔 in
    -- and vabs could contribute to a 3-chain
      (c2 : Cand-3-chain-vote intSys vabs)
    -- then the round of the block that v' votes for is at least the round of
@@ -83,14 +88,14 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
      ∀{mbr v vabs m v' v'abs m'}
    → Meta-Honest-PK pk
    -- For every vote v represented in a message output by the call
-   → v  ⊂Msg m  → send m ∈ outs
-   → (sig : WithVerSig pk v) → ¬ (∈GenInfo (ver-signature sig))
+   → v ⊂Msg m  → send m ∈ outs
+   → (sig : WithVerSig pk v) → ¬ (∈GenInfo genInfo (ver-signature sig))
    -- If v is really new and valid
    → ¬ (MsgWithSig∈ pk (ver-signature sig) (msgPool pre))
 
    -- And if there exists another v' that is also new and valid
    → v' ⊂Msg m'  → send m' ∈ outs
-   → (sig' : WithVerSig pk v') → ¬ (∈GenInfo (ver-signature sig'))
+   → (sig' : WithVerSig pk v') → ¬ (∈GenInfo genInfo (ver-signature sig'))
    → ¬ (MsgWithSig∈ pk (ver-signature sig') (msgPool pre))
    -- If v and v' share the same epoch
    → v ^∙ vEpoch ≡ v' ^∙ vEpoch
@@ -99,7 +104,7 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
    → toNodeId 𝓔 mbr ≡ pid
    → α-ValidVote 𝓔 v  mbr ≡ vabs
    → α-ValidVote 𝓔 v' mbr ≡ v'abs
-   → let intSys = PerState.PerEpoch.intSystemState pre r 𝓔 in
+   → let intSys = PerState.PerEpoch.intSystemState pre 𝓔 in
      (c2 : Cand-3-chain-vote intSys vabs)
    → Σ (VoteParentData intSys v'abs)
            (λ vp → Cand-3-chain-head-round intSys c2
@@ -118,7 +123,8 @@ module LibraBFT.Concrete.Properties.PreferredRound (𝓔 : EpochConfig) where
    -- Bring in 'unwind', 'ext-unforgeability' and friends
    open Structural sps-corr
    -- Bring in intSystemState
-   open        PerState st r
+   open        PerState st
+   open        PerReachableState r
    open        PerEpoch 𝓔
    open import LibraBFT.Concrete.Obligations.PreferredRound 𝓔 (ConcreteVoteEvidence 𝓔) as PR
 

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -3,7 +3,7 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-{-# OPTIONS --allow-unsolved-metas #-}
+
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -9,7 +9,6 @@ open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
-open import LibraBFT.ImplFake.Handle
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
@@ -19,55 +18,18 @@ open import Optics.All
 
 open        EpochConfig
 
--- This module defines an abstract system state (represented by a value
--- of type 'IntermediateSystemState') for a given concrete reachable
--- state.  The culminaton of this proof is seen in the 'intSystemState'
--- "function" at the bottom, which is probably the best place to start
--- understanding this.  Longer term, we will also need higher-level,
--- cross-epoch properties.
+-- This module defines an abstract system state (represented by a value of type
+-- 'IntermediateSystemState') for a given concrete state.  The culminaton of this
+-- module is the 'intSystemState' "function" at the bottom, which is probably the
+-- best place to start understanding this.  Longer term, we will also need
+-- higher-level, cross-epoch properties.
 
 module LibraBFT.Concrete.System where
 
  open import LibraBFT.Yasm.Base
- import      LibraBFT.Yasm.System ℓ-RoundManager ℓ-VSFP ConcSysParms as LYS
+ open import LibraBFT.Yasm.System ℓ-RoundManager ℓ-VSFP ConcSysParms
 
-
- open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK
-                                                                  (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
-
- module PerState (st : SystemState)(r : ReachableSystemState st) where
-
-    -- TODO-3: Remove this postulate when we are satisfied with the
-    -- "hash-collision-tracking" solution. For example, when proving voo
-    -- (in LibraBFT.LibraBFT.Concrete.Properties.VotesOnce), we
-    -- currently use this postulate to eliminate the possibility of two
-    -- votes that have the same signature but different VoteData
-    -- whenever we use sameSig⇒sameVoteData.  To eliminate the
-    -- postulate, we need to refine the properties we prove to enable
-    -- the possibility of a hash collision, in which case the required
-    -- property might not hold.  However, it is not sufficient to simply
-    -- prove that a hash collision *exists* (which is obvious,
-    -- regardless of the LibraBFT implementation).  Rather, we
-    -- ultimately need to produce a specific hash collision and relate
-    -- it to the data in the system, so that we can prove that the
-    -- desired properties hold *unless* an actual hash collision is
-    -- found by the implementation given the data in the system.  In
-    -- the meantime, we simply require that the collision identifies a
-    -- reachable state; later "collision tracking" will require proof
-    -- that the colliding values actually exist in that state.
-    postulate  -- temporary assumption that hash collisions don't exist (see comment above)
-      meta-sha256-cr : ¬ (NonInjective-≡ sha256)
-
-    sameSig⇒sameVoteDataNoCol : ∀ {v1 v2 : Vote} {pk}
-                              → WithVerSig pk v1
-                              → WithVerSig pk v2
-                              → v1 ^∙ vSignature ≡ v2 ^∙ vSignature
-                              → v2 ^∙ vVoteData ≡ v1 ^∙ vVoteData
-    sameSig⇒sameVoteDataNoCol {v1} {v2} wvs1 wvs2 refl
-       with sameSig⇒sameVoteData {v1} {v2} wvs1 wvs2 refl
-    ...| inj₁ hb = ⊥-elim (meta-sha256-cr hb)
-    ...| inj₂ x = x
-
+ module PerState (st : SystemState) where
     module PerEpoch (𝓔 : EpochConfig) where
 
      open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs hiding (qcVotes; Vote)
@@ -98,13 +60,6 @@ module LibraBFT.Concrete.System where
          vmSender     : NodeId
          nmSentByAuth : (vmSender , (nm vmFor)) ∈ sm
      open ∃VoteMsgSentFor public
-
-     ∃VoteMsgSentFor-stable : ∀ {pre : SystemState} {post : SystemState} {v}
-                            → Step pre post
-                            → ∃VoteMsgSentFor (msgPool pre) v
-                            → ∃VoteMsgSentFor (msgPool post) v
-     ∃VoteMsgSentFor-stable theStep (mk∃VoteMsgSentFor sndr vmFor sba) =
-                                     mk∃VoteMsgSentFor sndr vmFor (msgs-stable theStep sba)
 
      ∈QC⇒sent : ∀{st : SystemState} {q α}
               → Abs.Q q α-Sent (msgPool st)

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -6,7 +6,6 @@
 
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
-open import LibraBFT.ImplFake.Handle
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.Prelude
@@ -22,8 +21,8 @@ open import LibraBFT.Yasm.Base ℓ-RoundManager
 -- implementation.
 
 module LibraBFT.Concrete.System.Parameters where
- ConcSysParms : SystemParameters
- ConcSysParms = mkSysParms
+ ConcSysParms : SystemTypeParameters
+ ConcSysParms = mkSysTypeParms
                  NodeId
                  _≟NodeId_
                  GenesisInfo
@@ -32,16 +31,10 @@ module LibraBFT.Concrete.System.Parameters where
                  Vote
                  sig-Vote
                  _⊂Msg_
-                 genInfo
-                 ∈GenInfo
-                 initRM
-                 initWrapper
-                 peerStep
 
  open import LibraBFT.Yasm.System ℓ-RoundManager ℓ-VSFP ConcSysParms
 
- module _ (iiah : SystemInitAndHandlers ConcSysParms) where
-
+ module ParamsWithInitAndHandlers (iiah : SystemInitAndHandlers ConcSysParms) where
    open WithInitAndHandlers iiah
 
    -- What EpochConfigs are known in the system?  For now, only the

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -26,6 +26,7 @@ module LibraBFT.Concrete.System.Parameters where
                  NodeId
                  _≟NodeId_
                  GenesisInfo
+                 ∈GenInfo-impl
                  RoundManager
                  NetworkMsg
                  Vote
@@ -35,6 +36,7 @@ module LibraBFT.Concrete.System.Parameters where
  open import LibraBFT.Yasm.System ℓ-RoundManager ℓ-VSFP ConcSysParms
 
  module ParamsWithInitAndHandlers (iiah : SystemInitAndHandlers ConcSysParms) where
+   open SystemInitAndHandlers iiah
    open WithInitAndHandlers iiah
 
    -- What EpochConfigs are known in the system?  For now, only the

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -27,14 +27,14 @@ module LibraBFT.Concrete.System.Parameters where
                  NodeId
                  _≟NodeId_
                  GenesisInfo
-                 genInfo
                  RoundManager
-                 initRM
                  NetworkMsg
                  Vote
                  sig-Vote
                  _⊂Msg_
+                 genInfo
                  ∈GenInfo
+                 initRM
                  initWrapper
                  peerStep
 

--- a/LibraBFT/ImplFake/Handle.agda
+++ b/LibraBFT/ImplFake/Handle.agda
@@ -26,44 +26,6 @@ module LibraBFT.ImplFake.Handle where
 
  open EpochConfig
 
- record GenesisInfo : Set where
-   constructor mkGenInfo
-   field
-     -- TODO-1 : Nodes, PKs for initial epoch
-     -- TODO-1 : Faults to tolerate (or quorum size?)
-     genQC      : QuorumCert            -- We use the same genesis QC for both highestQC and
-                                        -- highestCommitCert.
- open GenesisInfo
-
- postulate -- valid assumption
-   -- We postulate the existence of GenesisInfo known to all
-   -- TODO: construct one or write a function that generates one from some parameters.
-   genInfo : GenesisInfo
-
- postulate -- TODO-2: define GenesisInfo to match implementation and write these functions
-   initVV  : GenesisInfo → ValidatorVerifier
-   init-EC : GenesisInfo → EpochConfig
-
- data ∈GenInfo : Signature → Set where
-  inGenQC : ∀ {vs} → vs ∈ qcVotes (genQC genInfo) → ∈GenInfo (proj₂ vs)
-
- open import LibraBFT.Abstract.Records UID _≟UID_ NodeId
-                                       (init-EC genInfo)
-                                       (ConcreteVoteEvidence (init-EC genInfo))
-                                       as Abs using ()
-
- postulate -- TODO-1 : prove
-   ∈GenInfo? : (sig : Signature) → Dec (∈GenInfo sig)
-
- postulate -- TODO-1: prove after defining genInfo
-   genVotesRound≡0     : ∀ {pk v}
-                      → (wvs : WithVerSig pk v)
-                      → ∈GenInfo (ver-signature wvs)
-                      → v ^∙ vRound ≡ 0
-   genVotesConsistent : (v1 v2 : Vote)
-                      → ∈GenInfo (_vSignature v1) → ∈GenInfo (_vSignature v2)
-                      → v1 ^∙ vProposedId ≡ v2 ^∙ vProposedId
-
  postulate -- TODO-1: reasonable assumption that some RoundManager exists, though we could prove
            -- it by construction; eventually we will construct an entire RoundManager, so
            -- this won't be needed
@@ -88,10 +50,10 @@ module LibraBFT.ImplFake.Handle where
  initRS = RoundState∙new 0 0 initPV nothing
 
  initRMEC : RoundManagerEC
- initRMEC = RoundManagerEC∙new (EpochState∙new 1 (initVV genInfo)) initRS initPE initSR false
+ initRMEC = RoundManagerEC∙new (EpochState∙new 1 (initVV genesisInfo)) initRS initPE initSR false
 
  postulate -- TODO-2 : prove these once initRMEC is defined directly
-   init-EC-epoch-1  : epoch (init-EC genInfo) ≡ 1
+   init-EC-epoch-1  : epoch (init-EC genesisInfo) ≡ 1
    initRMEC-correct : RoundManagerEC-correct initRMEC
 
  initRM : RoundManager
@@ -139,3 +101,4 @@ module LibraBFT.ImplFake.Handle where
  -- Here, we just pass 0 to `handle`.
  peerStep : NodeId → NetworkMsg → RoundManager → RoundManager × List (LYT.Action NetworkMsg)
  peerStep nid msg st = runHandler st (handle nid msg 0)
+

--- a/LibraBFT/ImplFake/Handle.agda
+++ b/LibraBFT/ImplFake/Handle.agda
@@ -7,6 +7,8 @@ open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap as KVMap
 open import LibraBFT.Base.PKCS
+open import LibraBFT.Concrete.System
+open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Hash
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
@@ -14,6 +16,7 @@ open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
+open import LibraBFT.Yasm.Base
 import      LibraBFT.Yasm.Types as LYT
 open import Optics.All
 
@@ -101,4 +104,11 @@ module LibraBFT.ImplFake.Handle where
  -- Here, we just pass 0 to `handle`.
  peerStep : NodeId → NetworkMsg → RoundManager → RoundManager × List (LYT.Action NetworkMsg)
  peerStep nid msg st = runHandler st (handle nid msg 0)
+
+ FakeInitAndHandlers : SystemInitAndHandlers ℓ-RoundManager ConcSysParms
+ FakeInitAndHandlers = mkSysInitAndHandlers
+                         genesisInfo
+                         initRM
+                         initWrapper
+                         peerStep
 

--- a/LibraBFT/ImplFake/Handle/Properties.agda
+++ b/LibraBFT/ImplFake/Handle/Properties.agda
@@ -23,14 +23,16 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
 open import Optics.All
+
+open import LibraBFT.ImplFake.Consensus.RoundManager
+open import LibraBFT.ImplFake.Handle
+open        ParamsWithInitAndHandlers FakeInitAndHandlers
 open        PeerCanSignForPK
 
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms FakeInitAndHandlers PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 module LibraBFT.ImplFake.Handle.Properties where
-  open import LibraBFT.ImplFake.Consensus.RoundManager
-  open import LibraBFT.ImplFake.Handle
 
   -- This proof is complete except for pieces that are directly about the handlers.  Our
   -- fake/simple handler does not yet obey the needed properties, so we can't finish this yet.

--- a/LibraBFT/ImplFake/Handle/Properties.agda
+++ b/LibraBFT/ImplFake/Handle/Properties.agda
@@ -211,9 +211,13 @@ module LibraBFT.ImplFake.Handle.Properties where
   ...| C c = const (≤-reflexive refl)
 
   postulate -- TODO-1: prove it
-    ¬genVotesRound≢0  : ∀ {pk sig}{st : SystemState}
-                      → ReachableSystemState st
-                      → Meta-Honest-PK pk
-                      → (mws : MsgWithSig∈ pk sig (msgPool st))
-                      → ¬ (∈GenInfo sig)
-                      → (msgPart mws) ^∙ vRound ≢ 0
+    ¬genVotesRound≢0  : ∀{pid s' outs pk}{pre : SystemState}
+                      → ReachableSystemState pre
+                      -- For any honest call to /handle/ or /init/,
+                      → (sps : StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (s' , outs))
+                      → ∀{v m} → Meta-Honest-PK pk
+                      -- For signed every vote v of every outputted message
+                      → v ⊂Msg m → send m ∈ outs
+                      → (wvs : WithVerSig pk v)
+                      → (¬ ∈GenInfo-impl genesisInfo (ver-signature wvs))
+                      → v ^∙ vRound ≢ 0

--- a/LibraBFT/ImplFake/Handle/Properties.agda
+++ b/LibraBFT/ImplFake/Handle/Properties.agda
@@ -103,7 +103,7 @@ module LibraBFT.ImplFake.Handle.Properties where
                  → initialised st pid ≡ initd
                  → qc ∈RoundManager (peerStates st pid)
                  → vs ∈ qcVotes qc
-                 → ¬ (∈GenInfo (proj₂ vs))
+                 → ¬ (∈GenInfo-impl genesisInfo (proj₂ vs))
                  → MsgWithSig∈ pk (proj₂ vs) (msgPool st)
 
   -- We can prove this easily because we don't yet do epoch changes,
@@ -169,7 +169,7 @@ module LibraBFT.ImplFake.Handle.Properties where
   newVoteSameEpochGreaterRound : ∀ {pre : SystemState}{pid s' outs v m pk}
                                → ReachableSystemState pre
                                → StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (s' , outs)
-                               → ¬ (∈GenInfo (_vSignature v))
+                               → ¬ (∈GenInfo-impl genesisInfo (_vSignature v))
                                → Meta-Honest-PK pk
                                → v ⊂Msg m → send m ∈ outs → (sig : WithVerSig pk v)
                                → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool pre)

--- a/LibraBFT/ImplFake/Properties.agda
+++ b/LibraBFT/ImplFake/Properties.agda
@@ -12,6 +12,7 @@ open import LibraBFT.ImplFake.Handle.Properties
 import      LibraBFT.ImplFake.Properties.VotesOnce      as VO
 import      LibraBFT.ImplFake.Properties.PreferredRound as PR
 open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types hiding (EpochConfig)
 open import LibraBFT.Prelude
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
@@ -21,6 +22,10 @@ open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 module LibraBFT.ImplFake.Properties (𝓔 : EpochConfig) where
   theImplObligations : ImplObligations FakeInitAndHandlers 𝓔
   theImplObligations = record { sps-cor = impl-sps-avp
+                              ; gvc     = genVotesConsistent
+                              ; gvr     = genVotesRound≡0
+                              ; v≢0     = ¬genVotesRound≢0
+                              ; ∈GI?    = ∈GenInfo?-impl genesisInfo
                               ; vo₁     = VO.vo₁ 𝓔
                               ; vo₂     = VO.vo₂ 𝓔
                               ; pr₁     = PR.pr₁ 𝓔

--- a/LibraBFT/ImplFake/Properties.agda
+++ b/LibraBFT/ImplFake/Properties.agda
@@ -7,6 +7,7 @@
 open import LibraBFT.Concrete.Obligations
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
+open import LibraBFT.ImplFake.Handle
 open import LibraBFT.ImplFake.Handle.Properties
 import      LibraBFT.ImplFake.Properties.VotesOnce      as VO
 import      LibraBFT.ImplFake.Properties.PreferredRound as PR
@@ -18,7 +19,7 @@ open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 -- "implementation" into the structure required by Concrete.Properties.
 
 module LibraBFT.ImplFake.Properties (𝓔 : EpochConfig) where
-  theImplObligations : ImplObligations 𝓔
+  theImplObligations : ImplObligations FakeInitAndHandlers 𝓔
   theImplObligations = record { sps-cor = impl-sps-avp
                               ; vo₁     = VO.vo₁ 𝓔
                               ; vo₂     = VO.vo₂ 𝓔

--- a/LibraBFT/ImplFake/Properties/PreferredRound.agda
+++ b/LibraBFT/ImplFake/Properties/PreferredRound.agda
@@ -3,7 +3,6 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-import      LibraBFT.Concrete.Properties.PreferredRound as PR
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.ImplFake.Handle
@@ -12,7 +11,10 @@ open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+import      LibraBFT.Concrete.Properties.PreferredRound FakeInitAndHandlers as PR
+open        ParamsWithInitAndHandlers FakeInitAndHandlers
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms FakeInitAndHandlers
+                               PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 open        Structural impl-sps-avp
 
 open import LibraBFT.Concrete.Obligations

--- a/LibraBFT/ImplFake/Properties/VotesOnce.agda
+++ b/LibraBFT/ImplFake/Properties/VotesOnce.agda
@@ -8,7 +8,6 @@
 
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
-import      LibraBFT.Concrete.Properties.VotesOnce as VO
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.ImplFake.Consensus.RoundManager.Properties
@@ -20,12 +19,14 @@ open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
+open import LibraBFT.Yasm.Base
 open import Optics.All
 
-open        EpochConfig
-open import LibraBFT.Yasm.Types
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
-open        Structural impl-sps-avp
+open        ParamsWithInitAndHandlers FakeInitAndHandlers
+import      LibraBFT.Concrete.Properties.VotesOnce FakeInitAndHandlers as VO
+open import LibraBFT.ImplShared.Util.HashCollisions FakeInitAndHandlers
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms FakeInitAndHandlers
+                               PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
 -- In this module, we prove the two implementation obligations for the VotesOnce rule.  Note
 -- that it is not yet 100% clear that the obligations are the best definitions to use.  See comments
@@ -34,6 +35,7 @@ open        Structural impl-sps-avp
 -- ambitious properties.
 
 module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
+  open        Structural impl-sps-avp
 
   -- This is the information we can establish about the state after the first time a signature is
   -- sent, and that we can carry forward to subsequent states, so we can use it to prove
@@ -155,7 +157,7 @@ module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
      -- The fake/trivial handler always sends a vote for its current epoch, but for a
      -- round greater than its last voted round
      with sameSig⇒sameVoteData (msgSigned mws) sig' (msgSameSig mws)
-  ...| inj₁ hb = ⊥-elim (PerState.meta-sha256-cr pre r hb)
+  ...| inj₁ hb = ⊥-elim (PerReachableState.meta-sha256-cr r hb)
   ...| inj₂ refl
      with msgSender mws ≟NodeId pid
   ...| no neq =

--- a/LibraBFT/ImplFake/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/ImplFake/Properties/VotesOnceDirect.agda
@@ -36,7 +36,7 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                        → StepPeerState pid (msgPool st) (initialised st)
                                        (peerStates st pid) (s' , outs)
                        → v ⊂Msg m → send m ∈ outs → (sig : WithVerSig pk v)
-                       → Meta-Honest-PK pk → ¬ (∈GenInfo (ver-signature sig))
+                       → Meta-Honest-PK pk → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
                        → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool st)
                        → v ^∙ vEpoch ≡ (_rmEC s') ^∙ rmEpoch
                        → v ^∙ vRound ≡ (_rmEC s') ^∙ rmLastVotedRound
@@ -59,7 +59,7 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
   MsgWithSig⇒ValidSenderInitialised : ∀ {st v pk}
                                     → ReachableSystemState st
                                     → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-                                    → ¬ (∈GenInfo (ver-signature sig))
+                                    → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
                                     → MsgWithSig∈ pk (ver-signature sig) (msgPool st)
                                     → ∃[ pid ] ( initialised st pid ≡ initd
                                                × PeerCanSignForPK st v pid pk )
@@ -118,7 +118,7 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                  → ReachableSystemState st
                  → PeerCanSignForPK st v pid pk
                  → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-                 → ¬ (∈GenInfo (ver-signature sig))
+                 → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
                  → MsgWithSig∈ pk (ver-signature sig) (msgPool st)
                  → initialised st pid ≡ initd
   msg∈pool⇒initd {pid'} {st = st} step@(step-s r (step-peer {pid} (step-honest stPeer))) pcs pkH sig ¬gen msv
@@ -157,7 +157,7 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                                        (peerStates st pid) (s' , outs))
                 → PeerCanSignForPK st v pid pk
                 → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-                → ¬ ∈GenInfo (ver-signature sig)
+                → ¬ ∈GenInfo-impl genesisInfo (ver-signature sig)
                 → MsgWithSig∈ pk (ver-signature sig) (msgPool st)
                 → (_rmEC s') ^∙ rmEpoch ≡ (v ^∙ vEpoch)
                 → (_rmEC (peerStates st pid)) ^∙ rmEpoch ≡ (v ^∙ vEpoch)
@@ -169,7 +169,7 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
   oldVoteRound≤lvr : ∀ {pid pk v}{pre : SystemState}
                    → (r : ReachableSystemState pre)
                    → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-                   → ¬ (∈GenInfo (ver-signature sig))
+                   → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
                    → MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
                    → PeerCanSignForPK pre v pid pk
                    → (_rmEC (peerStates pre pid)) ^∙ rmEpoch ≡ (v ^∙ vEpoch)

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -36,6 +36,7 @@ module LibraBFT.ImplShared.Consensus.Types where
   open import LibraBFT.ImplShared.Consensus.Types.EpochIndep     public
   open import LibraBFT.ImplShared.Consensus.Types.MetaEpochIndep public
   open import LibraBFT.ImplShared.Consensus.Types.EpochDep       public
+  open import LibraBFT.ImplShared.Util.Crypto                    public
 
   open import LibraBFT.Abstract.Types.EpochConfig UID NodeId     public
 
@@ -242,3 +243,41 @@ module LibraBFT.ImplShared.Consensus.Types where
 
   lSafetyData : Lens RoundManager SafetyData
   lSafetyData = lPersistentSafetyStorage ∙ pssSafetyData
+
+  record GenesisInfo : Set where
+    constructor mkGenInfo
+    field
+      -- TODO-1 : Nodes, PKs for initial epoch
+      -- TODO-1 : Faults to tolerate (or quorum size?)
+      genQC      : QuorumCert            -- We use the same genesis QC for both highestQC and
+                                         -- highestCommitCert.
+  open GenesisInfo
+
+  postulate -- valid assumption
+    -- We postulate the existence of GenesisInfo known to all
+    -- TODO: construct one or write a function that generates one from some parameters.
+    genesisInfo : GenesisInfo
+
+  postulate -- TODO-2: define GenesisInfo to match implementation and write these functions
+    initVV  : GenesisInfo → ValidatorVerifier
+    init-EC : GenesisInfo → EpochConfig
+
+  data ∈GenInfo-impl (gi : GenesisInfo) : Signature → Set where
+   inGenQC : ∀ {vs} → vs ∈ qcVotes (genQC gi) → ∈GenInfo-impl gi (proj₂ vs)
+
+  open import LibraBFT.Abstract.Records UID _≟UID_ NodeId
+                                        (init-EC genesisInfo)
+                                        (ConcreteVoteEvidence (init-EC genesisInfo))
+                                        as Abs using ()
+
+  postulate -- TODO-1 : prove
+    ∈GenInfo?-impl : (gi : GenesisInfo) (sig : Signature) → Dec (∈GenInfo-impl gi sig)
+
+  postulate -- TODO-1: prove after defining genInfo
+    genVotesRound≡0     : ∀ {pk v}
+                       → (wvs : WithVerSig pk v)
+                       → ∈GenInfo-impl genesisInfo (ver-signature wvs)
+                       → v ^∙ vRound ≡ 0
+    genVotesConsistent : (v1 v2 : Vote)
+                       → ∈GenInfo-impl genesisInfo (_vSignature v1) → ∈GenInfo-impl genesisInfo (_vSignature v2)
+                     → v1 ^∙ vProposedId ≡ v2 ^∙ vProposedId

--- a/LibraBFT/ImplShared/Util/HashCollisions.agda
+++ b/LibraBFT/ImplShared/Util/HashCollisions.agda
@@ -1,0 +1,62 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Concrete.System.Parameters
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Crypto
+open import LibraBFT.Prelude
+open import LibraBFT.Yasm.Base
+open import LibraBFT.Yasm.System ℓ-RoundManager ℓ-VSFP ConcSysParms
+open import Optics.All
+
+-- This module will in future provide machinery for tracking hash collisions, showing that they
+-- exist in a particular ReachableSystemState (that they exist at all is not interesting, they
+-- obviously do by the pigeonhole principle; what is interesting is that the properties we want hold
+-- unless a hash collision exists within an execution up to some ReachableSystemState.  For
+-- convenience while working on proofs, for now we simply postulate that hash collsions do not exist
+-- in any ReachableSystemState.
+
+module LibraBFT.ImplShared.Util.HashCollisions
+  (iiah  : SystemInitAndHandlers ℓ-RoundManager ConcSysParms)
+  where
+
+  open WithInitAndHandlers iiah
+
+  module PerReachableState {st} (r : ReachableSystemState st) where
+
+    -- TODO-3: Remove this postulate when we are satisfied with the
+    -- "hash-collision-tracking" solution. For example, when proving voo
+    -- (in LibraBFT.LibraBFT.Concrete.Properties.VotesOnce), we
+    -- currently use this postulate to eliminate the possibility of two
+    -- votes that have the same signature but different VoteData
+    -- whenever we use sameSig⇒sameVoteData.  To eliminate the
+    -- postulate, we need to refine the properties we prove to enable
+    -- the possibility of a hash collision, in which case the required
+    -- property might not hold.  However, it is not sufficient to simply
+    -- prove that a hash collision *exists* (which is obvious,
+    -- regardless of the LibraBFT implementation).  Rather, we
+    -- ultimately need to produce a specific hash collision and relate
+    -- it to the data in the system, so that we can prove that the
+    -- desired properties hold *unless* an actual hash collision is
+    -- found by the implementation given the data in the system.  In
+    -- the meantime, we simply require that the collision identifies a
+    -- reachable state; later "collision tracking" will require proof
+    -- that the colliding values actually exist in that state.
+    postulate  -- temporary assumption that hash collisions don't exist (see comment above)
+      meta-sha256-cr : ¬ (NonInjective-≡ sha256)
+
+    sameSig⇒sameVoteDataNoCol : ∀ {v1 v2 : Vote} {pk}
+                              → WithVerSig pk v1
+                              → WithVerSig pk v2
+                              → v1 ^∙ vSignature ≡ v2 ^∙ vSignature
+                              → v2 ^∙ vVoteData ≡ v1 ^∙ vVoteData
+    sameSig⇒sameVoteDataNoCol {v1} {v2} wvs1 wvs2 refl
+       with sameSig⇒sameVoteData {v1} {v2} wvs1 wvs2 refl
+    ...| inj₁ hb = ⊥-elim (meta-sha256-cr hb)
+    ...| inj₂ x = x
+

--- a/LibraBFT/Yasm/Base.agda
+++ b/LibraBFT/Yasm/Base.agda
@@ -18,6 +18,8 @@ module LibraBFT.Yasm.Base (ℓ-PeerState : Level) where
     PeerId    : Set
     _≟PeerId_ : ∀ (p₁ p₂ : PeerId) → Dec (p₁ ≡ p₂)
     Genesis   : Set
+    -- A relation specifying what Signatures are included in genInfo
+    ∈GenInfo  : Genesis → Signature → Set
     PeerState : Set ℓ-PeerState
     Msg       : Set
     Part      : Set -- Types of interest that can be represented in Msgs
@@ -26,7 +28,12 @@ module LibraBFT.Yasm.Base (ℓ-PeerState : Level) where
     instance Part-sig : WithSig Part
 
     -- A relation specifying what Parts are included in a Msg.
-    _⊂Msg_       : Part → Msg → Set
+
+    -- TODO-2: I changed the name of this to append the G because of the pain disambiguating it from
+    -- NetworkMsg.⊂Msg.  This issue https://github.com/agda/agda/issues/2175 suggests I should have
+    -- been able to get this right without renaming, but...  I'd like to underastand how to do this
+    -- right, but for expedience, not now.
+    _⊂MsgG_       : Part → Msg → Set
 
  module _ (systypes : SystemTypeParameters) where
    open SystemTypeParameters systypes
@@ -37,9 +44,6 @@ module LibraBFT.Yasm.Base (ℓ-PeerState : Level) where
       -- The same genesis information is given to any uninitialised peer before
       -- it can handle any messages.
       genInfo   : Genesis
-
-      -- A relation specifying what Signatures are included in genInfo
-      ∈GenInfo     : Signature → Set
 
       -- Represents an uninitialised PeerState, about which we know nothing whatsoever
       initPS    : PeerState

--- a/LibraBFT/Yasm/Base.agda
+++ b/LibraBFT/Yasm/Base.agda
@@ -12,16 +12,13 @@ open import LibraBFT.Yasm.Types
 module LibraBFT.Yasm.Base (ℓ-PeerState : Level) where
  -- Our system is configured through a value of type
  -- SystemParameters where we specify:
- record SystemParameters : Set (ℓ+1 ℓ-PeerState) where
-  constructor mkSysParms
+ record SystemTypeParameters : Set (ℓ+1 ℓ-PeerState) where
+  constructor mkSysTypeParms
   field
     PeerId    : Set
     _≟PeerId_ : ∀ (p₁ p₂ : PeerId) → Dec (p₁ ≡ p₂)
     Genesis   : Set
-    genInfo   : Genesis    -- The same genesis information is given to any uninitialised peer before
-                           -- it can handle any messages.
     PeerState : Set ℓ-PeerState
-    initPS    : PeerState  -- Represents an uninitialised PeerState, about which we know nothing whatsoever
     Msg       : Set
     Part      : Set -- Types of interest that can be represented in Msgs
 
@@ -31,12 +28,25 @@ module LibraBFT.Yasm.Base (ℓ-PeerState : Level) where
     -- A relation specifying what Parts are included in a Msg.
     _⊂Msg_       : Part → Msg → Set
 
-    -- A relation specifying what Signatures are included in genInfo
-    ∈GenInfo     : Signature → Set
+ module _ (systypes : SystemTypeParameters) where
+   open SystemTypeParameters systypes
 
-    -- Initializes a potentially-empty state with an EpochConfig
-    init : PeerId → Genesis → PeerState × List (Action Msg)
+   record SystemInitAndHandlers : Set (ℓ+1 ℓ-PeerState) where
+    constructor mkSysInitAndHandlers
+    field
+      -- The same genesis information is given to any uninitialised peer before
+      -- it can handle any messages.
+      genInfo   : Genesis
 
-    -- Handles a message on a previously initialized peer.
-    handle : PeerId → Msg → PeerState → PeerState × List (Action Msg)
+      -- A relation specifying what Signatures are included in genInfo
+      ∈GenInfo     : Signature → Set
+
+      -- Represents an uninitialised PeerState, about which we know nothing whatsoever
+      initPS    : PeerState
+
+      -- Initializes a potentially-empty state with an EpochConfig
+      init : PeerId → Genesis → PeerState × List (Action Msg)
+
+      -- Handles a message on a previously initialized peer.
+      handle : PeerId → Msg → PeerState → PeerState × List (Action Msg)
 

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -74,7 +74,7 @@ module LibraBFT.Yasm.System
    field
      msgWhole   : Msg
      msgPart    : Part
-     msg⊆       : msgPart ⊂Msg msgWhole
+     msg⊆       : msgPart ⊂MsgG msgWhole
      msgSender  : PeerId
      msg∈pool   : (msgSender , msgWhole) ∈ pool
      msgSigned  : WithVerSig pk msgPart
@@ -129,7 +129,6 @@ module LibraBFT.Yasm.System
  open SystemState public
 
  module WithInitAndHandlers (iiah : SystemInitAndHandlers ℓ-PeerState parms) where
-
    open SystemInitAndHandlers iiah
 
    -- * Forbidding the Forging of Signatures
@@ -181,7 +180,7 @@ module LibraBFT.Yasm.System
    -- that epoch using a cheat step.
    CheatPartConstraint : SentMessages → Part → Set
    CheatPartConstraint pool m = ∀{pk} → (ver : WithVerSig pk m)
-                                      → ¬ ∈GenInfo (ver-signature ver)
+                                      → ¬ ∈GenInfo genInfo (ver-signature ver)
                                       → Meta-Dishonest-PK pk
                                       ⊎ MsgWithSig∈ pk (ver-signature ver) pool
 
@@ -190,7 +189,7 @@ module LibraBFT.Yasm.System
    -- * the signature on any part of the message satisfies CheatCanSign, meaning
    --   that it is not a new signature for an honest public key
    CheatMsgConstraint : SentMessages → Msg → Set
-   CheatMsgConstraint pool m = ∀{part} → part ⊂Msg m → CheatPartConstraint pool part
+   CheatMsgConstraint pool m = ∀{part} → part ⊂MsgG m → CheatPartConstraint pool part
 
    initialState : SystemState
    initialState = record

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -128,338 +128,341 @@ module LibraBFT.Yasm.System
      msgPool     : SentMessages          -- All messages ever sent
  open SystemState public
 
+ module WithInitAndHandlers (iiah : SystemInitAndHandlers ℓ-PeerState parms) where
 
- -- * Forbidding the Forging of Signatures
- --
- -- Whenever our reasoning must involve digital signatures, it is standard
- -- to talk about EUF-CMA resistant signature schemes. Informally, this captures
- -- signatures schemes that cannot be compromised by certain adversaries.
- -- Formally, it means that for any probabilistic-polynomial-time adversary 𝓐,
- -- and some security parameter k:
- --
- --      Pr[ EUF-CMA(k) ] ≤ ε(k) for ε a negigible function.
- --
- -- EUF-CMA is defined as:
- --
- -- EUF-CMA(k):                           |  O(m):
- --   L        ← ∅                        |    σ ← Sign(sk , m)
- --   (pk, sk) ← Gen(k)                   |    L ← L ∪ { m }
- --   (m , σ)  ← 𝓐ᴼ(pk)                   |    return σ
- --   return (Verify(pk, m, σ) ∧ m ∉ L)   |
- --
- -- This says that 𝓐 cannot create a message that has /not yet been signed/ and
- -- forge a signature for it. The list 'L' keeps track of the messages that 𝓐
- -- asked to be signed by the oracle.
- --
- -- Because the probability of the adversary to win the EUF-CMA(k) game
- -- approaches 0 as k increases; it is reasonable to assume that winning
- -- the game is /impossible/ for realistic security parameters.
- --
- -- EUF-CMA security is incorporated into our model by constraining messages
- -- sent by a cheat step to ensure that for every verifiably signed part of
- -- such a message, if there is a signature on the part, then it is either for
- -- a dishonest public key (in which cases it's secret key may have been leaked),
- -- or a message has been sent with the same signature before (in which case the
- -- signature is simply being "replayed" from a previous message).
- --
- -- Dishonest (or "cheat") messages are those that are not the result of
- -- a /handle/ or /init/ call, but rather are the result of a /cheat/ step.
- --
- -- A part of a cheat message can contain a verifiable signature only if it
- -- is for a dishonest public key, or a message with the same signature has
- -- been sent before or can be derived from GenesisInfo (a cheater can
- -- "reuse" an honest signature sent before; it just can't produce a new
- -- one).  Note that this constraint precludes a peer sending a message
- -- that contains a new verifiable signature for an honest PK, even if the
- -- PK is the peer's own PK for some epoch (implying that the peer
- -- possesses the associated secret key).  In other words, a peer that is
- -- honest for a given epoch (by virtue of being a member of that epoch and
- -- being assigned an honest PK for the epoch), cannot send a message for
- -- that epoch using a cheat step.
- CheatPartConstraint : SentMessages → Part → Set
- CheatPartConstraint pool m = ∀{pk} → (ver : WithVerSig pk m)
-                                    → ¬ ∈GenInfo (ver-signature ver)
-                                    → Meta-Dishonest-PK pk
-                                    ⊎ MsgWithSig∈ pk (ver-signature ver) pool
+   open SystemInitAndHandlers iiah
 
- -- The only constraints on messages sent by cheat steps are that:
- -- * the sender is not an honest member in the epoch of any part of the message
- -- * the signature on any part of the message satisfies CheatCanSign, meaning
- --   that it is not a new signature for an honest public key
- CheatMsgConstraint : SentMessages → Msg → Set
- CheatMsgConstraint pool m = ∀{part} → part ⊂Msg m → CheatPartConstraint pool part
+   -- * Forbidding the Forging of Signatures
+   --
+   -- Whenever our reasoning must involve digital signatures, it is standard
+   -- to talk about EUF-CMA resistant signature schemes. Informally, this captures
+   -- signatures schemes that cannot be compromised by certain adversaries.
+   -- Formally, it means that for any probabilistic-polynomial-time adversary 𝓐,
+   -- and some security parameter k:
+   --
+   --      Pr[ EUF-CMA(k) ] ≤ ε(k) for ε a negigible function.
+   --
+   -- EUF-CMA is defined as:
+   --
+   -- EUF-CMA(k):                           |  O(m):
+   --   L        ← ∅                        |    σ ← Sign(sk , m)
+   --   (pk, sk) ← Gen(k)                   |    L ← L ∪ { m }
+   --   (m , σ)  ← 𝓐ᴼ(pk)                   |    return σ
+   --   return (Verify(pk, m, σ) ∧ m ∉ L)   |
+   --
+   -- This says that 𝓐 cannot create a message that has /not yet been signed/ and
+   -- forge a signature for it. The list 'L' keeps track of the messages that 𝓐
+   -- asked to be signed by the oracle.
+   --
+   -- Because the probability of the adversary to win the EUF-CMA(k) game
+   -- approaches 0 as k increases; it is reasonable to assume that winning
+   -- the game is /impossible/ for realistic security parameters.
+   --
+   -- EUF-CMA security is incorporated into our model by constraining messages
+   -- sent by a cheat step to ensure that for every verifiably signed part of
+   -- such a message, if there is a signature on the part, then it is either for
+   -- a dishonest public key (in which cases it's secret key may have been leaked),
+   -- or a message has been sent with the same signature before (in which case the
+   -- signature is simply being "replayed" from a previous message).
+   --
+   -- Dishonest (or "cheat") messages are those that are not the result of
+   -- a /handle/ or /init/ call, but rather are the result of a /cheat/ step.
+   --
+   -- A part of a cheat message can contain a verifiable signature only if it
+   -- is for a dishonest public key, or a message with the same signature has
+   -- been sent before or can be derived from GenesisInfo (a cheater can
+   -- "reuse" an honest signature sent before; it just can't produce a new
+   -- one).  Note that this constraint precludes a peer sending a message
+   -- that contains a new verifiable signature for an honest PK, even if the
+   -- PK is the peer's own PK for some epoch (implying that the peer
+   -- possesses the associated secret key).  In other words, a peer that is
+   -- honest for a given epoch (by virtue of being a member of that epoch and
+   -- being assigned an honest PK for the epoch), cannot send a message for
+   -- that epoch using a cheat step.
+   CheatPartConstraint : SentMessages → Part → Set
+   CheatPartConstraint pool m = ∀{pk} → (ver : WithVerSig pk m)
+                                      → ¬ ∈GenInfo (ver-signature ver)
+                                      → Meta-Dishonest-PK pk
+                                      ⊎ MsgWithSig∈ pk (ver-signature ver) pool
 
- initialState : SystemState
- initialState = record
-   { peerStates  = const initPS
-   ; initialised = const uninitd
-   ; msgPool     = []
-   }
+   -- The only constraints on messages sent by cheat steps are that:
+   -- * the sender is not an honest member in the epoch of any part of the message
+   -- * the signature on any part of the message satisfies CheatCanSign, meaning
+   --   that it is not a new signature for an honest public key
+   CheatMsgConstraint : SentMessages → Msg → Set
+   CheatMsgConstraint pool m = ∀{part} → part ⊂Msg m → CheatPartConstraint pool part
 
- -- * Small Step Semantics
- --
- -- The small step semantics are divided into three datatypes:
- --
- -- i)   StepPeerState executes a step through init or handle
- -- ii)  StepPeer executes a step through StepPeerState or cheat
- -- iii) Step transitions the system state by a StepPeer or by
- --      bringing a new epoch into existence
+   initialState : SystemState
+   initialState = record
+     { peerStates  = const initPS
+     ; initialised = const uninitd
+     ; msgPool     = []
+     }
 
- -- The pre and post states of Honest peers are related iff
- data StepPeerState (pid : PeerId)(pool : SentMessages)
-                    (peerInits : PeerId → InitStatus) (ps : PeerState) :
-                    (PeerState × List (LYT.Action Msg)) → Set where
-   -- An uninitialized peer can be initialized
-   step-init : peerInits pid ≡ uninitd
-             → StepPeerState pid pool peerInits ps (init pid genInfo)
+   -- * Small Step Semantics
+   --
+   -- The small step semantics are divided into three datatypes:
+   --
+   -- i)   StepPeerState executes a step through init or handle
+   -- ii)  StepPeer executes a step through StepPeerState or cheat
+   -- iii) Step transitions the system state by a StepPeer or by
+   --      bringing a new epoch into existence
 
-   -- The peer processes a message in the pool
-   step-msg  : ∀{m}
-             → m ∈ pool
-             → peerInits pid ≡ initd
-             → StepPeerState pid pool peerInits ps (handle pid (proj₂ m) ps)
+   -- The pre and post states of Honest peers are related iff
+   data StepPeerState (pid : PeerId)(pool : SentMessages)
+                      (peerInits : PeerId → InitStatus) (ps : PeerState) :
+                      (PeerState × List (LYT.Action Msg)) → Set where
+     -- An uninitialized peer can be initialized
+     step-init : peerInits pid ≡ uninitd
+               → StepPeerState pid pool peerInits ps (init pid genInfo)
 
- -- The pre-state of the suplied PeerId is related to the post-state and list of output messages iff:
- data StepPeer (pre : SystemState) : PeerId → PeerState → List (LYT.Action Msg) → Set ℓ-PeerState where
-   -- it can be obtained by a handle or init call.
-   step-honest : ∀{pid st outs}
-               → StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (st , outs)
-               → StepPeer pre pid st outs
+     -- The peer processes a message in the pool
+     step-msg  : ∀{m}
+               → m ∈ pool
+               → peerInits pid ≡ initd
+               → StepPeerState pid pool peerInits ps (handle pid (proj₂ m) ps)
 
-   -- or the peer decides to cheat.  CheatMsgConstraint ensures it cannot
-   -- forge signatures by honest peers.  Cheat steps do not modify peer
-   -- state: these are maintained exclusively by the implementation
-   -- handlers.
-   step-cheat  : ∀{pid m}
-               → CheatMsgConstraint (msgPool pre) m
-               → StepPeer pre pid (peerStates pre pid) (LYT.send m ∷ [])
+   -- The pre-state of the suplied PeerId is related to the post-state and list of output messages iff:
+   data StepPeer (pre : SystemState) : PeerId → PeerState → List (LYT.Action Msg) → Set ℓ-PeerState where
+     -- it can be obtained by a handle or init call.
+     step-honest : ∀{pid st outs}
+                 → StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (st , outs)
+                 → StepPeer pre pid st outs
 
- isCheat : ∀ {pre pid ms outs} → StepPeer pre pid ms outs → Set
- isCheat (step-honest _) = ⊥
- isCheat (step-cheat  _) = Unit
+     -- or the peer decides to cheat.  CheatMsgConstraint ensures it cannot
+     -- forge signatures by honest peers.  Cheat steps do not modify peer
+     -- state: these are maintained exclusively by the implementation
+     -- handlers.
+     step-cheat  : ∀{pid m}
+                 → CheatMsgConstraint (msgPool pre) m
+                 → StepPeer pre pid (peerStates pre pid) (LYT.send m ∷ [])
 
- initStatus : ∀ {pid pre ms outs}
-            → StepPeer pre pid ms outs
-            → InitStatus
-            → InitStatus
- initStatus {pid} (step-honest _) preinit = initd
- initStatus {pid} (step-cheat  _) preinit = preinit
+   isCheat : ∀ {pre pid ms outs} → StepPeer pre pid ms outs → Set
+   isCheat (step-honest _) = ⊥
+   isCheat (step-cheat  _) = Unit
 
- -- Computes the post-sysstate for a given step-peer.
- StepPeer-post : ∀{pid st' outs}{pre : SystemState }
-               → StepPeer pre pid st' outs → SystemState
- StepPeer-post {pid} {st'} {outs} {pre} sp = record pre
-   { peerStates  = ⟦ peerStates pre  , pid ← st' ⟧
-   ; initialised = ⟦ initialised pre , pid ← initStatus sp (initialised pre pid) ⟧
-   ; msgPool     = actionsToSentMessages pid outs ++ msgPool pre
-   }
+   initStatus : ∀ {pid pre ms outs}
+              → StepPeer pre pid ms outs
+              → InitStatus
+              → InitStatus
+   initStatus {pid} (step-honest _) preinit = initd
+   initStatus {pid} (step-cheat  _) preinit = preinit
 
- StepPeer-post-lemma : ∀{pid st' outs}{pre : SystemState}
+   -- Computes the post-sysstate for a given step-peer.
+   StepPeer-post : ∀{pid st' outs}{pre : SystemState }
+                 → StepPeer pre pid st' outs → SystemState
+   StepPeer-post {pid} {st'} {outs} {pre} sp = record pre
+     { peerStates  = ⟦ peerStates pre  , pid ← st' ⟧
+     ; initialised = ⟦ initialised pre , pid ← initStatus sp (initialised pre pid) ⟧
+     ; msgPool     = actionsToSentMessages pid outs ++ msgPool pre
+     }
+
+   StepPeer-post-lemma : ∀{pid st' outs}{pre : SystemState}
+                 → (pstep : StepPeer pre pid st' outs)
+                 → st' ≡ peerStates (StepPeer-post pstep) pid
+   StepPeer-post-lemma pstep = sym override-target-≡
+
+   StepPeer-post-lemma2 : ∀{pid}{pre : SystemState}{st outs}
+                        → (sps : StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (st , outs))
+                        → initialised (StepPeer-post {pid} {st} {outs} {pre} (step-honest sps)) pid ≡ initd
+   StepPeer-post-lemma2 {pre = pre} _ = override-target-≡
+
+   cheatStepDNMPeerStates : ∀{pid st' outs}{pre : SystemState}
+                          → (theStep : StepPeer pre pid st' outs)
+                          → isCheat theStep
+                          → peerStates (StepPeer-post theStep) ≡ peerStates pre
+   cheatStepDNMPeerStates {pid = pid} {pre = pre} (step-cheat _) _ = overrideSameVal-correct-ext {f = peerStates pre} {pid}
+
+   cheatStepDNMInitialised : ∀{pid st' outs}{pre : SystemState}
+                          → (theStep : StepPeer pre pid st' outs)
+                          → isCheat theStep
+                          → initialised (StepPeer-post theStep) ≡ initialised pre
+   cheatStepDNMInitialised {pid = pid} {pre = pre} (step-cheat _) _ = overrideSameVal-correct-ext
+
+   cheatStepDNMInitialised₁ : ∀{pid pid' st' outs}{pre : SystemState}
+                          → (theStep : StepPeer pre pid st' outs)
+                          → isCheat theStep
+                          → initialised (StepPeer-post theStep) pid' ≡ initialised pre pid'
+   cheatStepDNMInitialised₁ {pid} {pid'} {pre = pre} (step-cheat _) _ = overrideSameVal-correct pid pid'
+
+   cheatStepDNMPeerStates₁ : ∀{pid pid' st' outs}{pre : SystemState}
+                           → (theStep : StepPeer pre pid st' outs)
+                           → isCheat theStep
+                           → peerStates (StepPeer-post theStep) pid' ≡ peerStates pre pid'
+   cheatStepDNMPeerStates₁ {pid} {pid'} (step-cheat _) x = overrideSameVal-correct pid pid'
+
+   pids≢StepDNMPeerStates :  ∀{pid pid' s' outs}{pre : SystemState}
+                           → (sps : StepPeerState pid' (msgPool pre) (initialised pre) (peerStates pre pid') (s' , outs))
+                           → pid ≢ pid'
+                           → peerStates pre pid ≡ peerStates (StepPeer-post {pid'} {s'} {outs} {pre} (step-honest sps)) pid
+   pids≢StepDNMPeerStates sps pids≢ = override-target-≢ pids≢
+
+   data Step : SystemState → SystemState → Set (ℓ+1 ℓ-PeerState) where
+     -- TO-NOT-DO: it is tempting to merge this and StepPeer, now that step-peer
+     -- is the only constructor here.  I started to do so, but it propagates many
+     -- changes throughout the repo, and it's possible we will in future add steps
+     -- not performed by a specific peer (for example, if we model some notion of
+     -- time to prove liveness properties).
+     step-peer : ∀{pid st' outs}{pre : SystemState}
                → (pstep : StepPeer pre pid st' outs)
-               → st' ≡ peerStates (StepPeer-post pstep) pid
- StepPeer-post-lemma pstep = sym override-target-≡
-
- StepPeer-post-lemma2 : ∀{pid}{pre : SystemState}{st outs}
-                      → (sps : StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (st , outs))
-                      → initialised (StepPeer-post {pid} {st} {outs} {pre} (step-honest sps)) pid ≡ initd
- StepPeer-post-lemma2 {pre = pre} _ = override-target-≡
-
- cheatStepDNMPeerStates : ∀{pid st' outs}{pre : SystemState}
-                        → (theStep : StepPeer pre pid st' outs)
-                        → isCheat theStep
-                        → peerStates (StepPeer-post theStep) ≡ peerStates pre
- cheatStepDNMPeerStates {pid = pid} {pre = pre} (step-cheat _) _ = overrideSameVal-correct-ext {f = peerStates pre} {pid}
-
- cheatStepDNMInitialised : ∀{pid st' outs}{pre : SystemState}
-                        → (theStep : StepPeer pre pid st' outs)
-                        → isCheat theStep
-                        → initialised (StepPeer-post theStep) ≡ initialised pre
- cheatStepDNMInitialised {pid = pid} {pre = pre} (step-cheat _) _ = overrideSameVal-correct-ext
-
- cheatStepDNMInitialised₁ : ∀{pid pid' st' outs}{pre : SystemState}
-                        → (theStep : StepPeer pre pid st' outs)
-                        → isCheat theStep
-                        → initialised (StepPeer-post theStep) pid' ≡ initialised pre pid'
- cheatStepDNMInitialised₁ {pid} {pid'} {pre = pre} (step-cheat _) _ = overrideSameVal-correct pid pid'
-
- cheatStepDNMPeerStates₁ : ∀{pid pid' st' outs}{pre : SystemState}
-                         → (theStep : StepPeer pre pid st' outs)
-                         → isCheat theStep
-                         → peerStates (StepPeer-post theStep) pid' ≡ peerStates pre pid'
- cheatStepDNMPeerStates₁ {pid} {pid'} (step-cheat _) x = overrideSameVal-correct pid pid'
-
- pids≢StepDNMPeerStates :  ∀{pid pid' s' outs}{pre : SystemState}
-                         → (sps : StepPeerState pid' (msgPool pre) (initialised pre) (peerStates pre pid') (s' , outs))
-                         → pid ≢ pid'
-                         → peerStates pre pid ≡ peerStates (StepPeer-post {pid'} {s'} {outs} {pre} (step-honest sps)) pid
- pids≢StepDNMPeerStates sps pids≢ = override-target-≢ pids≢
-
- data Step : SystemState → SystemState → Set (ℓ+1 ℓ-PeerState) where
-   -- TO-NOT-DO: it is tempting to merge this and StepPeer, now that step-peer
-   -- is the only constructor here.  I started to do so, but it propagates many
-   -- changes throughout the repo, and it's possible we will in future add steps
-   -- not performed by a specific peer (for example, if we model some notion of
-   -- time to prove liveness properties).
-   step-peer : ∀{pid st' outs}{pre : SystemState}
-             → (pstep : StepPeer pre pid st' outs)
-             → Step pre (StepPeer-post pstep)
+               → Step pre (StepPeer-post pstep)
 
 
- msgs-stable : ∀ {pre : SystemState} {post : SystemState} {m}
-             → (theStep : Step pre post)
-             → m ∈ msgPool pre
-             → m ∈ msgPool post
- msgs-stable (step-peer {pid = pid} {outs = outs} _) m∈ = Any-++ʳ (actionsToSentMessages pid outs) m∈
+   msgs-stable : ∀ {pre : SystemState} {post : SystemState} {m}
+               → (theStep : Step pre post)
+               → m ∈ msgPool pre
+               → m ∈ msgPool post
+   msgs-stable (step-peer {pid = pid} {outs = outs} _) m∈ = Any-++ʳ (actionsToSentMessages pid outs) m∈
 
- peersRemainInitialized : ∀ {pid} {pre : SystemState} {post : SystemState}
-                        → Step pre post
-                        → initialised pre pid ≡ initd
-                        → initialised post pid ≡ initd
- peersRemainInitialized {pid} (step-peer {pid'} step) isInitd
-   with pid' ≟PeerId pid
- ...| no neq = isInitd
- ...| yes refl
-   with step
- ... | step-honest {pidS} {st} {outs} stp = refl
- ... | step-cheat _ = isInitd
+   peersRemainInitialized : ∀ {pid} {pre : SystemState} {post : SystemState}
+                          → Step pre post
+                          → initialised pre pid ≡ initd
+                          → initialised post pid ≡ initd
+   peersRemainInitialized {pid} (step-peer {pid'} step) isInitd
+     with pid' ≟PeerId pid
+   ...| no neq = isInitd
+   ...| yes refl
+     with step
+   ... | step-honest {pidS} {st} {outs} stp = refl
+   ... | step-cheat _ = isInitd
 
- -- not used yet, but some proofs could probably be cleaned up using this,
- -- e.g., prevVoteRnd≤-pred-step in Impl.VotesOnce
- sendMessages-target : ∀ {m : SenderMsgPair} {sm : SentMessages} {ml : List SenderMsgPair}
-                     → ¬ (m ∈ sm)
-                     → m ∈ (ml ++ sm)
-                     → m ∈ ml
- sendMessages-target {ml = ml} ¬m∈sm m∈++
-   with Any-++⁻ ml m∈++
- ...| inj₁ m∈ml = m∈ml
- ...| inj₂ m∈sm = ⊥-elim (¬m∈sm m∈sm)
+   -- not used yet, but some proofs could probably be cleaned up using this,
+   -- e.g., prevVoteRnd≤-pred-step in Impl.VotesOnce
+   sendMessages-target : ∀ {m : SenderMsgPair} {sm : SentMessages} {ml : List SenderMsgPair}
+                       → ¬ (m ∈ sm)
+                       → m ∈ (ml ++ sm)
+                       → m ∈ ml
+   sendMessages-target {ml = ml} ¬m∈sm m∈++
+     with Any-++⁻ ml m∈++
+   ...| inj₁ m∈ml = m∈ml
+   ...| inj₂ m∈sm = ⊥-elim (¬m∈sm m∈sm)
 
- -- * Reflexive-Transitive Closure
+   -- * Reflexive-Transitive Closure
 
- data Step* : SystemState → SystemState → Set (ℓ+1 ℓ-PeerState) where
-   step-0 : ∀{pre : SystemState}
-          → Step* pre pre
+   data Step* : SystemState → SystemState → Set (ℓ+1 ℓ-PeerState) where
+     step-0 : ∀{pre : SystemState}
+            → Step* pre pre
 
-   step-s : ∀{fst : SystemState}{pre : SystemState}{post : SystemState}
-          → Step* fst pre
-          → Step pre post
-          → Step* fst post
+     step-s : ∀{fst : SystemState}{pre : SystemState}{post : SystemState}
+            → Step* fst pre
+            → Step pre post
+            → Step* fst post
 
- ReachableSystemState : SystemState → Set (ℓ+1 ℓ-PeerState)
- ReachableSystemState = Step* initialState
+   ReachableSystemState : SystemState → Set (ℓ+1 ℓ-PeerState)
+   ReachableSystemState = Step* initialState
 
- peerStatePostSt : ∀ {pid s' s outs} {st : SystemState}
-                 → (r : ReachableSystemState st)
-                 → (stP : StepPeerState pid (msgPool st) (initialised st)
-                                        (peerStates st pid) (s' , outs))
-                 → peerStates (StepPeer-post {pre = st} (step-honest stP)) pid ≡ s
-                 → s ≡ s'
- peerStatePostSt _ _ ps≡s = trans (sym ps≡s) override-target-≡
+   peerStatePostSt : ∀ {pid s' s outs} {st : SystemState}
+                   → (r : ReachableSystemState st)
+                   → (stP : StepPeerState pid (msgPool st) (initialised st)
+                                          (peerStates st pid) (s' , outs))
+                   → peerStates (StepPeer-post {pre = st} (step-honest stP)) pid ≡ s
+                   → s ≡ s'
+   peerStatePostSt _ _ ps≡s = trans (sym ps≡s) override-target-≡
 
- Step*-trans : ∀ {st st' st''}
-             → Step* st st'
-             → Step* st' st''
-             → Step* st st''
- Step*-trans r step-0 = r
- Step*-trans r (step-s tr x) = step-s (Step*-trans r tr) x
+   Step*-trans : ∀ {st st' st''}
+               → Step* st st'
+               → Step* st' st''
+               → Step* st st''
+   Step*-trans r step-0 = r
+   Step*-trans r (step-s tr x) = step-s (Step*-trans r tr) x
 
- Step*-initdStable : ∀{st st' pid}
-                   → Step* st st'
-                   → initialised st  pid ≡ initd
-                   → initialised st' pid ≡ initd
- Step*-initdStable step-0 ini = ini
- Step*-initdStable {st} {pid = pid} (step-s {pre = pre} tr theStep) ini =
-                   peersRemainInitialized theStep (Step*-initdStable tr ini)
+   Step*-initdStable : ∀{st st' pid}
+                     → Step* st st'
+                     → initialised st  pid ≡ initd
+                     → initialised st' pid ≡ initd
+   Step*-initdStable step-0 ini = ini
+   Step*-initdStable {st} {pid = pid} (step-s {pre = pre} tr theStep) ini =
+                     peersRemainInitialized theStep (Step*-initdStable tr ini)
 
- MsgWithSig∈-Step* : ∀{sig pk}{st : SystemState}{st' : SystemState}
-                   → Step* st st'
-                   → MsgWithSig∈ pk sig (msgPool st)
-                   → MsgWithSig∈ pk sig (msgPool st')
- MsgWithSig∈-Step* step-0        msig = msig
- MsgWithSig∈-Step* (step-s tr (step-peer ps)) msig
-   = MsgWithSig∈-++ʳ (MsgWithSig∈-Step* tr msig)
+   MsgWithSig∈-Step* : ∀{sig pk}{st : SystemState}{st' : SystemState}
+                     → Step* st st'
+                     → MsgWithSig∈ pk sig (msgPool st)
+                     → MsgWithSig∈ pk sig (msgPool st')
+   MsgWithSig∈-Step* step-0        msig = msig
+   MsgWithSig∈-Step* (step-s tr (step-peer ps)) msig
+     = MsgWithSig∈-++ʳ (MsgWithSig∈-Step* tr msig)
 
- MsgWithSig∈-Step*-part : ∀{sig pk}{st : SystemState}{st' : SystemState}
-                        → (tr   : Step* st st')
-                        → (msig : MsgWithSig∈ pk sig (msgPool st))
-                        → msgPart msig ≡ msgPart (MsgWithSig∈-Step* tr msig)
- MsgWithSig∈-Step*-part step-0        msig = refl
- MsgWithSig∈-Step*-part (step-s tr (step-peer ps)) msig
-   = MsgWithSig∈-Step*-part tr msig
-
- MsgWithSig∈-Step*-sender : ∀{sig pk}{st : SystemState}{st' : SystemState}
+   MsgWithSig∈-Step*-part : ∀{sig pk}{st : SystemState}{st' : SystemState}
                           → (tr   : Step* st st')
                           → (msig : MsgWithSig∈ pk sig (msgPool st))
-                          → msgSender msig ≡ msgSender (MsgWithSig∈-Step* tr msig)
- MsgWithSig∈-Step*-sender step-0        msig = refl
- MsgWithSig∈-Step*-sender (step-s tr (step-peer ps)) msig
-   = MsgWithSig∈-Step*-sender tr msig
+                          → msgPart msig ≡ msgPart (MsgWithSig∈-Step* tr msig)
+   MsgWithSig∈-Step*-part step-0        msig = refl
+   MsgWithSig∈-Step*-part (step-s tr (step-peer ps)) msig
+     = MsgWithSig∈-Step*-part tr msig
+
+   MsgWithSig∈-Step*-sender : ∀{sig pk}{st : SystemState}{st' : SystemState}
+                            → (tr   : Step* st st')
+                            → (msig : MsgWithSig∈ pk sig (msgPool st))
+                            → msgSender msig ≡ msgSender (MsgWithSig∈-Step* tr msig)
+   MsgWithSig∈-Step*-sender step-0        msig = refl
+   MsgWithSig∈-Step*-sender (step-s tr (step-peer ps)) msig
+     = MsgWithSig∈-Step*-sender tr msig
 
 
- ------------------------------------------
+   ------------------------------------------
 
- -- Type synonym to express a relation over system states;
- SystemStateRel : ∀ {ℓ} → (SystemState → SystemState → Set (ℓ+1 ℓ-PeerState)) → Set (ℓ+1 (ℓ ℓ⊔ ℓ-PeerState))
- SystemStateRel {ℓ} P = ∀{st : SystemState}{st' : SystemState} → P st st' → Set (ℓ ℓ⊔ ℓ-PeerState)
+   -- Type synonym to express a relation over system states;
+   SystemStateRel : ∀ {ℓ} → (SystemState → SystemState → Set (ℓ+1 ℓ-PeerState)) → Set (ℓ+1 (ℓ ℓ⊔ ℓ-PeerState))
+   SystemStateRel {ℓ} P = ∀{st : SystemState}{st' : SystemState} → P st st' → Set (ℓ ℓ⊔ ℓ-PeerState)
 
- -- Just like Data.List.Any maps a predicate over elements to a predicate over lists,
- -- Any-step maps a relation over steps to a relation over steps in a trace.
- data Any-Step {ℓ : Level} (P : SystemStateRel {ℓ} Step) : SystemStateRel {ℓ} Step* where
-  step-here  : ∀{fst : SystemState}{pre : SystemState}{post : SystemState}
-             → (cont : Step* fst pre)
-             → {this : Step pre post}(prf  : P this)
-             → Any-Step P (step-s cont this)
+   -- Just like Data.List.Any maps a predicate over elements to a predicate over lists,
+   -- Any-step maps a relation over steps to a relation over steps in a trace.
+   data Any-Step {ℓ : Level} (P : SystemStateRel {ℓ} Step) : SystemStateRel {ℓ} Step* where
+    step-here  : ∀{fst : SystemState}{pre : SystemState}{post : SystemState}
+               → (cont : Step* fst pre)
+               → {this : Step pre post}(prf  : P this)
+               → Any-Step P (step-s cont this)
 
-  step-there : ∀{fst : SystemState}{pre : SystemState}{post : SystemState}
-             → {cont : Step* fst pre}
-             → {this : Step pre post}
-             → (prf  : Any-Step {ℓ} P cont)
-             → Any-Step P (step-s cont this)
+    step-there : ∀{fst : SystemState}{pre : SystemState}{post : SystemState}
+               → {cont : Step* fst pre}
+               → {this : Step pre post}
+               → (prf  : Any-Step {ℓ} P cont)
+               → Any-Step P (step-s cont this)
 
- Any-Step-map : ∀ {ℓ}{P P' : SystemStateRel {ℓ} Step}
-              → (∀ {pre : SystemState}{post : SystemState} → (x : Step pre post) → P x → P' x)
-              → ∀ {fst lst} {tr : Step* fst lst}
-              → Any-Step {ℓ} P tr
-              → Any-Step {ℓ} P' tr
- Any-Step-map p⇒p' (step-here cont {this} prf) = step-here cont (p⇒p' this prf)
- Any-Step-map p⇒p' (step-there anyStep) = step-there (Any-Step-map p⇒p' anyStep)
+   Any-Step-map : ∀ {ℓ}{P P' : SystemStateRel {ℓ} Step}
+                → (∀ {pre : SystemState}{post : SystemState} → (x : Step pre post) → P x → P' x)
+                → ∀ {fst lst} {tr : Step* fst lst}
+                → Any-Step {ℓ} P tr
+                → Any-Step {ℓ} P' tr
+   Any-Step-map p⇒p' (step-here cont {this} prf) = step-here cont (p⇒p' this prf)
+   Any-Step-map p⇒p' (step-there anyStep) = step-there (Any-Step-map p⇒p' anyStep)
 
- Any-Step-elim
-   : ∀{ℓ}{ℓ-Q}{st₀ : SystemState}{st₁ : SystemState}{P : SystemStateRel {ℓ} Step}{Q : Set ℓ-Q}
-   → {r : Step* st₀ st₁}
-   → (P⇒Q : ∀{s : SystemState}{s' : SystemState}{st : Step s s'}
-          → P st → Step* s' st₁ → Q)
-   → Any-Step {ℓ} P r → Q
- Any-Step-elim P⇒Q (step-here cont prf)
-   = P⇒Q prf step-0
- Any-Step-elim P⇒Q (step-there {this = this} f)
-   = Any-Step-elim (λ p s → P⇒Q p (step-s s this)) f
+   Any-Step-elim
+     : ∀{ℓ}{ℓ-Q}{st₀ : SystemState}{st₁ : SystemState}{P : SystemStateRel {ℓ} Step}{Q : Set ℓ-Q}
+     → {r : Step* st₀ st₁}
+     → (P⇒Q : ∀{s : SystemState}{s' : SystemState}{st : Step s s'}
+            → P st → Step* s' st₁ → Q)
+     → Any-Step {ℓ} P r → Q
+   Any-Step-elim P⇒Q (step-here cont prf)
+     = P⇒Q prf step-0
+   Any-Step-elim P⇒Q (step-there {this = this} f)
+     = Any-Step-elim (λ p s → P⇒Q p (step-s s this)) f
 
- -- A predicate over peer states, parts and peerIds, representing which peers can send new
- -- signatures for which PKs.  The PeerState is needed to provide access to information the peer has
- -- about who uses what keys for what parts (in our case, EpochConfigs either derived from genesis
- -- information or agreed during epoch changes).
- ValidSenderForPK-type : Set (ℓ+1 ℓ-VSFP ℓ⊔ ℓ+1 ℓ-PeerState)
- ValidSenderForPK-type = SystemState → Part → PeerId → PK → Set ℓ-VSFP
+   -- A predicate over peer states, parts and peerIds, representing which peers can send new
+   -- signatures for which PKs.  The PeerState is needed to provide access to information the peer has
+   -- about who uses what keys for what parts (in our case, EpochConfigs either derived from genesis
+   -- information or agreed during epoch changes).
+   ValidSenderForPK-type : Set (ℓ+1 ℓ-VSFP ℓ⊔ ℓ+1 ℓ-PeerState)
+   ValidSenderForPK-type = SystemState → Part → PeerId → PK → Set ℓ-VSFP
 
- ValidSenderForPK-stable-type : ValidSenderForPK-type → Set (ℓ-VSFP ℓ⊔ ℓ+1 ℓ-PeerState)
- ValidSenderForPK-stable-type vs4pk = ∀ {pre post part pid pk}
-                                      → ReachableSystemState pre
-                                      → Step pre post
-                                      → vs4pk pre  part pid pk
-                                      → vs4pk post part pid pk
+   ValidSenderForPK-stable-type : ValidSenderForPK-type → Set (ℓ-VSFP ℓ⊔ ℓ+1 ℓ-PeerState)
+   ValidSenderForPK-stable-type vs4pk = ∀ {pre post part pid pk}
+                                        → ReachableSystemState pre
+                                        → Step pre post
+                                        → vs4pk pre  part pid pk
+                                        → vs4pk post part pid pk
 
- ------------------------------------------
+   ------------------------------------------
 
- module _ (P : SystemState → Set) where
+   module _ (P : SystemState → Set) where
 
-   Step*-Step-fold : (∀{pid st' outs}{st : SystemState}
-                        → ReachableSystemState st
-                        → (pstep : StepPeer st pid st' outs)
-                        → P st
-                        → P (StepPeer-post pstep))
-                   → P initialState
-                   → ∀{st : SystemState}
-                   → (tr : ReachableSystemState st) → P st
-   Step*-Step-fold fs p₀ step-0 = p₀
-   Step*-Step-fold fs p₀ (step-s tr (step-peer p)) = fs tr p (Step*-Step-fold fs p₀ tr)
+     Step*-Step-fold : (∀{pid st' outs}{st : SystemState}
+                          → ReachableSystemState st
+                          → (pstep : StepPeer st pid st' outs)
+                          → P st
+                          → P (StepPeer-post pstep))
+                     → P initialState
+                     → ∀{st : SystemState}
+                     → (tr : ReachableSystemState st) → P st
+     Step*-Step-fold fs p₀ step-0 = p₀
+     Step*-Step-fold fs p₀ (step-s tr (step-peer p)) = fs tr p (Step*-Step-fold fs p₀ tr)

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -22,7 +22,7 @@ import      LibraBFT.Yasm.Types as LYT
 module LibraBFT.Yasm.System
    (ℓ-PeerState : Level)
    (ℓ-VSFP      : Level)
-   (parms      : LYB.SystemParameters ℓ-PeerState)
+   (parms      : LYB.SystemTypeParameters ℓ-PeerState)
  where
 
  data InitStatus : Set where
@@ -34,7 +34,7 @@ module LibraBFT.Yasm.System
  uninitd≢initd = λ ()
 
  open import LibraBFT.Yasm.Base
- open SystemParameters parms
+ open SystemTypeParameters parms
  open import Util.FunctionOverride PeerId _≟PeerId_
 
  open import LibraBFT.Base.PKCS
@@ -117,6 +117,17 @@ module LibraBFT.Yasm.System
     ; msgSameSig = msgSameSig msig
     }
 
+ -- * The System State
+ --
+ -- A system consists in a partial map from PeerId to PeerState, a pool
+ -- of sent messages and a number of available epochs.
+ record SystemState : Set (ℓ+1 ℓ-PeerState) where
+   field
+     peerStates  : PeerId → PeerState
+     initialised : PeerId → InitStatus
+     msgPool     : SentMessages          -- All messages ever sent
+ open SystemState public
+
 
  -- * Forbidding the Forging of Signatures
  --
@@ -177,17 +188,6 @@ module LibraBFT.Yasm.System
  --   that it is not a new signature for an honest public key
  CheatMsgConstraint : SentMessages → Msg → Set
  CheatMsgConstraint pool m = ∀{part} → part ⊂Msg m → CheatPartConstraint pool part
-
- -- * The System State
- --
- -- A system consists in a partial map from PeerId to PeerState, a pool
- -- of sent messages and a number of available epochs.
- record SystemState : Set (ℓ+1 ℓ-PeerState) where
-   field
-     peerStates  : PeerId → PeerState
-     initialised : PeerId → InitStatus
-     msgPool     : SentMessages          -- All messages ever sent
- open SystemState public
 
  initialState : SystemState
  initialState = record

--- a/LibraBFT/Yasm/Yasm.agda
+++ b/LibraBFT/Yasm/Yasm.agda
@@ -15,13 +15,16 @@ import      LibraBFT.Yasm.System as LYS
 module LibraBFT.Yasm.Yasm
    (ℓ-PeerState : Level)
    (ℓ-VSFP      : Level)
-   (parms       : LYB.SystemParameters ℓ-PeerState)
-   (ValidSenderForPK        : LYS.ValidSenderForPK-type        ℓ-PeerState ℓ-VSFP parms)
-   (ValidSenderForPK-stable : LYS.ValidSenderForPK-stable-type ℓ-PeerState ℓ-VSFP parms ValidSenderForPK)
+   (parms       : LYB.SystemTypeParameters ℓ-PeerState)
+   (iiah  : LYB.SystemInitAndHandlers ℓ-PeerState parms)
+   (ValidSenderForPK        : LYS.WithInitAndHandlers.ValidSenderForPK-type        ℓ-PeerState ℓ-VSFP parms iiah)
+   (ValidSenderForPK-stable : LYS.WithInitAndHandlers.ValidSenderForPK-stable-type ℓ-PeerState ℓ-VSFP parms iiah ValidSenderForPK)
   where
- open LYB.SystemParameters parms
- open import LibraBFT.Yasm.Base                                                                        public
- open import LibraBFT.Yasm.Types                                                                       public
- open import LibraBFT.Yasm.System     ℓ-PeerState ℓ-VSFP parms                                          public
- open import LibraBFT.Yasm.Properties ℓ-PeerState ℓ-VSFP parms ValidSenderForPK ValidSenderForPK-stable public
- open import Util.FunctionOverride    PeerId _≟PeerId_                                                 public
+ open LYB.SystemTypeParameters  parms
+ open LYB.SystemInitAndHandlers iiah
+ open import LibraBFT.Yasm.Base                                                                              public
+ open import LibraBFT.Yasm.Types                                                                             public
+ open import LibraBFT.Yasm.System     ℓ-PeerState ℓ-VSFP parms                                               public
+ open import LibraBFT.Yasm.Properties ℓ-PeerState ℓ-VSFP parms iiah ValidSenderForPK ValidSenderForPK-stable public
+ open        WithInitAndHandlers iiah                                                                        public
+ open import Util.FunctionOverride    PeerId _≟PeerId_                                                       public


### PR DESCRIPTION
The main purpose of this PR is to enable us to hook up the under-development implementation model to the concrete properties without breaking or losing our fake implementation and proofs about it.  This further enables proving multiple variants on an implementation.  The main changes are:

* Refactor `Yasm` so that we first instantiate it with the types, and subsequently instantiate it with initialisation information and handlers.
* Tease apart `Concrete` namespace from `Impl*`, so that anything it needs to know about an implementation is provided as a module parameter, not directly from an implementation as it did before.
   * As a result, there is one new proof (`NewVoteRound≢0`) required in `LibraBFT.Concrete.Properties.VotesOnce` and an implementation obligation is provided about honest votes that should enable this proof.
* Move initialisation-related information (mostly postulated for now) into `LibraBFT.Impl.Consensus.Types`, so both `Impl` and `FakeImpl` can share it.
* Establish `ImplementationObligations` for the fake handler (`FakeInitAndHandlers`); the real implementation will need one too, and it can use the same `genesisInfo` and `initRM`, while providing its own handlers.

I had some naming conflict pain and couldn't easily resolve it the "right" way, so had to rename some things to avoid the conflict.  Not ideal but expedient.

I have tried to separate this work into coherent commits (including a couple that are indent-only), but there is no guarantee that each commit builds successfully.

@cwjnkins, this should enable you to establish a handler for the real implementation model, and work towards creating `ImplObligations` for it, analogous to `theImplObligations` in `LibraBFT.ImplFake.Properties`.

@lisandrasilva, assuming we merge this or something like it, it should be a good time to port a version of your proofs in #43.  I would suggest looking at the changes to `LibraBFT.Concrete.Properties.VotesOnce` first, as you will likely have to make similar changes.  P.S., I bet you can't prove `NewVoteRound≢0` 😉 