### PR TITLE
Establish `Either`, `Left` and `Right` as aliases for `⊎`, `inj₁` and `inj₂` to enable more faithful model of Haskell code

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -21,8 +21,8 @@ module LibraBFT.Impl.Consensus.BlockStorage.BlockStore where
 open RWST-do
 
 postulate
-  executeAndInsertBlockM : Block → LBFT (FakeErr ⊎ ExecutedBlock)
-  insertTimeoutCertificateM : TimeoutCertificate → LBFT (FakeErr ⊎ Unit)
+  executeAndInsertBlockM : Block → LBFT (Either FakeErr ExecutedBlock)
+  insertTimeoutCertificateM : TimeoutCertificate → LBFT (Either FakeErr Unit)
   getBlock : ∀ {𝓔 : EpochConfig} → HashValue → BlockStore 𝓔 → Maybe ExecutedBlock
   getQuorumCertForBlock : ∀ {𝓔 : EpochConfig} → HashValue → BlockStore 𝓔 → Maybe QuorumCert
   syncInfoM : LBFT SyncInfo

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -22,4 +22,4 @@ module LibraBFT.Impl.Consensus.BlockStorage.SyncManager where
 open RWST-do
 
 postulate
-  insertQuorumCertM : QuorumCert → BlockRetriever → LBFT (ErrLog ⊎ Unit)
+  insertQuorumCertM : QuorumCert → BlockRetriever → LBFT (Either ErrLog Unit)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
@@ -13,5 +13,5 @@ open import Optics.All
 module LibraBFT.Impl.Consensus.ConsensusTypes.Block where
 
 postulate
-  validateSignature : Block → ValidatorVerifier → FakeErr ⊎ Unit
+  validateSignature : Block → ValidatorVerifier → Either FakeErr Unit
 

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
@@ -13,5 +13,5 @@ open import Optics.All
 module LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert where
 
 postulate
-  verify : QuorumCert → ValidatorVerifier → ErrLog ⊎ Unit
+  verify : QuorumCert → ValidatorVerifier → Either ErrLog Unit
 

--- a/LibraBFT/Impl/Consensus/Network.agda
+++ b/LibraBFT/Impl/Consensus/Network.agda
@@ -15,4 +15,4 @@ open import Optics.All
 module LibraBFT.Impl.Consensus.Network where
 
   postulate  -- TODO-1: implement this
-    processProposal : {- NodeId → -} ProposalMsg → Epoch → ValidatorVerifier → (FakeErr ⊎ FakeInfo) ⊎ Unit
+    processProposal : {- NodeId → -} ProposalMsg → Epoch → ValidatorVerifier → (Either FakeErr FakeInfo) ⊎ Unit

--- a/LibraBFT/Impl/Consensus/PersistentLivenessStorage.agda
+++ b/LibraBFT/Impl/Consensus/PersistentLivenessStorage.agda
@@ -17,4 +17,4 @@ open RWST-do
 
 -- TODO-3?: Implement this
 postulate
-  saveVoteM : Vote → LBFT (FakeErr ⊎ Unit)
+  saveVoteM : Vote → LBFT (Either FakeErr Unit)

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -248,8 +248,8 @@ addVoteM now vote = do
 
 newQcAggregatedM now qc a =
   SyncManager.insertQuorumCertM qc (BlockRetriever∙new now a) >>= λ where
-    (inj₁ e)    → logErr -- TODO : Haskell logs err and returns ().  Do we need to return error?
-    (inj₂ unit) → processCertificatesM now
+    (Left e)     → logErr -- TODO : Haskell logs err and returns ().  Do we need to return error?
+    (Right unit) → processCertificatesM now
 
 newTcAggregatedM now tc =
   BlockStore.insertTimeoutCertificateM tc >>= λ where

--- a/LibraBFT/Impl/Consensus/Types/PendingVotes.agda
+++ b/LibraBFT/Impl/Consensus/Types/PendingVotes.agda
@@ -50,11 +50,11 @@ insertVoteM vote vv = do
                                  (Map.lookup liDigest (pv ^∙ pvLiDigestToVotes)))
     lPendingVotes ∙ pvLiDigestToVotes %= Map.kvm-insert-Haskell liDigest liWithSig
     case ValidatorVerifier.checkVotingPower vv (Map.kvm-keys (liWithSig ^∙ liwsSignatures)) of λ where
-      (inj₂ unit) →
+      (Right unit) →
         pure (NewQuorumCertificate (QuorumCert∙new (vote ^∙ vVoteData) liWithSig))
-      (inj₁ (TooLittleVotingPower votingPower _)) →
+      (Left (TooLittleVotingPower votingPower _)) →
         continue2 votingPower
-      (inj₁ _) →
+      (Left _) →
         pure VRR_TODO
 
   continue2 qcVotingPower =
