### PR TITLE
Chris monad and eq instances

### DIFF
--- a/LibraBFT/Impl/Consensus/ConsensusTypes/ProposalMsg.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/ProposalMsg.agda
@@ -1,0 +1,17 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+open import LibraBFT.Base.Types
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.ConsensusTypes.ProposalMsg where
+
+
+postulate
+  verify : ProposalMsg → ValidatorVerifier → Either FakeErr Unit

--- a/LibraBFT/Impl/Consensus/Network.agda
+++ b/LibraBFT/Impl/Consensus/Network.agda
@@ -9,10 +9,26 @@ open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.NetworkMsg
 open import LibraBFT.ImplShared.Util.Util
+import      LibraBFT.Impl.Consensus.ConsensusTypes.ProposalMsg as ProposalMsg
+open import LibraBFT.Impl.OBM.Util
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Consensus.Network where
 
-  postulate  -- TODO-1: implement this
-    processProposal : {- NodeId → -} ProposalMsg → Epoch → ValidatorVerifier → (Either FakeErr FakeInfo) ⊎ Unit
+processProposal : {- NodeId → -} ProposalMsg → Epoch → ValidatorVerifier → (Either FakeErr FakeInfo) ⊎ Unit
+processProposal {- peerId -} proposal myEpoch vv =
+  case pProposal of λ where
+    (Left e) → Left (Left e)
+    (Right unit) →
+      grd‖ proposal ^∙ pmProposal ∙ bEpoch == myEpoch ≔
+           return unit
+         -- TODO : push this onto a queue if epoch is in future (is this still relevant?)
+         ‖ proposal ^∙ pmProposal ∙ bEpoch == myEpoch + 1 ≔
+           Left (Right fakeInfo) -- proposal in new epoch arrived before my epoch change
+         ‖ otherwise≔
+           Left (Left fakeErr)   -- proposal for wrong epoch
+  where
+  pProposal = do
+    ProposalMsg.verify proposal vv
+    {- lcheck (proposal ^∙ pmProposal ∙ bAuthor == just peerId) -}

--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -30,7 +30,7 @@ module LibraBFT.Impl.IO.OBM.InputOutputHandlers where
   handleProposal : Instant → ProposalMsg → LBFT Unit
   handleProposal now pm = do
     (myEpoch , vv) ← epvv
-    case Network.processProposal pm myEpoch vv of λ where
+    case Network.processProposal {- {!!} -} pm myEpoch vv of λ where
       (Left (Left _)) → logErr
       (Left (Right _)) → logInfo
       (Right _)        → RoundManager.processProposalMsgM now pm

--- a/LibraBFT/Impl/OBM/Util.agda
+++ b/LibraBFT/Impl/OBM/Util.agda
@@ -1,0 +1,15 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.Prelude
+
+module LibraBFT.Impl.OBM.Util where
+
+lcheck : ∀ {ℓ} {A : Set ℓ} ⦃ _ : ToBool A ⦄ → A → {- List String → -} Either FakeErr Unit
+lcheck b {- t -} = case check (toBool b) [] of λ where
+  (Left e)  → Left fakeErr
+  (Right r) → Right r

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -352,4 +352,22 @@ module LibraBFT.Prelude where
   f-sum : ∀{a}{A : Set a} → (A → ℕ) → List A → ℕ
   f-sum f = sum ∘ List-map f
 
+  record Monad {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
+    infixl 1 _>>=_ _>>_
+    field
+      return : ∀ {A : Set ℓ₁} → A → M A
+      _>>=_  : ∀ {A B : Set ℓ₁} → M A → (A → M B) → M B
+
+    _>>_ : ∀ {A B : Set ℓ₁} → M A → M B → M B
+    m₁ >> m₂ = m₁ >>= λ _ → m₂
+
+  open Monad ⦃ ... ⦄ public
+
+  open import Category.Monad
+  import      Data.Sum.Categorical.Left
+  instance
+    Monad-Error : ∀ {ℓ}{C : Set ℓ} → Monad{ℓ}{ℓ} (Either C)
+    Monad.return (Monad-Error{ℓ}{C}) = RawMonad.return (Data.Sum.Categorical.Left.monad C ℓ)
+    Monad._>>=_ (Monad-Error{ℓ}{C}) = RawMonad._>>=_ (Data.Sum.Categorical.Left.monad C ℓ)
+
   open import LibraBFT.Base.Util public

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -290,6 +290,32 @@ module LibraBFT.Prelude where
   pattern Left  x = inj₁ x
   pattern Right x = inj₂ x
 
+  open import Data.String as String
+    hiding (_==_)
+
+  check : Bool → List String → Either String Unit
+  check b t = if b then inj₂ unit else inj₁ (String.intersperse "; " t)
+
+  record Eq {ℓ : Level} (A : Set ℓ) : Set ℓ where
+    infix 4 _==_
+    field
+      _==_ : (a b : A) → Dec (a ≡ b)
+  open Eq ⦃ ... ⦄ public
+
+  instance
+    Eq-Nat : Eq ℕ
+    Eq._==_ Eq-Nat = _≟ℕ_
+
+    -- TODO-1: Data.Maybe.Relation.Binary.Pointwise
+    Eq-Maybe : ∀ {ℓ} {A : Set ℓ} ⦃ _ : Eq A ⦄ → Eq (Maybe A)
+    (Eq-Maybe Eq.== nothing) nothing = yes refl
+    (Eq-Maybe Eq.== nothing) (just x) = no λ where ()
+    (Eq-Maybe Eq.== just x) nothing = no λ where ()
+    (Eq-Maybe Eq.== just a) (just b)
+      with a == b
+    ... | no  proof = no (λ where refl → proof refl)
+    ... | yes proof = yes (cong just proof)
+
   -- TODO-1: Maybe this belongs somewhere else?  It's in a similar
   -- category as Optics, so maybe should similarly be in a module that
   -- is separate from the main project?


### PR DESCRIPTION
I have added some definitions to allow do-notation for all sorts of monads, and defined instances for `Either` and (the old) `RWST`. To demonstrate the need, I have implemented `processProposal` in `LibraBFT.Impl.Consensus.Network`.

Also, I have gone ahead and added an `Eq` record, opened with Agda's instance argument syntax, to allow writing `_==_` for equality tests. If we change the implementation such that `NetworkMsg` contains the sender of the message, this could be used to complete the definition of `processProposal` that follows the Haskell prototype closely (the code that would do this is currently commented out).