### PR TITLE
Small merge review changes from #43, reinstate and fix `FakeImpl.Properties.VotesOnce.vo₁` proof

### DIFF
--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -38,7 +38,7 @@ module LibraBFT.Concrete.Obligations (iiah : SystemInitAndHandlers ℓ-RoundMana
       -- VotesOnce:
       gvc  : Common.ImplObl-genVotesConsistent 𝓔
       gvr  : Common.ImplObl-genVotesRound≡0 𝓔
-      v≢0  : Common.ImplObl-NewVoteSignedAndRound≢0 𝓔
+      v≢0  : Common.ImplObl-NewVoteRound≢0 𝓔
       ∈GI? : (sig : Signature) → Dec (∈GenInfo genInfo sig)
       iro : Common.IncreasingRoundObligation 𝓔
       vo₂ : VO.ImplObligation₂ 𝓔

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -54,7 +54,7 @@ module LibraBFT.Concrete.Properties
     validState : ValidSysState intSystemState
     validState = record
       { vss-votes-once      = VO.Proof.voo iiah 𝓔 sps-cor gvc gvr v≢0 ∈GI? iro vo₂ st r
-      ; vss-preferred-round = PR.Proof.prr iiah 𝓔 sps-cor gvr ∈GI? iro pr₁ pr₂ st r
+      ; vss-preferred-round = PR.Proof.prr iiah 𝓔 sps-cor gvr v≢0 ∈GI? iro pr₁ pr₂ st r
       }
 
     open IntermediateSystemState intSystemState

--- a/LibraBFT/Concrete/Properties/Common.agda
+++ b/LibraBFT/Concrete/Properties/Common.agda
@@ -1,3 +1,9 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
 open import Optics.All
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
@@ -12,7 +18,8 @@ open        EpochConfig
 open import LibraBFT.Concrete.System
 open import LibraBFT.Yasm.Base
 
-
+-- This module contains definitions and proofs used by both the VotesOnce and PreferredRoundRule
+-- proofs.
 
 module LibraBFT.Concrete.Properties.Common (iiah : SystemInitAndHandlers ℓ-RoundManager ConcSysParms) (𝓔 : EpochConfig) where
  open        SystemTypeParameters ConcSysParms

--- a/LibraBFT/Concrete/Properties/Common.agda
+++ b/LibraBFT/Concrete/Properties/Common.agda
@@ -26,7 +26,8 @@ module LibraBFT.Concrete.Properties.Common (iiah : SystemInitAndHandlers ℓ-Rou
  open        SystemInitAndHandlers iiah
  open        ParamsWithInitAndHandlers iiah
  open import LibraBFT.ImplShared.Util.HashCollisions iiah
- open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms iiah PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+ open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms iiah PeerCanSignForPK
+                                (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
 
  record VoteForRound∈ (pk : PK)(round : ℕ)(epoch : ℕ)(bId : HashValue)(pool : SentMessages) : Set where
    constructor mkVoteForRound∈
@@ -53,8 +54,8 @@ module LibraBFT.Concrete.Properties.Common (iiah : SystemInitAndHandlers ℓ-Rou
                              → ∈GenInfo genInfo (_vSignature v1) → ∈GenInfo genInfo (_vSignature v2)
                              → v1 ^∙ vProposedId ≡ v2 ^∙ vProposedId
 
- ImplObl-NewVoteSignedAndRound≢0 : Set (ℓ+1 ℓ-RoundManager)
- ImplObl-NewVoteSignedAndRound≢0 =
+ ImplObl-NewVoteRound≢0 : Set (ℓ+1 ℓ-RoundManager)
+ ImplObl-NewVoteRound≢0 =
    ∀{pid s' outs pk}{pre : SystemState}
    → ReachableSystemState pre
    -- For any honest call to /handle/ or /init/,
@@ -87,9 +88,10 @@ module LibraBFT.Concrete.Properties.Common (iiah : SystemInitAndHandlers ℓ-Rou
      ⊎ VoteForRound∈ pk (v ^∙ vRound) (v ^∙ vEpoch) (v ^∙ vProposedId) (msgPool pre)
 
  module ConcreteCommonProperties
-        (st : SystemState)
-        (r  : ReachableSystemState st)
-        (Impl-gvr : ImplObl-genVotesRound≡0)
+        (st         : SystemState)
+        (r          : ReachableSystemState st)
+        (Impl-gvr   : ImplObl-genVotesRound≡0)
+        (Impl-nvr≢0 : ImplObl-NewVoteRound≢0)
    where
 
    open PerReachableState r
@@ -105,8 +107,7 @@ module LibraBFT.Concrete.Properties.Common (iiah : SystemInitAndHandlers ℓ-Rou
 
     -- If a Vote signed for an honest PK has been sent, and it is not in genInfo, then
     -- it is for a round > 0
-    -- TODO-1: prove using Impl-v≢0
-   postulate
+   postulate -- TODO-1: prove using Impl-nvr≢0
       NewVoteRound≢0 : ∀ {pk round epoch bId} {st : SystemState}
                      → ReachableSystemState st
                      → Meta-Honest-PK pk

--- a/LibraBFT/Concrete/Properties/PreferredRound.agda
+++ b/LibraBFT/Concrete/Properties/PreferredRound.agda
@@ -101,6 +101,7 @@ module LibraBFT.Concrete.Properties.PreferredRound (iiah : SystemInitAndHandlers
  module Proof
    (sps-corr : StepPeerState-AllValidParts)
    (Impl-gvr : ImplObl-genVotesRound≡0)
+   (Impl-nvr≢0 : ImplObl-NewVoteRound≢0)
    (Impl-∈GI? : (sig : Signature) → Dec (∈GenInfo genInfo sig))
    (Impl-IRO : IncreasingRoundObligation)
    (Impl-PR1 : ImplObligation₁)
@@ -108,13 +109,13 @@ module LibraBFT.Concrete.Properties.PreferredRound (iiah : SystemInitAndHandlers
    where
   -- Any reachable state satisfies the PR rule for any epoch in the system.
   module _ (st : SystemState)(r : ReachableSystemState st) where
-   -- Bring in 'unwind', 'ext-unforgeability' and friends
+   -- Bring in newMsg⊎msgSentB4
    open Structural sps-corr
    -- Bring in intSystemState
    open        PerState st
    open        PerReachableState r
    open        PerEpoch 𝓔
-   open        ConcreteCommonProperties st r Impl-gvr
+   open        ConcreteCommonProperties st r Impl-gvr Impl-nvr≢0
 
 
    α-ValidVote-trans : ∀ {pk mbr vabs pool} (v : Vote)

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -84,13 +84,13 @@ module LibraBFT.Concrete.Properties.VotesOnce (iiah : SystemInitAndHandlers ℓ-
 
  -- Next, we prove that, given the necessary obligations,
  module Proof
-   (sps-corr : StepPeerState-AllValidParts)
-   (Impl-gvc : ImplObl-genVotesConsistent)
-   (Impl-gvr : ImplObl-genVotesRound≡0)
-   (Impl-v≢0 : ImplObl-NewVoteSignedAndRound≢0)
-   (Impl-∈GI? : (sig : Signature) → Dec (∈GenInfo genInfo sig))
-   (Impl-IRO : IncreasingRoundObligation)
-   (Impl-VO2 : ImplObligation₂)
+   (sps-corr   : StepPeerState-AllValidParts)
+   (Impl-gvc   : ImplObl-genVotesConsistent)
+   (Impl-gvr   : ImplObl-genVotesRound≡0)
+   (Impl-nvr≢0 : ImplObl-NewVoteRound≢0)
+   (Impl-∈GI?  : (sig : Signature) → Dec (∈GenInfo genInfo sig))
+   (Impl-IRO   : IncreasingRoundObligation)
+   (Impl-VO2   : ImplObligation₂)
    where
 
   -- Any reachable state satisfies the VO rule for any epoch in the system.
@@ -101,7 +101,7 @@ module LibraBFT.Concrete.Properties.VotesOnce (iiah : SystemInitAndHandlers ℓ-
    open PerState st
    open PerReachableState r
    open PerEpoch 𝓔
-   open ConcreteCommonProperties st r Impl-gvr
+   open ConcreteCommonProperties st r Impl-gvr Impl-nvr≢0
 
    open import LibraBFT.Concrete.Obligations.VotesOnce 𝓔 (ConcreteVoteEvidence 𝓔) as VO
 

--- a/LibraBFT/ImplFake/Handle/Properties.agda
+++ b/LibraBFT/ImplFake/Handle/Properties.agda
@@ -176,7 +176,6 @@ module LibraBFT.ImplFake.Handle.Properties where
                                → v ⊂Msg m → send m ∈ outs → (sig : WithVerSig pk v)
                                → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
                                → v ^∙ vEpoch ≡ (_rmEC (peerStates pre pid)) ^∙ rmEpoch
-                               × suc ((_rmEC (peerStates pre pid)) ^∙ rmLastVotedRound) ≡ v ^∙ vRound  -- New vote for higher round than last voted
                                × v ^∙ vRound ≡ ((_rmEC s') ^∙ rmLastVotedRound)     -- Last voted round is round of new vote
   newVoteSameEpochGreaterRound {pre = pre} {pid} {v = v} {m} {pk} r (step-msg {(_ , P pm)} msg∈pool pinit) ¬init hpk v⊂m m∈outs sig vnew
      rewrite pinit
@@ -189,7 +188,7 @@ module LibraBFT.ImplFake.Handle.Properties where
        -- VoteMsg sent comprises QCs from the peer's state.  Votes represented in
        -- those QCS have signatures that have been sent before, contradicting the
        -- assumption that v's signature has not been sent before.
-  ...| vote∈vm {si} = refl , refl , refl
+  ...| vote∈vm {si} = refl , refl
   ...| vote∈qc {vs = vs} {qc} vs∈qc v≈rbld (inV qc∈m)
                   rewrite cong _vSignature v≈rbld
     with qcVotesSentB4 r pinit (VoteMsgQCsFromRoundManager r (step-msg msg∈pool pinit) hpk v⊂m (here refl) qc∈m) vs∈qc ¬init

--- a/LibraBFT/ImplFake/Properties/VotesOnce.agda
+++ b/LibraBFT/ImplFake/Properties/VotesOnce.agda
@@ -90,7 +90,7 @@ module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
   ...| eids≡
      with newVoteSameEpochGreaterRound r hstep (¬subst ¬init (msgSameSig mws)) hpk (msg⊆ mws) nm∈outs (msgSigned mws)
                                                (¬subst ¬sentb4 (msgSameSig mws))
-  ...| refl , refl , newlvr
+  ...| refl , newlvr
      with StepPeer-post-lemma pstep
   ...| post≡ = r , ¬sentb4 , mkCarrier (step-s r (step-peer (step-honest hstep)))
                                        mws
@@ -143,10 +143,6 @@ module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
   -- they contain will be from GenesisInfo.
   vo₁ {pid} {pk = pk} {pre = pre} r sm@(step-msg {(_ , nm)} m∈pool pidini)
       {m = m} {v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 vspk v'⊂m' m'∈pool sig' ¬init' refl
-     with msgsToSendWereSent {pid} {nm} m∈outs
-  ...| _ , vm , _ , _
-     with newVoteSameEpochGreaterRound r (step-msg m∈pool pidini) ¬init hpk v⊂m m∈outs sig ¬sentb4
-  ...| eIds≡' , suclvr≡v'rnd , _
      -- Use unwind to find the step that first sent the signature for v', then Any-Step-elim to
      -- prove that going from the poststate of that step to pre results in a state in which the
      -- round of v' is at most the last voted round recorded in the peerState of the peer that
@@ -177,20 +173,14 @@ module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
                                                     (trans (pk≡ (pcs4in𝓔 vpf'')) (sym (pk≡ (pcs4in𝓔 vpb))))))
                             (nid≡ (pcs4in𝓔 vpb))))
 
-  vo₁ {pid} {pk = pk} {pre = pre} r sm@(step-msg m∈pool ps≡)
-      {v' = v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 vspk v'⊂m' m'∈pool sig' _ refl
-     | _ , _ , _ , refl
-     | eIds≡' , _ , refl
-     | mkCarrier r' mws ini vpf' preprop
-     | inj₂ refl
-     | yes refl
+  ...| yes refl -- Same peer sends both v and v'
+     with newVoteSameEpochGreaterRound r (step-msg m∈pool ini) ¬init hpk v⊂m m∈outs sig ¬sentb4
+  ...| eIds≡' , refl
+     with msgsToSendWereSent {pid} {nm} m∈outs
+  ...| _ , _ , _ , refl
      with preprop
   ...| inj₁ diffEpoch = ⊥-elim (diffEpoch eIds≡')
-  ...| inj₂ (sameEpoch , v'rnd≤lvr)
-                    -- So we have proved both that the round of v' is ≤ the lastVotedRound of
-                    -- the peer's state and that the round of v' is one greater than that value,
-                    -- which leads to a contradiction
-                    = inj₁ (s≤s v'rnd≤lvr)
+  ...| inj₂ (sameEpoch , v'rnd≤lvr) = inj₁ (s≤s v'rnd≤lvr)
 
   -- TODO-1: This proof should be refactored to reduce redundant reasoning about the two votes.  The
   -- newVoteSameEpochGreaterRound property uses similar reasoning.

--- a/LibraBFT/ImplFake/Properties/VotesOnce.agda
+++ b/LibraBFT/ImplFake/Properties/VotesOnce.agda
@@ -137,12 +137,11 @@ module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
               → LvrCarrier pk (signature v' unit) final
   fSE⇒rnd≤lvr hpk {theStep = step-peer (step-honest _)} (_ , _ , lvrc) step* = LvrCarrier-transp* lvrc step*
 
-  postulate
-    vo₁ : Common.IncreasingRoundObligation 𝓔
+  vo₁ : Common.IncreasingRoundObligation 𝓔
   -- Initialization doesn't send any messages at all so far; Agda figures that out so no proof
   -- required here.  In future it may send messages, but any verifiable Signatures for honest PKs
   -- they contain will be from GenesisInfo.
-{-  vo₁ {pid} {pk = pk} {pre = pre} r sm@(step-msg {(_ , nm)} m∈pool pidini)
+  vo₁ {pid} {pk = pk} {pre = pre} r sm@(step-msg {(_ , nm)} m∈pool pidini)
       {m = m} {v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 vspk v'⊂m' m'∈pool sig' ¬init' refl
      with msgsToSendWereSent {pid} {nm} m∈outs
   ...| _ , vm , _ , _
@@ -179,13 +178,9 @@ module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
                             (nid≡ (pcs4in𝓔 vpb))))
 
   vo₁ {pid} {pk = pk} {pre = pre} r sm@(step-msg m∈pool ps≡)
-<<<<<<< HEAD:LibraBFT/Impl/Properties/VotesOnce.agda
       {v' = v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 vspk v'⊂m' m'∈pool sig' _ refl
-=======
-      {v' = v'} hpk v⊂m m∈outs sig ¬init ¬sentb4 v'⊂m' m'∈pool sig' _ refl rnds≡
->>>>>>> mainUpstream:LibraBFT/ImplFake/Properties/VotesOnce.agda
-     | _ , vm , _ , _
-     | eIds≡' , suclvr≡v'rnd , _
+     | _ , _ , _ , refl
+     | eIds≡' , _ , refl
      | mkCarrier r' mws ini vpf' preprop
      | inj₂ refl
      | yes refl
@@ -195,12 +190,10 @@ module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
                     -- So we have proved both that the round of v' is ≤ the lastVotedRound of
                     -- the peer's state and that the round of v' is one greater than that value,
                     -- which leads to a contradiction
-                    = inj₁ {!!} --⊥-elim (1+n≰n (≤-trans (≤-reflexive suclvr≡v'rnd)
-                                           --  (≤-trans (≤-reflexive rnds≡) v'rnd≤lvr)))
+                    = inj₁ (s≤s v'rnd≤lvr)
 
   -- TODO-1: This proof should be refactored to reduce redundant reasoning about the two votes.  The
   -- newVoteSameEpochGreaterRound property uses similar reasoning.
--}
 
   vo₂ : VO.ImplObligation₂ 𝓔
   vo₂ {pid = pid} {pk = pk} {pre = pre} r (step-msg {_ , nm} m∈pool pinit) {v = v} {m}


### PR DESCRIPTION
This PR applies a few minor changes resulting from the review of #43, and also reinstates and fixes the previously  broken proof for `FakeImpl.Properties.VotesOnce.vo₁`.