### PR TITLE
Refactor `Output` and friends to `ImplShared`, start modeling network handlers

### DIFF
--- a/LibraBFT/Impl/Consensus/Network.agda
+++ b/LibraBFT/Impl/Consensus/Network.agda
@@ -1,0 +1,18 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.Types
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.NetworkMsg
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.Network where
+
+  postulate  -- TODO-1: implement this
+    processProposal : {- NodeId → -} ProposalMsg → Epoch → ValidatorVerifier → (FakeErr ⊎ FakeInfo) ⊎ Unit

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -19,6 +19,7 @@ open import LibraBFT.Impl.Consensus.SafetyRules.SafetyRules      as SafetyRules
 open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -1,0 +1,102 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.Encode
+open import LibraBFT.Base.KVMap as KVMap
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Concrete.System
+open import LibraBFT.Concrete.System.Parameters
+open import LibraBFT.Hash
+open import LibraBFT.Impl.IO.OBM.InputOutputHandlers
+open import LibraBFT.Impl.Consensus.RoundManager
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
+open import LibraBFT.ImplShared.Util.Crypto
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Lemmas
+open import LibraBFT.Prelude
+open import LibraBFT.Yasm.Base
+import      LibraBFT.Yasm.Types as LYT
+open import Optics.All
+
+-- This module provides scaffolding to define the handlers for our implementation model and connect
+-- them to the interface of the SystemModel.  Initially it inherits a bunch of postulated stuff for
+-- initial state from the fake implementation, but these will evolve here, while the fake one
+-- probably won't.  There is probably more refactoring we can do with FakeImpl too (see comment
+-- below).
+
+module LibraBFT.Impl.Handle where
+ open RWST-do
+ open EpochConfig
+
+ postulate -- TODO-1: reasonable assumption that some RoundManager exists, though we could prove
+           -- it by construction; eventually we will construct an entire RoundManager, so
+           -- this won't be needed
+
+ -- This represents an uninitialised RoundManager, about which we know nothing, which we use as
+ -- the initial RoundManager for every peer until it is initialised.
+   fakeRM : RoundManager
+
+ initSR : SafetyRules
+ initSR =  over (srPersistentStorage ∙ pssSafetyData ∙ sdEpoch) (const 1)
+                (over (srPersistentStorage ∙ pssSafetyData ∙ sdLastVotedRound) (const 0)
+                      (_rmSafetyRules (_rmEC fakeRM)))
+
+ postulate -- TODO-1: Implement this.
+   initPE : ProposerElection
+
+ initPV : PendingVotes
+ initPV = PendingVotes∙new KVMap.empty nothing KVMap.empty
+
+ initRS : RoundState
+ initRS = RoundState∙new 0 0 initPV nothing
+
+ initRMEC : RoundManagerEC
+ initRMEC = RoundManagerEC∙new (EpochState∙new 1 (initVV genesisInfo)) initRS initPE initSR false
+
+ postulate -- TODO-2 : prove these once initRMEC is defined directly
+   init-EC-epoch-1  : epoch (init-EC genesisInfo) ≡ 1
+   initRMEC-correct : RoundManagerEC-correct initRMEC
+
+ initRM : RoundManager
+ initRM = fakeRM
+
+ -- Eventually, the initialization should establish some properties we care about, but for now we
+ -- just initialise again to fakeRM, which means we cannot prove the base case for various
+ -- properties, e.g., in Impl.Properties.VotesOnce
+ -- TODO: create real RoundManager using GenesisInfo
+ initialRoundManagerAndMessages
+     : (a : Author) → GenesisInfo
+     → RoundManager × List NetworkMsg
+ initialRoundManagerAndMessages a _ = initRM , []
+
+ -- TODO-2: These "wrappers" can probably be shared with FakeImpl, and therefore more of this could
+ -- be factored into LibraBFT.ImplShared.Interface.* (maybe Output, in which case maybe that should
+ -- be renamed?)
+
+ initWrapper : NodeId → GenesisInfo → RoundManager × List (LYT.Action NetworkMsg)
+ initWrapper nid g = ×-map₂ (List-map LYT.send) (initialRoundManagerAndMessages nid g)
+
+ -- Here we invoke the handler that models the real implementation handler.
+ runHandler : RoundManager → LBFT Unit → RoundManager × List (LYT.Action NetworkMsg)
+ runHandler st handler = ×-map₂ (outputsToActions {st}) (proj₂ (LBFT-run handler st))
+
+ -- And ultimately, the all-knowing system layer only cares about the
+ -- step function.
+ --
+ -- Note that we currently do not do anything non-trivial with the timestamp.
+ -- Here, we just pass 0 to `handle`.
+ peerStep : NodeId → NetworkMsg → RoundManager → RoundManager × List (LYT.Action NetworkMsg)
+ peerStep nid msg st = runHandler st (handle nid msg 0)
+
+ InitAndHandlers : SystemInitAndHandlers ℓ-RoundManager ConcSysParms
+ InitAndHandlers = mkSysInitAndHandlers
+                     genesisInfo
+                     initRM
+                     initWrapper
+                     peerStep
+

