### PR TITLE
Overhaul the `RWST` monad and add support for reasoning with Dijkstra's weakest precondition calculus.

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -18,8 +18,6 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.BlockStorage.BlockStore where
 
-open RWST-do
-
 postulate
   executeAndInsertBlockM : Block → LBFT (Either FakeErr ExecutedBlock)
   insertTimeoutCertificateM : TimeoutCertificate → LBFT (Either FakeErr Unit)

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -19,7 +19,5 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.BlockStorage.SyncManager where
 
-open RWST-do
-
 postulate
   insertQuorumCertM : QuorumCert → BlockRetriever → LBFT (Either ErrLog Unit)

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -20,4 +20,4 @@ open import Optics.All
 module LibraBFT.Impl.Consensus.BlockStorage.SyncManager where
 
 postulate
-  insertQuorumCertM : QuorumCert → BlockRetriever → LBFT (Either ErrLog Unit)
+  insertQuorumCertM : QuorumCert → BlockRetriever → LBFT (Either FakeErr Unit)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
@@ -13,5 +13,5 @@ open import Optics.All
 module LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert where
 
 postulate
-  verify : QuorumCert → ValidatorVerifier → Either ErrLog Unit
+  verify : QuorumCert → ValidatorVerifier → Either FakeErr Unit
 

--- a/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
@@ -13,8 +13,6 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.Liveness.ProposerElection where
 
-open RWST-do
-
 postulate
   getValidProposer : ProposerElection → Round → Author
 

--- a/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
@@ -20,7 +20,7 @@ isValidProposerM : Author → Round → LBFT Bool
 isValidProposer : ProposerElection → Author → Round → Bool
 
 isValidProposalM : Block → LBFT Bool
-isValidProposalM b = maybeS (b ^∙ bAuthor) (pure false) (λ a → isValidProposerM a (b ^∙ bRound))
+isValidProposalM b = maybeS-RWST (b ^∙ bAuthor) (pure false) (λ a → isValidProposerM a (b ^∙ bRound))
 
 isValidProposerM a r = isValidProposer <$> use lProposerElection <*> pure a <*> pure r
 

--- a/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
@@ -21,8 +21,6 @@ open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
 module LibraBFT.Impl.Consensus.Liveness.RoundState where
 
-open RWST-do
-
 ------------------------------------------------------------------------------
 
 processCertificatesM : Instant → SyncInfo → LBFT (Maybe NewRoundEvent)

--- a/LibraBFT/Impl/Consensus/PersistentLivenessStorage.agda
+++ b/LibraBFT/Impl/Consensus/PersistentLivenessStorage.agda
@@ -13,8 +13,6 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.PersistentLivenessStorage where
 
-open RWST-do
-
 -- TODO-3?: Implement this
 postulate
   saveVoteM : Vote → LBFT (Either FakeErr Unit)

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -30,8 +30,6 @@ open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
 module LibraBFT.Impl.Consensus.RoundManager where
 
-open RWST-do
-
 ------------------------------------------------------------------------------
 
 processCommitM : LedgerInfoWithSignatures → LBFT (List ExecutedBlock)

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -54,23 +54,19 @@ module processProposalMsgM (now : Instant) (pm : ProposalMsg) where
   step₂ : Either FakeErr Bool → LBFT Unit
 
   step₀ =
-    case pm ^∙ pmProposer of λ where
+    caseMM pm ^∙ pmProposer of λ where
       nothing → logInfo -- log: info: proposal with no author
       (just pAuthor) → step₁ pAuthor
   step₁ pAuthor =
         ensureRoundAndSyncUpM now (pm ^∙ pmProposal ∙ bRound) (pm ^∙ pmSyncInfo)
                               pAuthor true >>= step₂
-  step₂ r =
-        -- IMPL-DIFF: We use `ifM` to test whether the round of the proposal is
-        -- current, to take advantage of the obligations `RWST-weakestPre` generates.
-        case r of λ where
-        (Left _) → logErr -- log: error: <propagate error>
-        (Right pmCurrent) →
-          if pmCurrent
-            then processProposalM (pm ^∙ pmProposal)
-            else do
-              currentRound ← use (lRoundState ∙ rsCurrentRound)
-              logInfo  -- log: info: dropping proposal for old round
+  step₂ =
+        λ where
+          (Left e)      → logErr -- log: error: <propagate error>
+          (Right true)  → processProposalM (pm ^∙ pmProposal)
+          (Right false) → do
+            currentRound ← use (lRoundState ∙ rsCurrentRound)
+            logInfo              -- log: info: dropping proposal for old round
 
 processProposalMsgM = processProposalMsgM.step₀
 
@@ -90,14 +86,14 @@ module ensureRoundAndSyncUpM
 
   step₀ = do
     currentRound ← use (lRoundState ∙ rsCurrentRound)
-    if ⌊ messageRound <? currentRound ⌋
+    ifM messageRound <? currentRound
       then ok false
       else step₁
   step₁ =
         syncUpM now syncInfo author helpRemote ∙?∙ λ _ → step₂
   step₂ = do
           currentRound' ← use (lRoundState ∙ rsCurrentRound)
-          if not ⌊ messageRound ≟ℕ currentRound' ⌋
+          ifM not ⌊ messageRound ≟ℕ currentRound' ⌋
             then bail fakeErr -- error: after sync, round does not match local
             else ok true
 
@@ -119,8 +115,7 @@ module ProcessProposalM (proposal : Block) where
   step₀ : LBFT Unit
   step₁ : ∀ {pre} → BlockStore (α-EC-RM pre) → Bool → LBFT Unit
   step₂ : Either FakeErr Vote → LBFT Unit
-  step₃ : Vote → LBFT Unit
-  step₄ : Vote → SyncInfo → LBFT Unit
+  step₃ : Vote → SyncInfo → LBFT Unit
 
   step₀ = do
     s ← get  -- IMPL-DIFF: see comment NO-DEPENDENT-LENSES
@@ -128,7 +123,7 @@ module ProcessProposalM (proposal : Block) where
     vp ← ProposerElection.isValidProposalM proposal
     step₁ {s} bs vp
   step₁ bs vp =
-    grd‖ is-nothing (proposal ^∙ bAuthor) ≔
+    ifM‖ is-nothing (proposal ^∙ bAuthor) ≔
          logErr -- log: error: proposal does not have an author
        ‖ not vp ≔
          logErr -- log: error: proposer for block is not valid for this round
@@ -139,25 +134,19 @@ module ProcessProposalM (proposal : Block) where
                 ⌊ parentBlock ^∙ ebRound <?ℕ proposal ^∙ bRound ⌋) ≔
          logErr -- log: error: parentBlock < proposalRound
        ‖ otherwise≔ do