@@ -66,11 +66,11 @@ insertVoteM vote vv = do
                                      (pv ^∙ pvMaybePartialTC))
         lPendingVotes ∙ pvMaybePartialTC %= const (just partialTc)
         case ValidatorVerifier.checkVotingPower vv (Map.kvm-keys (partialTc ^∙ tcSignatures)) of λ where
-          (inj₂ unit) →
+          (Right unit) →
             pure (NewTimeoutCertificate partialTc)
-          (inj₁ (TooLittleVotingPower votingPower _)) →
+          (Left (TooLittleVotingPower votingPower _)) →
             pure (TCVoteAdded votingPower)
-          (inj₁ _) →
+          (Left _) →
             pure VRR_TODO
       nothing →
         pure (QCVoteAdded qcVotingPower)

--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -31,9 +31,9 @@ module LibraBFT.Impl.IO.OBM.InputOutputHandlers where
   handleProposal now pm = do
     (myEpoch , vv) ← epvv
     case Network.processProposal pm myEpoch vv of λ where
-      (inj₁ (inj₁ _)) → logErr
-      (inj₁ (inj₂ _)) → logInfo
-      (inj₂ _)        → RoundManager.processProposalMsgM now pm
+      (Left (Left _)) → logErr
+      (Left (Right _)) → logInfo
+      (Right _)        → RoundManager.processProposalMsgM now pm
 
   handle : NodeId → NetworkMsg → Instant → LBFT Unit
   handle _self msg now =

--- a/LibraBFT/Impl/Types/ValidatorVerifier.agda
+++ b/LibraBFT/Impl/Types/ValidatorVerifier.agda
@@ -14,17 +14,17 @@ module LibraBFT.Impl.Types.ValidatorVerifier where
 
 getVotingPower : ValidatorVerifier → AccountAddress → Maybe U64
 
-checkVotingPower : ValidatorVerifier → List AccountAddress → VerifyError ⊎ Unit
+checkVotingPower : ValidatorVerifier → List AccountAddress → Either VerifyError Unit
 checkVotingPower self authors = loop authors 0
  where
-  loop : List AccountAddress → U64 → VerifyError ⊎ Unit
+  loop : List AccountAddress → U64 → Either VerifyError Unit
   loop (a ∷ as) acc = case getVotingPower self a of λ where
-                        nothing  → inj₁ (UnknownAuthor (a ^∙ aAuthorName))
+                        nothing  → Left (UnknownAuthor (a ^∙ aAuthorName))
                         (just n) → loop as (n + acc)
   loop [] aggregatedVotingPower =
     if-dec aggregatedVotingPower <? self ^∙ vvQuorumVotingPower
-    then inj₁ (TooLittleVotingPower aggregatedVotingPower (self ^∙ vvQuorumVotingPower))
-    else inj₂ unit
+    then Left (TooLittleVotingPower aggregatedVotingPower (self ^∙ vvQuorumVotingPower))
+    else Right unit
 
 getVotingPower self author =
 --  (λ a → a ^∙ vciVotingPower) <$> (Map.lookup author (self ^∙ vvAddressToValidatorInfo))

--- a/LibraBFT/ImplShared/Util/RWST.agda
+++ b/LibraBFT/ImplShared/Util/RWST.agda
@@ -102,11 +102,11 @@ module LibraBFT.ImplShared.Util.RWST (ℓ-State : Level) where
   ask : RWST Ev Wr St Ev
   ask = rwst (λ ev st → (ev , st , []))
 
-  ok : ∀ {B : Set ℓ-B} → A → RWST Ev Wr St (B ⊎ A)
-  ok = RWST-return ∘ inj₂
+  ok : ∀ {B : Set ℓ-B} → A → RWST Ev Wr St (Either B A)
+  ok = RWST-return ∘ Right
 
-  bail : B → RWST Ev Wr St (B ⊎ A)
-  bail = RWST-return ∘ inj₁
+  bail : B → RWST Ev Wr St (Either B A)
+  bail = RWST-return ∘ Left
 
   -- Easy to use do notation; i.e.;
   module RWST-do where
@@ -162,18 +162,18 @@ module LibraBFT.ImplShared.Util.RWST (ℓ-State : Level) where
     where open RWST-do
 
   infixl 4 _∙?∙_
-  _∙?∙_ : RWST Ev Wr St (C ⊎ A) → (A → RWST Ev Wr St (C ⊎ B)) → RWST Ev Wr St (C ⊎ B)
+  _∙?∙_ : RWST Ev Wr St (Either C A) → (A → RWST Ev Wr St (Either C B)) → RWST Ev Wr St (Either C B)
   m ∙?∙ f = do
     r ← m
     case r of λ where
-      (inj₁ c) → pure (inj₁ c)
-      (inj₂ a) → f a
+      (Left c) → pure (Left c)
+      (Right a) → f a
     where open RWST-do
 
-  _∙^∙_ : RWST Ev Wr St (B ⊎ A) → (B → B) → RWST Ev Wr St (B ⊎ A)
+  _∙^∙_ : RWST Ev Wr St (Either A B) → (A → A) → RWST Ev Wr St (Either A B)
   m ∙^∙ f = do
     x ← m
     case x of λ where