--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -1,0 +1,43 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+{-# OPTIONS --allow-unsolved-metas #-}
+
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.Consensus.Network as Network
+open import LibraBFT.Impl.Consensus.RoundManager as RoundManager
+open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.NetworkMsg
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+-- This module defines the handler for our implementation.  For most message types, it does some
+-- initial validation before passing the message on to the proper handlers.
+
+module LibraBFT.Impl.IO.OBM.InputOutputHandlers where
+
+  open RWST-do
+
+  epvv : LBFT (Epoch × ValidatorVerifier)
+  epvv = _,_ <$> gets (_^∙ rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch ∘ _rmEC)
+             <*> gets (_^∙ rmEpochState ∙ esVerifier ∘ _rmEC)
+
+  handleProposal : Instant → ProposalMsg → LBFT Unit
+  handleProposal now pm = do
+    (myEpoch , vv) ← epvv
+    case Network.processProposal pm myEpoch vv of λ where
+      (inj₁ (inj₁ _)) → logErr
+      (inj₁ (inj₂ _)) → logInfo
+      (inj₂ _)        → RoundManager.processProposalMsgM now pm
+
+  handle : NodeId → NetworkMsg → Instant → LBFT Unit
+  handle _self msg now =
+     case msg of λ where
+       (P pm) → handleProposal now pm
+       (V vm) → {!!} -- TODO-1: processVote now v
+       (C cm) → return unit    -- We don't do anything with commit messages, they are just for defining Correctness.

--- a/LibraBFT/Impl/OBM/Logging/Logging.agda
+++ b/LibraBFT/Impl/OBM/Logging/Logging.agda
@@ -6,6 +6,7 @@
 
 
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 

--- a/LibraBFT/ImplFake/Consensus/RoundManager.agda
+++ b/LibraBFT/ImplFake/Consensus/RoundManager.agda
@@ -10,6 +10,7 @@ open import LibraBFT.Base.Types
 open import LibraBFT.Hash
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId

--- a/LibraBFT/ImplFake/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/ImplFake/Consensus/RoundManager/Properties.agda
@@ -12,6 +12,7 @@ open import LibraBFT.Base.Types
 open import LibraBFT.Hash
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -309,31 +309,3 @@ module LibraBFT.ImplShared.Consensus.Types where
     FakeInfo FakeErr : Set
     fakeErr          : FakeErr
     fakeInfo         : FakeInfo
-
-  data Output : Set where
-    BroadcastProposal : ProposalMsg                   → Output
-    LogErr            : FakeErr                       → Output
-    LogInfo           : FakeInfo                      → Output
-    SendVote          : VoteMsg → List Author → Output
-  open Output public
-
-  SendVote-inj-v : ∀ {x1 x2 y1 y2} → SendVote x1 y1 ≡ SendVote x2 y2 → x1 ≡ x2
-  SendVote-inj-v refl = refl
-
-  SendVote-inj-si : ∀ {x1 x2 y1 y2} → SendVote x1 y1 ≡ SendVote x2 y2 → y1 ≡ y2
-  SendVote-inj-si refl = refl
-
-  IsSendVote : Output → Set
-  IsSendVote out = ∃₂ λ mv pid → out ≡ SendVote mv pid
-
-  isSendVote? : (out : Output) → Dec (IsSendVote out)
-  isSendVote? (BroadcastProposal _) = no λ ()
-  isSendVote? (LogErr _)            = no λ ()
-  isSendVote? (LogInfo _)           = no λ ()
-  isSendVote? (SendVote mv pid)     = yes (mv , pid , refl)
-
-  SendVote∉Output : ∀ {vm pid outs} → List-filter isSendVote? outs ≡ [] → ¬ (SendVote vm pid ∈ outs)
-  SendVote∉Output () (here refl)
-  SendVote∉Output{outs = x ∷ outs'} eq (there vm∈outs)
-     with isSendVote? x
-  ... | no proof = SendVote∉Output eq vm∈outs

--- a/LibraBFT/ImplShared/Interface/Output.agda
+++ b/LibraBFT/ImplShared/Interface/Output.agda
@@ -1,0 +1,61 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+-- This module defines Outputs produced by handlers, as well as functions and properties relating
+-- these to Yasm Actions.
+
+open import LibraBFT.Base.KVMap
+open import LibraBFT.ImplShared.NetworkMsg
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.Prelude
+open import LibraBFT.Yasm.Types
+
+module LibraBFT.ImplShared.Interface.Output where
+
+  data Output : Set where
+    BroadcastProposal : ProposalMsg                   → Output
+    LogErr            : FakeErr                       → Output
+    LogInfo           : FakeInfo                      → Output
+    SendVote          : VoteMsg → List Author → Output
+  open Output public
+
+  SendVote-inj-v : ∀ {x1 x2 y1 y2} → SendVote x1 y1 ≡ SendVote x2 y2 → x1 ≡ x2
+  SendVote-inj-v refl = refl
+
+  SendVote-inj-si : ∀ {x1 x2 y1 y2} → SendVote x1 y1 ≡ SendVote x2 y2 → y1 ≡ y2
+  SendVote-inj-si refl = refl
+
+  IsSendVote : Output → Set
+  IsSendVote out = ∃₂ λ mv pid → out ≡ SendVote mv pid
+
+  isSendVote? : (out : Output) → Dec (IsSendVote out)
+  isSendVote? (BroadcastProposal _) = no λ ()
+  isSendVote? (LogErr _)            = no λ ()
+  isSendVote? (LogInfo _)           = no λ ()
+  isSendVote? (SendVote mv pid)     = yes (mv , pid , refl)
+
+  SendVote∉Output : ∀ {vm pid outs} → List-filter isSendVote? outs ≡ [] → ¬ (SendVote vm pid ∈ outs)
+  SendVote∉Output () (here refl)
+  SendVote∉Output{outs = x ∷ outs'} eq (there vm∈outs)
+     with isSendVote? x
+  ... | no proof = SendVote∉Output eq vm∈outs
+
+  -- Note: the SystemModel allows anyone to receive any message sent, so intended recipient is ignored;
+  -- it is included in the model only to facilitate future work on liveness properties, when we will need
+  -- assumptions about message delivery between honest peers.
+  outputToActions : RoundManager → Output → List (Action NetworkMsg)
+  outputToActions rm (BroadcastProposal p) = List-map (const (send (P p)))
+                                                      (List-map proj₁
+                                                                (kvm-toList (_vvAddressToValidatorInfo
+                                                                              (_esVerifier
+                                                                                (_rmEpochState (_rmEC rm))))))
+  outputToActions _  (LogErr x)            = []
+  outputToActions _  (LogInfo x)           = []
+  outputToActions _  (SendVote vm toList)  = List-map (const (send (V vm))) toList
+
+  outputsToActions : ∀ {State} → List Output → List (Action NetworkMsg)
+  outputsToActions {st} = concat ∘ List-map (outputToActions st)
+

--- a/LibraBFT/ImplShared/Util/Util.agda
+++ b/LibraBFT/ImplShared/Util/Util.agda
@@ -5,6 +5,7 @@
 -}
 open import LibraBFT.Prelude
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
 
 -- This module defines the LBFT monad used by our (fake/simple,
 -- for now) "implementation", along with some utility functions


### PR DESCRIPTION
This PR refactors some of the types and functions defined with the `FakeImpl` handler into `ImplShared` to enable them to be used also by the real implementation model.  It further begins modeling the actual network handlers so we can see where to connect the pieces.