-         -- DIFF: For the verification effort, we use special-purpose case
-         -- distinction operators, so the Haskell
-         -- > executeAndVoteM proposal >>= \case
-         -- is translated to the following.
            executeAndVoteM proposal >>= step₂
-  step₂ r =
-         case r of λ where
-           (Left _) → logErr -- <propagate error>
-           (Right vote) → step₃ vote
-  step₃ vote = do
-             RoundState.recordVote vote
-             si ← BlockStore.syncInfoM
-             step₄ vote si
-  step₄ vote si = do
-             recipient ← ProposerElection.getValidProposer
-                         <$> use lProposerElection
-                         <*> pure (proposal ^∙ bRound + 1)
-             act (SendVote (VoteMsg∙new vote si) (recipient ∷ []))
-             -- TODO-2:                                                mkNodesInOrder1 recipient
+  step₂ =  λ where
+             (Left _)     → logErr -- log: error: <propagate error>
+             (Right vote) → do
+               RoundState.recordVote vote
+               si ← BlockStore.syncInfoM
+               step₃ vote si
+  step₃ vote si = do
+               recipient ← ProposerElection.getValidProposer
+                           <$> use lProposerElection
+                           <*> pure (proposal ^∙ bRound + 1)
+               act (SendVote (VoteMsg∙new vote si) (recipient ∷ []))
+               -- TODO-2:                           mkNodesInOrder1 recipient
 
 processProposalM = ProcessProposalM.step₀
 
@@ -173,10 +162,10 @@ module ExecuteAndVoteM (b : Block) where
     cr ← use (lRoundState ∙ rsCurrentRound)
     vs ← use (lRoundState ∙ rsVoteSent)
     so ← use lSyncOnly
-    grd‖ is-just vs
-         ≔ bail fakeErr -- error: already voted this round
-       ‖ so
-         ≔ bail fakeErr -- error: sync-only set
+    ifM‖ is-just vs ≔
+         bail fakeErr -- error: already voted this round
+       ‖ so ≔
+         bail fakeErr -- error: sync-only set
        ‖ otherwise≔ step₂ eb
   step₂ eb = do
            let maybeSignedVoteProposal' = ExecutedBlock.maybeSignedVoteProposal eb
@@ -200,7 +189,7 @@ processVoteMsgM now voteMsg = do
   processVoteM now (voteMsg ^∙ vmVote)
 
 processVoteM now vote =
