### PR TITLE
implemented LedgerInfoWithSignatures.verifySignatures

### DIFF
--- a/LibraBFT/Impl/Consensus/Types/PendingVotes.agda
+++ b/LibraBFT/Impl/Consensus/Types/PendingVotes.agda
@@ -52,7 +52,7 @@ insertVoteM vote vv = do
     case ValidatorVerifier.checkVotingPower vv (Map.kvm-keys (liWithSig ^∙ liwsSignatures)) of λ where
       (Right unit) →
         pure (NewQuorumCertificate (QuorumCert∙new (vote ^∙ vVoteData) liWithSig))
-      (Left (TooLittleVotingPower votingPower _)) →
+      (Left (ErrVerify (TooLittleVotingPower votingPower _))) →
         continue2 votingPower
       (Left _) →
         pure VRR_TODO
@@ -68,7 +68,7 @@ insertVoteM vote vv = do
         case ValidatorVerifier.checkVotingPower vv (Map.kvm-keys (partialTc ^∙ tcSignatures)) of λ where
           (Right unit) →
             pure (NewTimeoutCertificate partialTc)
-          (Left (TooLittleVotingPower votingPower _)) →
+          (Left (ErrVerify (TooLittleVotingPower votingPower _))) →
             pure (TCVoteAdded votingPower)
           (Left _) →
             pure VRR_TODO

--- a/LibraBFT/Impl/OBM/Crypto.agda
+++ b/LibraBFT/Impl/OBM/Crypto.agda
@@ -1,0 +1,28 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.Encode
+open import LibraBFT.Base.PKCS                  as PKCS hiding (sign; verify)
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.Prelude
+
+module LibraBFT.Impl.OBM.Crypto where
+
+record CryptoHash (A : Set) : Set where
+  field
+    sign        : SK → A → Signature
+    verify      : {-Text-} PK → Signature → A → Either FakeErr Unit
+    ⦃ encodeA ⦄ : Encoder A
+
+open CryptoHash ⦃ ... ⦄ public
+
+instance
+  CryptoHashLedgerInfo : CryptoHash LedgerInfo
+  CryptoHashLedgerInfo = record
+    { sign   = λ sk li     → PKCS.sign-raw  (encode li)     sk
+    ; verify = λ pk sig li → if PKCS.verify (encode li) sig pk
+                             then Right unit
+                             else Left fakeErr }

--- a/LibraBFT/Impl/Types/LedgerInfoWithSignatures.agda
+++ b/LibraBFT/Impl/Types/LedgerInfoWithSignatures.agda
@@ -4,8 +4,10 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.KVMap           as Map
+open import LibraBFT.Base.KVMap                   as Map
 open import LibraBFT.Base.PKCS
+import      LibraBFT.Impl.OBM.Crypto              as Crypto
+open import LibraBFT.Impl.Types.ValidatorVerifier as ValidatorVerifier
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 open import Optics.All
@@ -20,6 +22,9 @@ addSignature validator sig liws =
     nothing  →
       liws & liwsSignatures ∙~ Map.kvm-insert-Haskell validator sig (liws ^∙ liwsSignatures)
 
-postulate -- TODO-1: implement
-  verifySignatures : LedgerInfoWithSignatures → ValidatorVerifier → Either FakeErr Unit
+verifySignatures : LedgerInfoWithSignatures → ValidatorVerifier → Either FakeErr Unit
+verifySignatures self validator = -- withErrCtx'
+  -- ["LedgerInfoWithSignatures", "verify"]
+  ValidatorVerifier.batchVerifyAggregatedSignatures
+     validator (self ^∙ liwsLedgerInfo) (self ^∙ liwsSignatures)
 

--- a/LibraBFT/Impl/Types/ValidatorVerifier.agda
+++ b/LibraBFT/Impl/Types/ValidatorVerifier.agda
@@ -44,14 +44,8 @@ verifyAggregatedStructSignature
 verifyAggregatedStructSignature self v aggregatedSignature = do
   checkNumOfSignatures self aggregatedSignature
   checkVotingPower self (Map.kvm-keys aggregatedSignature)
-  loop (Map.kvm-toList aggregatedSignature)
- where
-  loop : List (Author × Signature) → Either FakeErr Unit
-  loop  []  = Right unit
-  loop ((author , signature) ∷ xs) =
-    case verify self author v signature of λ where
-      (Right unit) → loop xs
-      l            → l
+  forM_ (Map.kvm-toList aggregatedSignature) λ (author , signature) →
+    verify self author v signature
 
 batchVerifyAggregatedSignatures
   : {V : Set} ⦃ _ : Crypto.CryptoHash V ⦄

--- a/LibraBFT/Impl/Types/ValidatorVerifier.agda
+++ b/LibraBFT/Impl/Types/ValidatorVerifier.agda
@@ -50,9 +50,9 @@ verifyAggregatedStructSignature self v aggregatedSignature = do
   loop : List (Author × Signature) → Either FakeErr Unit
   loop  []  = Right unit
   loop ((author , signature) ∷ xs) =
-    if true -- verify self author v signature
-    then loop xs
-    else Left fakeErr
+    case verify self author v signature of λ where
+      (Right unit) → loop xs
+      l            → l
 
 batchVerifyAggregatedSignatures
   : {V : Set} ⦃ _ : Crypto.CryptoHash V ⦄

--- a/LibraBFT/Impl/Types/ValidatorVerifier.agda
+++ b/LibraBFT/Impl/Types/ValidatorVerifier.agda
@@ -20,8 +20,8 @@ getPublicKey         : ValidatorVerifier → AccountAddress → Maybe PK
 getVotingPower       : ValidatorVerifier → AccountAddress → Maybe U64
 
 verifyIfAuthor