-      (inj₁ e) → pure (inj₁ (f e))
-      (inj₂ r) → pure (inj₂ r)
+      (Left  e) → pure (Left (f e))
+      (Right r) → pure (Right r)
     where open RWST-do

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -100,15 +100,6 @@ module LibraBFT.Lemmas where
  _ : Maybe-map toℕ (List-index _≟_ 4 (nats 4)) ≡ nothing
  _ = refl
 
- -- TODO-2: There's probably something equivalent in the standard library
- ⊎-elimˡ : ∀ {ℓ₀ ℓ₁}{A₀ : Set ℓ₀}{A₁ : Set ℓ₁} → ¬ A₀ → A₀ ⊎ A₁ → A₁
- ⊎-elimˡ _  (inj₂ a) = a
- ⊎-elimˡ ¬a (inj₁ a) = ⊥-elim (¬a a)
-
- ⊎-elimʳ : ∀ {ℓ₀ ℓ₁}{A₀ : Set ℓ₀}{A₁ : Set ℓ₁} → ¬ A₁ → A₀ ⊎ A₁ → A₀
- ⊎-elimʳ _  (inj₁ a) = a
- ⊎-elimʳ ¬a (inj₂ a) = ⊥-elim (¬a a)
-
  allDistinct : ∀ {A : Set} → List A → Set
  allDistinct l = ∀ (i j : Σ ℕ (_< length l)) →
                    proj₁ i ≡ proj₁ j

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -279,6 +279,12 @@ module LibraBFT.Prelude where
   (inj₁ x) ⊎⟫= _ = inj₁ x
   (inj₂ a) ⊎⟫= f = f a
 
+  -- Syntactic support for more faithful model of Haskell code
+  Either : ∀ {a b} → Set a → Set b → Set (a ℓ⊔ b)
+  Either A B = A ⊎ B
+  pattern Left  x = inj₁ x
+  pattern Right x = inj₂ x
+
   -- TODO-1: Maybe this belongs somewhere else?  It's in a similar
   -- category as Optics, so maybe should similarly be in a module that
   -- is separate from the main project?

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -17,6 +17,13 @@ module LibraBFT.Prelude where
   open import Agda.Builtin.Unit
     public
 
+  open import Function
+    using (_∘_; id; case_of_; _on_; typeOf; flip; const; _∋_)
+    public
+
+  infixl 1 _&_
+  _&_ = Function._|>_
+
   open import Data.Unit.NonEta
     public
 
@@ -163,7 +170,6 @@ module LibraBFT.Prelude where
     renaming (cong to ≅-cong; cong₂ to ≅-cong₂)
     public
 
-
   open import Relation.Binary
     public
 
@@ -174,6 +180,14 @@ module LibraBFT.Prelude where
                    → to-witness x ≡ a → f ≡ just a
   to-witness-lemma (just x) refl = refl
 
+  open import Relation.Nullary
+    hiding (Irrelevant; proof)
+    public
+
+  open import Relation.Nullary.Decidable
+    hiding (map)
+    public
+
   open import Data.Sum
     renaming ([_,_] to either; map to ⊎-map; map₂ to ⊎-map₂)
     public
@@ -182,12 +196,11 @@ module LibraBFT.Prelude where
     using (inj₁-injective ; inj₂-injective)
     public
 
-  open import Function
-    using (_∘_; id; case_of_; _on_; typeOf; flip; const; _∋_)
-    public
+  ⊎-elimˡ : ∀ {ℓ₀ ℓ₁}{A₀ : Set ℓ₀}{A₁ : Set ℓ₁} → ¬ A₀ → A₀ ⊎ A₁ → A₁
+  ⊎-elimˡ ¬a = either (⊥-elim ∘ ¬a) id
 
-  infixl 1 _&_
-  _&_ = Function._|>_
+  ⊎-elimʳ : ∀ {ℓ₀ ℓ₁}{A₀ : Set ℓ₀}{A₁ : Set ℓ₁} → ¬ A₁ → A₀ ⊎ A₁ → A₀
+  ⊎-elimʳ ¬a = either id (⊥-elim ∘ ¬a)
 
   open import Data.Product
     renaming (map to ×-map; map₂ to ×-map₂; map₁ to ×-map₁; <_,_> to split; swap to ×-swap)
@@ -195,14 +208,6 @@ module LibraBFT.Prelude where
     public
 
   open import Data.Product.Properties
-    public
-
-  open import Relation.Nullary
-    hiding (Irrelevant; proof)
-    public
-
-  open import Relation.Nullary.Decidable
-    hiding (map)
     public
 
   infix 4 _<?ℕ_


### PR DESCRIPTION
This PR enables us to use `Either`, `Left` and `Right` in Agda so that we can model Haskell code more faithfully.

It also restates `⊎-elim*` in terms of functions available in the standard library; this required a little reordering in `LibraBFT.Prelude`.

Thanks @cwjnkins for the input.