-  if not (Vote.isTimeout vote)
+  ifM not (Vote.isTimeout vote)
   then (do
     let nextRound = vote ^∙ vVoteData ∙ vdProposed ∙ biRound + 1
     -- IMPL-TODO pgAuthor
@@ -216,7 +205,7 @@ processVoteM now vote =
     let blockId = vote ^∙ vVoteData ∙ vdProposed ∙ biId
     s ← get  -- IMPL-DIFF: see comment NO-DEPENDENT-LENSES
     let bs = _epBlockStore (_rmWithEC s)
-    if true -- (is-just (BlockStore.getQuorumCertForBlock blockId {!!})) -- IMPL-TODO
+    ifM true -- (is-just (BlockStore.getQuorumCertForBlock blockId {!!})) -- IMPL-TODO
       then logInfo
       else addVoteM now vote -- TODO-1: logging
 

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -19,8 +19,6 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.SafetyRules.SafetyRules where
 
-open RWST-do
-
 postulate
   obmCheckSigner : SafetyRules → Bool
   extensionCheckM : VoteProposal → LBFT (Either FakeErr VoteData)

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -23,7 +23,6 @@ postulate
   obmCheckSigner : SafetyRules → Bool
   extensionCheckM : VoteProposal → LBFT (Either FakeErr VoteData)
   constructLedgerInfoM : Block → HashValue → LBFT (Either FakeErr LedgerInfo)
-  verifyQcM : QuorumCert → LBFT (Either FakeErr Unit)
 
 ------------------------------------------------------------------------------
 
@@ -40,10 +39,10 @@ verifyAndUpdatePreferredRoundM quorumCert safetyData = do
       twoChainRound  = quorumCert ^∙ qcParentBlock ∙ biRound
   -- LBFT-ALGO v3:p6: "... votes in round k only if the QC inside the k proposal
   -- is at least" PreferredRound."
-  if ⌊ oneChainRound <? preferredRound ⌋
+  ifM oneChainRound <? preferredRound
     then bail fakeErr -- error: incorrect preferred round, QC round does not match preferred round
     else do
-      updated ← grd‖ twoChainRound >? preferredRound ≔
+      updated ← ifM‖ twoChainRound >? preferredRound ≔
                      pure (safetyData & sdPreferredRound ∙~ twoChainRound) -- log: info: updated preferred round
                    ‖ twoChainRound <? preferredRound ≔
                      pure safetyData                                       -- log: info: 2-chain round is lower than preferred round, but 1-chain is higher
@@ -55,7 +54,7 @@ verifyAndUpdatePreferredRoundM quorumCert safetyData = do
 
 verifyEpochM : Epoch → SafetyData → LBFT (Either FakeErr Unit)
 verifyEpochM epoch safetyData =
-  if not ⌊ epoch ≟ℕ safetyData ^∙ sdEpoch ⌋
+  ifM not ⌊ epoch ≟ℕ safetyData ^∙ sdEpoch ⌋
     then bail fakeErr -- log: error: incorrect epoch
     else ok unit
 
@@ -65,9 +64,16 @@ verifyEpochM epoch safetyData =
 verifyAndUpdateLastVoteRoundM : Round → SafetyData → LBFT (Either FakeErr SafetyData)
 verifyAndUpdateLastVoteRoundM round safetyData =
   -- LBFT-ALGO v3:p6 : "... votes in round k it if is higher than" LastVotedRound
-  if ⌊ round >? (safetyData ^∙ sdLastVotedRound) ⌋
+  ifM round >? (safetyData ^∙ sdLastVotedRound)
     then ok (safetyData & sdLastVotedRound ∙~ round )
     else bail fakeErr -- log: error: incorrect last vote round
+
+------------------------------------------------------------------------------
+
+verifyQcM : QuorumCert → LBFT (Either FakeErr Unit)
+verifyQcM qc = do
+  validatorVerifier ← gets rmGetValidatorVerifier -- See DEPENDENT-LENSES-COMMENT
+  pure (QuorumCert.verify qc validatorVerifier)   -- TODO-1: withErrCtx
 
 ------------------------------------------------------------------------------
 
@@ -78,6 +84,9 @@ constructAndSignVoteM-continue2 : VoteProposal → ValidatorSigner →  Block �
 constructAndSignVoteM : MaybeSignedVoteProposal → LBFT (Either FakeErr Vote)
 constructAndSignVoteM maybeSignedVoteProposal = do
   vs ← use (lSafetyRules ∙ srValidatorSigner)
+  -- NOTE: It's OK to use `case` here, rather than `caseMM`, becase we are
+  -- splitting on /precisely/ the expression that is given to us by the
+  -- preceding bind.
   case vs of λ where
     nothing → bail fakeErr -- error: srValidatorSigner is nothing
     (just validatorSigner) → do
@@ -93,9 +102,9 @@ module constructAndSignVoteM-continue0 (voteProposal : VoteProposal) (validatorS
     safetyData0 ← use (lPersistentSafetyStorage ∙ pssSafetyData)
     verifyEpochM (proposedBlock ^∙ bEpoch) safetyData0 ∙?∙ λ _ → step₁ safetyData0
   step₁ safetyData0 = do
-      case (safetyData0 ^∙ sdLastVote) of λ where
+      caseMM (safetyData0 ^∙ sdLastVote) of λ where
         (just vote) →
-          if ⌊ vote ^∙ vVoteData ∙ vdProposed ∙ biRound ≟ℕ (proposedBlock ^∙ bRound) ⌋
+          ifM vote ^∙ vVoteData ∙ vdProposed ∙ biRound ≟ℕ (proposedBlock ^∙ bRound)
             then ok vote
             else constructAndSignVoteM-continue1 voteProposal validatorSigner proposedBlock safetyData0
         nothing → constructAndSignVoteM-continue1 voteProposal validatorSigner proposedBlock safetyData0

--- a/LibraBFT/Impl/Consensus/Types/PendingVotes.agda
+++ b/LibraBFT/Impl/Consensus/Types/PendingVotes.agda
@@ -18,8 +18,6 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.Types.PendingVotes where
 
-open RWST-do
-
 insertVoteM : Vote → ValidatorVerifier → LBFT VoteReceptionResult
 insertVoteM vote vv = do
   let liDigest = hashLI (vote ^∙ vLedgerInfo)

--- a/LibraBFT/Impl/Consensus/Types/PendingVotesSpec.agda
+++ b/LibraBFT/Impl/Consensus/Types/PendingVotesSpec.agda
@@ -24,8 +24,6 @@ open import Data.Vec as Vec using (Vec; lookup)
 
 module LibraBFT.Impl.Consensus.Types.PendingVotesSpec where
 
-open RWST-do
-
 gs : ∀ {A : Set} {n : ℕ} → Vec A n → Fin n → A
 gs = Vec.lookup
 

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -30,7 +30,6 @@ open import Optics.All
 -- below).
 
 module LibraBFT.Impl.Handle where
- open RWST-do
  open EpochConfig
 
  postulate -- TODO-1: reasonable assumption that some RoundManager exists, though we could prove

--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -28,8 +28,8 @@ module LibraBFT.Impl.IO.OBM.InputOutputHandlers where
   handleProposal : Instant → ProposalMsg → LBFT Unit
   handleProposal now pm = do
     (myEpoch , vv) ← epvv
-    case Network.processProposal pm myEpoch vv of λ where
-      (Left (Left _)) → logErr
+    caseM⊎ Network.processProposal {- {!!} -} pm myEpoch vv of λ where
+      (Left (Left _))  → logErr
       (Left (Right _)) → logInfo
       (Right _)        → RoundManager.processProposalMsgM now pm
 

--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -21,8 +21,6 @@ open import Optics.All
 
 module LibraBFT.Impl.IO.OBM.InputOutputHandlers where
 
-  open RWST-do
-
   epvv : LBFT (Epoch × ValidatorVerifier)
   epvv = _,_ <$> gets (_^∙ rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch ∘ _rmEC)
              <*> gets (_^∙ rmEpochState ∙ esVerifier ∘ _rmEC)

--- a/LibraBFT/Impl/OBM/Logging/Logging.agda
+++ b/LibraBFT/Impl/OBM/Logging/Logging.agda
@@ -12,8 +12,6 @@ open import LibraBFT.Prelude
 
 module LibraBFT.Impl.OBM.Logging.Logging where
 
-  open RWST-do
-
   logErr : LBFT Unit
   logErr = tell1 (LogErr fakeErr)
 

--- a/LibraBFT/ImplFake/Consensus/RoundManager.agda
+++ b/LibraBFT/ImplFake/Consensus/RoundManager.agda
@@ -26,8 +26,6 @@ open import Optics.All
 
 module LibraBFT.ImplFake.Consensus.RoundManager where
 
-open RWST-do
-
 processCommitM : LedgerInfoWithSignatures → LBFT (List ExecutedBlock)
 processCommitM finalityProof = pure []
 

--- a/LibraBFT/ImplFake/Handle.agda
+++ b/LibraBFT/ImplFake/Handle.agda
@@ -26,7 +26,6 @@ open import Optics.All
 
 module LibraBFT.ImplFake.Handle where
  open import LibraBFT.ImplFake.Consensus.RoundManager
- open RWST-do
 
  open EpochConfig
 

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -592,7 +592,3 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     TooLittleVotingPower : U64 → U64 →     VerifyError
     TooManySignatures    : Usize → Usize → VerifyError
     InvalidSignature     :                 VerifyError
-
-  -- TODO-1: Implement this (low priority)
-  ErrLog : Set
-  ErrLog = Unit

--- a/LibraBFT/ImplShared/Util/RWST.agda
+++ b/LibraBFT/ImplShared/Util/RWST.agda
@@ -11,7 +11,7 @@ open import LibraBFT.Prelude
 -- programs written using this RWST monad. The main definitions are:
 -- 1. RWST, a datatype for the ASTs of stateful programs that read from an
 --    environment and produce output.
---    This datatype includes constructors for branching code, to aide in the
+--    This datatype includes constructors for branching code, to aid in the
 --    verification effort (see below).
 -- 2. RWST-weakestPre, a large elimination that, given an RWST program and a
 --    post condition for the program, produces the weakest precondition needed
@@ -56,7 +56,7 @@ private
     Ev Wr St : Set
     A B C    : Set
 
--- To execute an RWST program, you prove an environment and prestate. This
+-- To execute an RWST program, you provide an environment and prestate. This
 -- produces a result value, poststate, and list of outputs.
 RWST-run : RWST Ev Wr St A → Ev → St → A × St × List Wr
 RWST-run (RWST-return x) ev st  = x , st , []
@@ -157,7 +157,8 @@ RWST-weakestPre-bindPost ev f Post x post outs =
 -- For every RWST computation `m`, `RWST-Contract m` is the type of proofs that,
 -- for all post conditions `P`, starting environments `ev` and prestates `pre`,
 -- to prove that `P` holds after running `m` in `ev` and `pre`, it suffices to
--- provide the weakest precondition for `P` with respect to `m`, `ev`, and `pre`.
+-- provide a proof of the weakest precondition for `P` with respect to `m`,
+-- `ev`, and `pre`.
 RWST-Contract : (m : RWST Ev Wr St A) → Set₁
 RWST-Contract{Ev}{Wr}{St}{A} m =
   (P : RWST-Post Wr St A)
@@ -165,7 +166,10 @@ RWST-Contract{Ev}{Wr}{St}{A} m =
   → let (x , post , outs) = RWST-run m ev pre in
     P x post outs
 
--- This proves `RWST-Contract m` for arbitrary `m`.
+-- This proves that `RWST-weakestPre` gives a *sufficient* precondition for
+-- establishing a desired postcondition. Note thought that it does not prove
+-- that this precondition is the weakest such one; even though this is true, it
+-- is not important for our purposes.
 RWST-contract : (m : RWST Ev Wr St A) → RWST-Contract m
 RWST-contract (RWST-return x₁) P ev pre wp = wp
 RWST-contract (RWST-bind m f) P ev pre wp

--- a/LibraBFT/ImplShared/Util/RWST.agda
+++ b/LibraBFT/ImplShared/Util/RWST.agda
@@ -5,175 +5,236 @@
 -}
 
 open import LibraBFT.Prelude