-  : {v : Set} ⦃ cryptoHashV : Crypto.CryptoHash v ⦄
-  → {-Text →-} ValidatorVerifier → AccountAddress → v → Signature
+  : {V : Set} ⦃ _ : Crypto.CryptoHash V ⦄
+  → {-Text →-} ValidatorVerifier → AccountAddress → V → Signature
   → Either FakeErr Unit
 verifyIfAuthor {-msg-} self author v signature = case getPublicKey self author of λ where
   (just pk) → case Crypto.verify {-msg-} pk signature v of λ where
@@ -32,14 +32,14 @@ verifyIfAuthor {-msg-} self author v signature = case getPublicKey self author o
 --  known = fmap _aAuthorName (Map.keys (self^.vvAddressToValidatorInfo))
 
 verify
-  : {v : Set} ⦃ cryptoHashV : Crypto.CryptoHash v ⦄
-  → ValidatorVerifier → AccountAddress → v → Signature
+  : {V : Set} ⦃ _ : Crypto.CryptoHash V ⦄
+  → ValidatorVerifier → AccountAddress → V → Signature
   → Either FakeErr Unit
 verify = verifyIfAuthor -- (icSemi ["ValidatorVerifier", "verifySignature"])
 
 verifyAggregatedStructSignature
-  : {v : Set} ⦃ cryptoHashV : Crypto.CryptoHash v ⦄
-  → ValidatorVerifier → v → KVMap AccountAddress Signature
+  : {V : Set} ⦃ _ : Crypto.CryptoHash V ⦄
+  → ValidatorVerifier → V → KVMap AccountAddress Signature
   → Either FakeErr Unit
 verifyAggregatedStructSignature self v aggregatedSignature = do
   checkNumOfSignatures self aggregatedSignature
@@ -55,8 +55,8 @@ verifyAggregatedStructSignature self v aggregatedSignature = do
     else Left fakeErr
 
 batchVerifyAggregatedSignatures
-  : {v : Set} ⦃ cryptoHashV : Crypto.CryptoHash v ⦄
-  → ValidatorVerifier → v → KVMap AccountAddress Signature
+  : {V : Set} ⦃ _ : Crypto.CryptoHash V ⦄
+  → ValidatorVerifier → V → KVMap AccountAddress Signature
   → Either FakeErr Unit
 batchVerifyAggregatedSignatures = verifyAggregatedStructSignature
 

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -301,9 +301,13 @@ module LibraBFT.ImplShared.Consensus.Types where
                        → ∈GenInfo-impl genesisInfo (_vSignature v1) → ∈GenInfo-impl genesisInfo (_vSignature v2)
                      → v1 ^∙ vProposedId ≡ v2 ^∙ vProposedId
 
+  data FakeErr : Set where
+    ErrVerify : VerifyError → FakeErr
+
   -- These are placeholders so that we can model error and logging outputs even
   -- though we don't yet model them in detail.
   postulate
-    FakeInfo FakeErr : Set
+    FakeInfo         : Set
     fakeErr          : FakeErr
     fakeInfo         : FakeInfo
+

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -40,7 +40,7 @@ module LibraBFT.Prelude where
 
   open import Data.List
     renaming (map to List-map ; filter to List-filter ; lookup to List-lookup;
-              tabulate to List-tabulate)
+              tabulate to List-tabulate ; foldl to List-foldl)
     hiding (fromMaybe; [_])
     public
 
@@ -407,5 +407,9 @@ module LibraBFT.Prelude where
     Monad-Error : ∀ {ℓ}{C : Set ℓ} → Monad{ℓ}{ℓ} (Either C)
     Monad.return (Monad-Error{ℓ}{C}) = RawMonad.return (Data.Sum.Categorical.Left.monad C ℓ)
     Monad._>>=_ (Monad-Error{ℓ}{C}) = RawMonad._>>=_ (Data.Sum.Categorical.Left.monad C ℓ)
+
+  forM_ : ∀ {A B : Set} {m : Set → Set} ⦃ _ : Monad m ⦄ → List A → (A → m B) → m Unit
+  forM_      []  _ = return unit
+  forM_ (x ∷ xs) f = f x >> forM_ xs f
 
   open import LibraBFT.Base.Util public

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -40,7 +40,7 @@ module LibraBFT.Prelude where
 
   open import Data.List
     renaming (map to List-map ; filter to List-filter ; lookup to List-lookup;
-              tabulate to List-tabulate ; foldl to List-foldl)
+              tabulate to List-tabulate)
     hiding (fromMaybe; [_])
     public
 
@@ -411,5 +411,9 @@ module LibraBFT.Prelude where
   forM_ : ∀ {A B : Set} {m : Set → Set} ⦃ _ : Monad m ⦄ → List A → (A → m B) → m Unit
   forM_      []  _ = return unit
   forM_ (x ∷ xs) f = f x >> forM_ xs f
+
+  foldrM : ∀ {A B : Set} {m : Set → Set} ⦃ _ : Monad m ⦄ → (A → B → m B) → B → List A → m B
+  foldrM _ b      []  = return b
+  foldrM f b (a ∷ as) = foldrM f b as >>= λ b' -> f a b'
 
   open import LibraBFT.Base.Util public


### PR DESCRIPTION
This implements `LedgerInfoWithSignatures.verifySignatures`

That required implementing
- various validation functions in `ValidatorVerifier`
- creating a `CryptoHash` typeclass with `sign` and `verify` functions in `LibraBFT.Impl.OBM.Crypto`
  - implementing a `CryptoHash LedgerInfo` instance
  - other instances will be created when needed

This is work based on the `mark-verifyqcm` branch.