-open import Optics.All
 
--- This module defines syntax and functionality modeling an RWST monad,
--- which we use to define an implementation.
+-- This module defines functionality modeling an RWST monad, which we use to
+-- define an implementation, and functionality for proving properties about
+-- programs written using this RWST monad. The main definitions are:
+-- 1. RWST, a datatype for the ASTs of stateful programs that read from an
+--    environment and produce output.
+--    This datatype includes constructors for branching code, to aide in the
+--    verification effort (see below).
+-- 2. RWST-weakestPre, a large elimination that, given an RWST program and a
+--    post condition for the program, produces the weakest precondition needed
+--    to satisfy that post condition. Branches in code using the constructors
+--    `RWST-if` and friends are translated into products, with each component of
+--    the product corresponding to a possible branch taken.
+-- 3. RWST-Contract is the type of proofs that, given a stateful computation and
+--    a post condition, the weakest precondition suffices to prove that post
+--    condition.
+-- 4. RWST-contract proves RWST-Contract, i.e., for every stateful computation
+--    `m` and post condition `P`, given a proof over a pre-state `pre` the
+--    weakest precondition for `P` holds, then postcondition `P` holds for the
+--    post-state obtained from running `m` in state `pre`.
+
 -- TODO-2: this module is independent of any particular implementation
 -- and arguably belongs somewhere more general, such as next to Optics.
 
-module LibraBFT.ImplShared.Util.RWST (ℓ-State : Level) where
+module LibraBFT.ImplShared.Util.RWST where
 
-  ----------------
-  -- RWST Monad --
-  ----------------
+-- RWST, the AST of computations with state `St` reading from an environment
+-- `Ev` and producing a list of outputs of type `Wr`
+data RWST (Ev Wr St : Set) : Set → Set₁ where
+  -- Primitive combinators
+  RWST-return : ∀ {A}   → A                                       → RWST Ev Wr St A
+  RWST-bind   : ∀ {A B} → RWST Ev Wr St A → (A → RWST Ev Wr St B) → RWST Ev Wr St B
+  RWST-gets   : ∀ {A} → (St → A)                                  → RWST Ev Wr St A
+  RWST-put    : St                                                → RWST Ev Wr St Unit
+  RWST-ask    :                                                     RWST Ev Wr St Ev
+  RWST-tell   : List Wr                                           → RWST Ev Wr St Unit
+  -- Branching combinators (used for creating more convenient contracts)
+  RWST-if     : ∀ {A} → Guards (RWST Ev Wr St A)                  → RWST Ev Wr St A
+  RWST-either : ∀ {A B C} → Either B C
+                → (B → RWST Ev Wr St A) → (C → RWST Ev Wr St A)   → RWST Ev Wr St A
+  RWST-ebind  : ∀ {A B C}
+                → RWST Ev Wr St (Either C A)
+                → (A → RWST Ev Wr St (Either C B))                → RWST Ev Wr St (Either C B)
+  RWST-maybe  : ∀ {A B} → Maybe B
+                → (RWST Ev Wr St A) → (B → RWST Ev Wr St A)       → RWST Ev Wr St A
 
-  -- 'Fake' RWST monad; fake in the sense
-  -- we use the free monoid on the writer (aka. lists)
-  -- instad of requiring it to be a monoid in a separate
-  -- argument.
-  RWST-Raw : Set → Set → Set ℓ-State → {ℓ-Result : Level} → Set ℓ-Result → Set (ℓ-State ℓ⊔ ℓ-Result)
-  RWST-Raw Ev Wr St R = Ev → St → (R × St × List Wr)
+private
+  variable
+    Ev Wr St : Set
+    A B C    : Set
 
-  -- Wrap it in a type; prevents spurious evaluation and
-  -- obliges us to 'run' the monad.
-  data RWST (Ev Wr : Set) (St : Set ℓ-State) {ℓ-Result : Level} : Set ℓ-Result → Set (ℓ-State ℓ⊔ ℓ-Result) where
-    rwst : ∀ {R : Set ℓ-Result} → RWST-Raw Ev Wr St {ℓ-Result} R → RWST Ev Wr St R
+-- To execute an RWST program, you prove an environment and prestate. This
+-- produces a result value, poststate, and list of outputs.
+RWST-run : RWST Ev Wr St A → Ev → St → A × St × List Wr
+RWST-run (RWST-return x) ev st  = x , st , []
+RWST-run (RWST-bind m f) ev st
+   with RWST-run m ev st
+...| x₁ , st₁ , outs₁
+   with RWST-run (f x₁) ev st₁
+...| x₂ , st₂ , outs₂           = x₂ , st₂ , outs₁ ++ outs₂
+RWST-run (RWST-gets f) ev st    = f st , st , []
+RWST-run (RWST-put st) ev _     = unit , st , []
+RWST-run RWST-ask ev st         = ev , st , []
+RWST-run (RWST-tell outs) ev st = unit , st , outs
+RWST-run (RWST-if (clause (b ≔ c) gs)) ev st =
+  if toBool b then RWST-run c ev st else RWST-run (RWST-if gs) ev st
+RWST-run (RWST-if (otherwise≔ c)) ev st = RWST-run c ev st
+RWST-run (RWST-either (Left x) f₁ f₂) ev st = RWST-run (f₁ x) ev st
+RWST-run (RWST-either (Right y) f₁ f₂) ev st = RWST-run (f₂ y) ev st
+RWST-run (RWST-ebind m f) ev st
+   with RWST-run m ev st
+...| Left c , st₁ , outs₁ = Left c , st₁ , outs₁
+...| Right a , st₁ , outs₁
+   with RWST-run (f a) ev st₁
+...| r , st₂ , outs₂ = r , st₂ , outs₁ ++ outs₂
+RWST-run (RWST-maybe nothing f₁ f₂) ev st = RWST-run f₁ ev st
+RWST-run (RWST-maybe (just x) f₁ f₂) ev st = RWST-run (f₂ x) ev st
 
-  private
-   variable
-    Ev Wr : Set
-    ℓ-A ℓ-B ℓ-C : Level
-    A : Set ℓ-A
-    B : Set ℓ-B
-    C : Set ℓ-C
-    St : Set ℓ-State
+-- Accessors for the result, poststate, and outputs.
+RWST-result : RWST Ev Wr St A → Ev → St → A
+RWST-result m ev st = proj₁ (RWST-run m ev st)
 
-  RWST-run : RWST Ev Wr St A → Ev → St → (A × St × List Wr)
-  RWST-run (rwst f) = f
+RWST-post : RWST Ev Wr St A → Ev → St → St
+RWST-post m ev st = proj₁ (proj₂ (RWST-run m ev st))
 
-  RWST-bind : RWST Ev Wr St A → (A → RWST Ev Wr St B) → RWST Ev Wr St B
-  RWST-bind x f = rwst (λ ev st →
-    let (a , st'  , wr₀) = RWST-run x     ev st
-        (b , st'' , wr₁) = RWST-run (f a) ev st'
-     in b , st'' , wr₀ ++ wr₁)
+RWST-outs : RWST Ev Wr St A → Ev → St → List Wr
+RWST-outs m ev st = proj₂ (proj₂ (RWST-run m ev st))
 
-  RWST-return : A → RWST Ev Wr St A
-  RWST-return x = rwst (λ _ st → x , st , [])
+-- Preconditions are predicates over environments and prestates.
+RWST-Pre : (Ev St : Set) → Set₁
+RWST-Pre Ev St = (ev : Ev) (pre : St) → Set
 
-  -- Functorial Functionality
+-- Postconditions are predicates over a result, poststate, and list of outputs.
+RWST-Post : (Wr St A : Set) → Set₁
+RWST-Post Wr St A = (x : A) (post : St) (outs : List Wr) → Set
 
-  RWST-map : (A → B) → RWST Ev Wr St A → RWST Ev Wr St B
-  RWST-map f x = rwst (λ ev st →
-    let (a , st' , wr) = RWST-run x ev st
-     in f a , st' , wr)
+-- RWST-weakestPre computes a predicate transformer: it maps a RWST
+-- computation `m` and desired postcondition `Post` to the weakest precondition
+-- needed to prove `P` holds after running `m`.
+RWST-PredTrans : (Ev Wr St A : Set) → Set₁
+RWST-PredTrans Ev Wr St A = RWST-Post Wr St A → RWST-Pre Ev St
 
-  -- Provided Functionality
+-- When RWST computations are sequenced, e.g., `RWST-bind m λ x → f x`,
+-- outputs are concatenated. The postcondition desired for the above sequence
+-- becomes a postcondition for `f x` in which the outputs of `m` are prepended
+-- to the outputs of `f x`.
+RWST-Post++ : ∀ {Wr St A} → RWST-Post Wr St A → List Wr → RWST-Post Wr St A
+RWST-Post++ P outs x post outs₁ = P x post (outs ++ outs₁)
 
-  get : RWST Ev Wr St {ℓ-State} St
-  get = rwst (λ _ st → st , st , [])
+-- Consider again the sequence `RWST-bind m₁ λ x → f x`. We also translate a
+-- postcondition `P` for the sequence into a postcondition for `m` ---
+-- specifically, the post condition we want for `m` is that the weakest
+-- precondition for `RWST-Post++ P outs` holds, where `outs` are the outputs of
+-- `m`.
+RWST-weakestPre-bindPost  : (ev : Ev) (f : A → RWST Ev Wr St B) → RWST-Post Wr St B → RWST-Post Wr St A
+RWST-weakestPre-ebindPost : (ev : Ev) (f : A → RWST Ev Wr St (C ⊎ B)) → RWST-Post Wr St (C ⊎ B) → RWST-Post Wr St (C ⊎ A)
 
-  gets : (St → A) → RWST Ev Wr St A
-  gets f = RWST-bind get (RWST-return ∘ f)
+RWST-weakestPre : (m : RWST Ev Wr St A) → RWST-PredTrans Ev Wr St A
+RWST-weakestPre (RWST-return x) P ev pre = P x pre []
+RWST-weakestPre (RWST-bind m f) P ev pre =
+  RWST-weakestPre m (RWST-weakestPre-bindPost ev f P) ev pre
+RWST-weakestPre (RWST-gets f) P ev pre = P (f pre) pre []
+RWST-weakestPre (RWST-put post) P ev pre = P unit post []
+RWST-weakestPre RWST-ask P ev pre = P ev pre []
+RWST-weakestPre (RWST-tell outs) P ev pre = P unit pre outs
+RWST-weakestPre (RWST-if (clause (b ≔ c) gs)) P ev pre =
+  (toBool b ≡ true → RWST-weakestPre c P ev pre)
+  × (toBool b ≡ false → RWST-weakestPre (RWST-if gs) P ev pre)
+RWST-weakestPre (RWST-if (otherwise≔ c)) P ev pre =
+  RWST-weakestPre c P ev pre
+RWST-weakestPre (RWST-either e f₁ f₂) P ev pre =
+    (∀ x → (e ≡ Left x) →
+      RWST-weakestPre (f₁ x) P ev pre)
+  × (∀ y → (e ≡ Right y) →
+       RWST-weakestPre (f₂ y) P ev pre)
+RWST-weakestPre (RWST-ebind m f) P ev pre =
+  RWST-weakestPre m (RWST-weakestPre-ebindPost ev f P) ev pre
+RWST-weakestPre (RWST-maybe m f₁ f₂) P ev pre =
+  (m ≡ nothing → RWST-weakestPre f₁ P ev pre)
+  × (∀ j → m ≡ just j → RWST-weakestPre (f₂ j) P ev pre)
 
-{- TODO-2: extend Lens to work with different levels and reinstate this
+RWST-weakestPre-ebindPost ev f Post (Left r) post outs =
+  Post (Left r) post outs
+RWST-weakestPre-ebindPost ev f Post (Right r) post outs =
+  ∀ c → c ≡ r → RWST-weakestPre (f c) (RWST-Post++ Post outs) ev post
 
-   Note that a preliminary exploration by @cwjnkins revealed this to
-   be more painful than it's worth, at least until we have a
-   compelling use case for St to be at a higher level.  In the
-   meantime, we have defined use and modify' specifically for our
-   state type, which is in Set; see LibraBFT.ImplFake.Util.Util.
+RWST-weakestPre-bindPost ev f Post x post outs =
+  ∀ r → r ≡ x → RWST-weakestPre (f r) (RWST-Post++ Post outs) ev post
 
-  use : Lens St A → RWST Ev Wr St A
-  use f = RWST-bind get (RWST-return ∘ (_^∙ f))
--}
+-- For every RWST computation `m`, `RWST-Contract m` is the type of proofs that,
+-- for all post conditions `P`, starting environments `ev` and prestates `pre`,
+-- to prove that `P` holds after running `m` in `ev` and `pre`, it suffices to
+-- provide the weakest precondition for `P` with respect to `m`, `ev`, and `pre`.
+RWST-Contract : (m : RWST Ev Wr St A) → Set₁
+RWST-Contract{Ev}{Wr}{St}{A} m =
+  (P : RWST-Post Wr St A)
+  → (ev : Ev) (pre : St) → RWST-weakestPre m P ev pre
+  → let (x , post , outs) = RWST-run m ev pre in
+    P x post outs
 
-  modify : (St → St) → RWST Ev Wr St Unit
-  modify f = rwst (λ _ st → unit , f st , [])
+-- This proves `RWST-Contract m` for arbitrary `m`.
+RWST-contract : (m : RWST Ev Wr St A) → RWST-Contract m
+RWST-contract (RWST-return x₁) P ev pre wp = wp
+RWST-contract (RWST-bind m f) P ev pre wp
+   with RWST-contract m _ ev pre wp
+...| con
+   with RWST-run m ev pre
+...| x₁ , st₁ , outs₁ =
+  RWST-contract (f x₁) _ ev st₁ (con x₁ refl)
+RWST-contract (RWST-gets f) P ev pre wp = wp
+RWST-contract (RWST-put x₁) P ev pre wp = wp
+RWST-contract RWST-ask P ev pre wp = wp
+RWST-contract (RWST-tell x₁) P ev pre wp = wp
+RWST-contract{Ev}{Wr}{St}{A} (RWST-if gs) P ev pre wp = RWST-contract-if gs P ev pre wp
+  where
+  RWST-contract-if : (gs : Guards (RWST Ev Wr St A)) → RWST-Contract (RWST-if gs)
+  RWST-contract-if (clause (b ≔ c) gs) P ev pre (wp₁ , wp₂)
+    with toBool b
+  ...| true = RWST-contract c _ ev pre (wp₁ refl)
+  ...| false = RWST-contract-if gs _ ev pre (wp₂ refl)
+  RWST-contract-if (otherwise≔ x) P ev pre wp =
+    RWST-contract x P ev pre wp
+RWST-contract (RWST-either (Left x) f₁ f₂) P ev pre (wp₁ , wp₂) =
+  RWST-contract (f₁ x) _ ev pre (wp₁ x refl)
+RWST-contract (RWST-either (Right y) f₁ f₂) P ev pre (wp₁ , wp₂) =
+  RWST-contract (f₂ y) _ ev pre (wp₂ y refl)
+RWST-contract (RWST-ebind m f) P ev pre wp
+   with RWST-contract m _ ev pre wp
+...| con
+   with RWST-run m ev pre
+... | Left x , st₁ , outs₁ = con
+... | Right y , st₁ , outs₁ = RWST-contract (f y) _ ev st₁ (con y refl)
+RWST-contract (RWST-maybe nothing f₁ f₂) P ev pre (wp₁ , wp₂)
+  = RWST-contract f₁ _ ev pre (wp₁ refl)
+RWST-contract (RWST-maybe (just x) f₁ f₂) P ev pre (wp₁ , wp₂) =
+  RWST-contract (f₂ x) _ ev pre (wp₂ x refl)
 
-{- TODO-2: extend Lens to work with different levels and reinstate this
-   See comment above for use
-  modify' : ∀ {A} → Lens St A → A → RWST Ev Wr St Unit
-  modify' l val = modify λ x → x [ l := val ]
-  syntax modify' l val = l ∙= val
--}
-
-  put : St → RWST Ev Wr St Unit
-  put s = modify (λ _ → s)
-
-  tell : List Wr → RWST Ev Wr St Unit
-  tell wrs = rwst (λ _ st → unit , st , wrs)
-
-  tell1 : Wr → RWST Ev Wr St Unit
-  tell1 wr = tell (wr ∷ [])
-
-  act = tell1
-
-  ask : RWST Ev Wr St Ev
-  ask = rwst (λ ev st → (ev , st , []))
-
-  ok : ∀ {B : Set ℓ-B} → A → RWST Ev Wr St (Either B A)
-  ok = RWST-return ∘ Right
-
-  bail : B → RWST Ev Wr St (Either B A)
-  bail = RWST-return ∘ Left
-
-  -- Easy to use do notation; i.e.;
-  module RWST-do where
-    infixl 1 _>>=_ _>>_
-    _>>=_  : RWST Ev Wr St A → (A → RWST Ev Wr St B) → RWST Ev Wr St B
-    _>>=_  = RWST-bind
-
-    _>>_   : RWST Ev Wr St A → RWST Ev Wr St B → RWST Ev Wr St B
-    x >> y = x >>= λ _ → y
-
-    return : A → RWST Ev Wr St A
-    return = RWST-return
-
-    pure : A → RWST Ev Wr St A
-    pure = return
-
-    infixl 4 _<$>_
-    _<$>_ : (A → B) → RWST Ev Wr St A → RWST Ev Wr St B
-    _<$>_ = RWST-map
-
-    infixl 4 _<*>_
-    _<*>_ : RWST Ev Wr St (A → B) → RWST Ev Wr St A → RWST Ev Wr St B
-    fs <*> xs = do
-      f ← fs
-      x ← xs
-      pure (f x)
-
-  private
-    ex₀ : RWST ℕ Wr (Lift ℓ-State ℕ) ℕ
-    ex₀ = do
-       x₁ ← get
-       x₂ ← ask
-       return (lower x₁ + x₂)
-       where open RWST-do
-
-  -- Derived Functionality
-  maybeSM : RWST Ev Wr St (Maybe A) → RWST Ev Wr St B → (A → RWST Ev Wr St B) → RWST Ev Wr St B
-  maybeSM mma mb f = do
-    x ← mma
-    case x of λ where
-      nothing → mb
-      (just j) → f j
-    where
-    open RWST-do
-
-  maybeSMP : RWST Ev Wr St (Maybe A) → B → (A → RWST Ev Wr St B)
-          → RWST Ev Wr St B
-  maybeSMP ma b f = do
-    x ← ma
-    case x of λ where
-      nothing → return b
-      (just j) → f j
-    where open RWST-do
-
-  infixl 4 _∙?∙_
-  _∙?∙_ : RWST Ev Wr St (Either C A) → (A → RWST Ev Wr St (Either C B)) → RWST Ev Wr St (Either C B)
-  m ∙?∙ f = do
-    r ← m
-    case r of λ where
-      (Left c) → pure (Left c)
-      (Right a) → f a
-    where open RWST-do
-
-  _∙^∙_ : RWST Ev Wr St (Either A B) → (A → A) → RWST Ev Wr St (Either A B)
-  m ∙^∙ f = do
-    x ← m
-    case x of λ where
-      (Left  e) → pure (Left (f e))
-      (Right r) → pure (Right r)
-    where open RWST-do
+-- This helper function is primarily used to take a proof concerning one
+-- computation `m` and show that that proof implies a property concerning a
+-- larger computation which contains `m`.
+RWST-⇒
+  : (P Q : RWST-Post Wr St A) → (∀ r st outs → P r st outs → Q r st outs)
+    → ∀ m (ev : Ev) st → RWST-weakestPre m P ev st → RWST-weakestPre m Q ev st
+RWST-⇒ P Q pf (RWST-return x) ev st pre = pf x st [] pre
+RWST-⇒ P Q pf (RWST-bind m f) ev st pre =
+  RWST-⇒ _ _
+    (λ r₁ st₁ outs₁ pf₁ x x≡ →
+      RWST-⇒ _ _
+        (λ r₂ st₂ outs₂ pf₂ → pf r₂ st₂ (outs₁ ++ outs₂) pf₂)
+        (f x) ev st₁ (pf₁ x x≡))
+    m ev st pre
+RWST-⇒ P Q pf (RWST-gets f) ev st pre = pf _ _ _ pre
+RWST-⇒ P Q pf (RWST-put x) ev st pre = pf _ _ _ pre
+RWST-⇒ P Q pf RWST-ask ev st pre = pf _ _ _ pre
+RWST-⇒ P Q pf (RWST-tell x) ev st pre = pf _ _ _ pre
+RWST-⇒ P Q pf (RWST-if (otherwise≔ x)) ev st pre = RWST-⇒ _ _ pf x ev st pre
+RWST-⇒ P Q pf (RWST-if (clause (b ≔ c) cs)) ev st (pre₁ , pre₂) =
+  (λ pf' → RWST-⇒ _ _ pf c ev st (pre₁ pf'))
+  , λ pf' → RWST-⇒ _ _ pf (RWST-if cs) ev st (pre₂ pf')
+proj₁ (RWST-⇒ P Q pf (RWST-either (Left x) f₁ f₂) ev st (pre₁ , pre₂)) x₁ x₁≡ =
+  RWST-⇒ _ _ pf (f₁ x₁) ev st (pre₁ x₁ x₁≡)
+proj₂ (RWST-⇒ P Q pf (RWST-either (Left x) f₁ f₂) ev st (pre₁ , pre₂)) y ()
+proj₁ (RWST-⇒ P Q pf (RWST-either (Right y) f₁ f₂) ev st (pre₁ , pre₂)) y₁ ()
+proj₂ (RWST-⇒ P Q pf (RWST-either (Right y) f₁ f₂) ev st (pre₁ , pre₂)) y₁ y₁≡ =
+  RWST-⇒ _ _ pf (f₂ y₁) ev st (pre₂ y₁ y₁≡)
+RWST-⇒ P Q pf (RWST-ebind m f) ev st pre =
+  RWST-⇒ _ _
+    (λ { (Left x₁) st₁ outs x → pf _ _ _ x
+       ; (Right y) st₁ outs x → λ c x₁ →
+           RWST-⇒ _ _ (λ r st₂ outs₁ x₂ → pf r st₂ (outs ++ outs₁) x₂) (f c) ev st₁ (x c x₁)})
+    m ev st pre
+proj₁ (RWST-⇒ P Q pf (RWST-maybe x m f) ev st (pre₁ , pre₂)) ≡nothing = RWST-⇒ _ _ pf m ev st (pre₁ ≡nothing)
+proj₂ (RWST-⇒ P Q pf (RWST-maybe x m f) ev st (pre₁ , pre₂)) b b≡ = RWST-⇒ _ _ pf (f b) ev st (pre₂ b b≡)

--- a/LibraBFT/ImplShared/Util/RWST/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/RWST/Syntax.agda
@@ -1,0 +1,131 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.ImplShared.Util.RWST
+open import LibraBFT.Prelude
+open import Optics.All
+
+-- This module contains definitions allowing RWST programs to be written using
+-- Agda's do-notation, as well as convenient short names for operations
+-- (including lens operations).
+module LibraBFT.ImplShared.Util.RWST.Syntax where
+
+private
+  variable
+    Ev Wr St : Set
+    A B C    : Set
+
+-- From this instance declaration, we get _<$>_, pure, and _<*>_ also.
+instance
+  RWST-Monad : Monad (RWST Ev Wr St)
+  Monad.return RWST-Monad = RWST-return
+  Monad._>>=_ RWST-Monad = RWST-bind
+
+gets : (St → A) → RWST Ev Wr St A
+gets = RWST-gets
+
+get : RWST Ev Wr St St
+get = gets id
+
+put : St → RWST Ev Wr St Unit
+put = RWST-put
+
+modify : (St → St) → RWST Ev Wr St Unit
+modify f = do
+  st ← get
+  put (f st)
+
+ask : RWST Ev Wr St Ev
+ask = RWST-ask
+
+tell : List Wr → RWST Ev Wr St Unit
+tell = RWST-tell
+
+tell1 : Wr → RWST Ev Wr St Unit
+tell1 x = tell (x ∷ [])
+
+act = tell1
+
+-- Conditionals
+infix 1 ifM‖_
+ifM‖_ : Guards (RWST Ev Wr St A) → RWST Ev Wr St A
+ifM‖_ = RWST-if
+
+infix 0 ifM_then_else_
+ifM_then_else_ : ⦃ _ : ToBool B ⦄ → B → (c₁ c₂ : RWST Ev Wr St A) → RWST Ev Wr St A
+ifM b then c₁ else c₂ =
+  ifM‖ b ≔ c₁
+     ‖ otherwise≔ c₂
+
+infix 0 caseM⊎_of_ caseMM_of_
+caseM⊎_of_ : Either B C → (Either B C → RWST Ev Wr St A) → RWST Ev Wr St A
+caseM⊎ e of f = RWST-either e (f ∘ Left) (f ∘ Right)
+
+caseMM_of_ : Maybe B → (Maybe B → RWST Ev Wr St A) → RWST Ev Wr St A
+caseMM m of f = RWST-maybe m (f nothing) (f ∘ just)
+
+-- Composition with error monad
+ok : A → RWST Ev Wr St (B ⊎ A)
+ok = return ∘ Right
+
+bail : B → RWST Ev Wr St (B ⊎ A)
+bail = return ∘ Left
+
+infixl 4 _∙?∙_
+_∙?∙_ : RWST Ev Wr St (Either C A) → (A → RWST Ev Wr St (Either C B)) → RWST Ev Wr St (Either C B)
+_∙?∙_ = RWST-ebind
+
+-- Composition/use with partiality monad
+maybeS-RWST : Maybe A → (RWST Ev Wr St B) → (A → RWST Ev Wr St B) → RWST Ev Wr St B
+maybeS-RWST ma n j =
+  caseMM ma of λ where
+    nothing → n
+    (just x) → j x
+
+maybeSM : RWST Ev Wr St (Maybe A) → RWST Ev Wr St B → (A → RWST Ev Wr St B) → RWST Ev Wr St B
+maybeSM mma mb f = do
+  x ← mma
+  caseMM x of λ where
+    nothing → mb
+    (just j) → f j
+  where
+
+maybeSMP : RWST Ev Wr St (Maybe A) → B → (A → RWST Ev Wr St B)
+           → RWST Ev Wr St B
+maybeSMP ma b f = do
+  x ← ma
+  caseMM x of λ where
+    nothing → return b
+    (just j) → f j
+
+infixl 4 _∙^∙_
+_∙^∙_ : RWST Ev Wr St (Either B A) → (B → B) → RWST Ev Wr St (Either B A)
+m ∙^∙ f = do
+  x ← m
+  caseM⊎ x of λ where
+    (Left e) → pure (Left (f e))
+    (Right r) → pure (Right r)
+
+-- Lens functionality
+--
+-- If we make RWST work for different level State types, we will break use and
+-- modify because Lens does not support different levels, we define use and
+-- modify' here for RoundManager. We are ok as long as we can keep
+-- RoundManager in Set. If we ever need to make RoundManager at some higher
+-- Level, we will have to consider making Lens level-agnostic. Preliminary
+-- exploration by @cwjnkins showed this to be somewhat painful in particular
+-- around composition, so we are not pursuing it for now.
+use : Lens St A → RWST Ev Wr St A
+use f = gets (_^∙ f)
+
+modifyL : Lens St A → (A → A) → RWST Ev Wr St Unit
+modifyL l f = modify (over l f)
+syntax modifyL l f = l %= f
+
+setL : Lens St A → A → RWST Ev Wr St Unit
+setL l x = l %= const x
+syntax setL l x = l ∙= x
+

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -389,11 +389,9 @@ module LibraBFT.Prelude where
       x ← xs
       return (f x)
 
-  open import Category.Monad
-  import      Data.Sum.Categorical.Left
   instance
     Monad-Error : ∀ {ℓ}{C : Set ℓ} → Monad{ℓ}{ℓ} (Either C)
-    Monad.return (Monad-Error{ℓ}{C}) = RawMonad.return (Data.Sum.Categorical.Left.monad C ℓ)
-    Monad._>>=_ (Monad-Error{ℓ}{C}) = RawMonad._>>=_ (Data.Sum.Categorical.Left.monad C ℓ)
+    Monad.return (Monad-Error{ℓ}{C}) = inj₂
+    Monad._>>=_ (Monad-Error{ℓ}{C}) = either (const ∘ inj₁) _&_
 
   open import LibraBFT.Base.Util public

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -352,4 +352,48 @@ module LibraBFT.Prelude where
   f-sum : ∀{a}{A : Set a} → (A → ℕ) → List A → ℕ
   f-sum f = sum ∘ List-map f
 
+  record Functor  {ℓ₁ ℓ₂ : Level} (F : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
+    infixl 4 _<$>_
+    field
+      _<$>_ : ∀ {A B : Set ℓ₁} → (A → B) → F A → F B
+
+  open Functor ⦃ ... ⦄ public
+
+  record Applicative {ℓ₁ ℓ₂ : Level} (F : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
+    infixl 4 _<*>_
+    field
+      pure  : ∀ {A : Set ℓ₁} → A → F A
+      _<*>_ : ∀ {A B : Set ℓ₁} → F (A → B) → F A → F B
+
+  open Applicative ⦃ ... ⦄ public
+  instance
+    ApplicativeFunctor : ∀ {ℓ₁ ℓ₂} {F : Set ℓ₁ → Set ℓ₂} ⦃ _ : Applicative F ⦄ → Functor F
+    Functor._<$>_ ApplicativeFunctor f xs = pure f <*> xs
+
+  record Monad {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
+    infixl 1 _>>=_ _>>_
+    field
+      return : ∀ {A : Set ℓ₁} → A → M A
+      _>>=_  : ∀ {A B : Set ℓ₁} → M A → (A → M B) → M B
+
+    _>>_ : ∀ {A B : Set ℓ₁} → M A → M B → M B
+    m₁ >> m₂ = m₁ >>= λ _ → m₂
+
+  open Monad ⦃ ... ⦄ public
+
+  instance
+    MonadApplicative : ∀ {ℓ₁ ℓ₂} {M : Set ℓ₁ → Set ℓ₂} ⦃ _ : Monad M ⦄ → Applicative M
+    Applicative.pure MonadApplicative = return
+    Applicative._<*>_ MonadApplicative fs xs = do
+      f ← fs
+      x ← xs
+      return (f x)
+
+  open import Category.Monad
+  import      Data.Sum.Categorical.Left
+  instance
+    Monad-Error : ∀ {ℓ}{C : Set ℓ} → Monad{ℓ}{ℓ} (Either C)
+    Monad.return (Monad-Error{ℓ}{C}) = RawMonad.return (Data.Sum.Categorical.Left.monad C ℓ)
+    Monad._>>=_ (Monad-Error{ℓ}{C}) = RawMonad._>>=_ (Data.Sum.Categorical.Left.monad C ℓ)
+
   open import LibraBFT.Base.Util public


### PR DESCRIPTION
This PR also:

- adds a `Monad` record opened with Agda's instance arguments, to simulate Haskell's type classes (this allows us to use do-notation for `Either` as well as `LBFT`)
- moves the convenient syntax for do-notation with `RWST` to its own file. This module is imported publicly by `LibraBFT/ImplShared/Util/Util.agda`, so many occurrences of `open RWST-do` have been removed from the implementation models.
- replaces some `if` and `case` statements with the branching operators of the new `RWST` datatype
- removes `ErrLog` and replaces all remaining occurrences with `FakeErr`