### PR TITLE
Logging in, and proofs about, `LibraBFT.Impl.Consensus.SafetyRules.SafetyRules`

### DIFF
--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
@@ -15,3 +15,6 @@ module LibraBFT.Impl.Consensus.ConsensusTypes.Block where
 postulate
   validateSignature : Block → ValidatorVerifier → Either FakeErr Unit
 
+genBlockInfo : Block → {- HashValue → -} {- Version → -} {- Maybe EpochState → -} BlockInfo
+genBlockInfo b {- executedStateId -} {- version -} {- nextEpochState -} = BlockInfo∙new
+  (b ^∙ bEpoch) (b ^∙ bRound) (b ^∙ bId)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/VoteData.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/VoteData.agda
@@ -1,0 +1,16 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.PKCS
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.ConsensusTypes.VoteData where
+
+new : BlockInfo → BlockInfo → VoteData
+new = VoteData∙new
+

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -54,12 +54,15 @@ module processProposalMsgM (now : Instant) (pm : ProposalMsg) where
   step₂ : Either FakeErr Bool → LBFT Unit
 
   step₀ =
+
     caseMM pm ^∙ pmProposer of λ where
       nothing → logInfo -- log: info: proposal with no author
       (just pAuthor) → step₁ pAuthor
+
   step₁ pAuthor =
         ensureRoundAndSyncUpM now (pm ^∙ pmProposal ∙ bRound) (pm ^∙ pmSyncInfo)
                               pAuthor true >>= step₂
+
   step₂ =
         λ where
           (Left e)      → logErr -- log: error: <propagate error>
@@ -89,8 +92,10 @@ module ensureRoundAndSyncUpM
     ifM messageRound <? currentRound
       then ok false
       else step₁
+
   step₁ =
         syncUpM now syncInfo author helpRemote ∙?∙ λ _ → step₂
+
   step₂ = do
           currentRound' ← use (lRoundState ∙ rsCurrentRound)
           ifM not ⌊ messageRound ≟ℕ currentRound' ⌋
@@ -122,6 +127,7 @@ module ProcessProposalM (proposal : Block) where
     let bs = rmGetBlockStore s
     vp ← ProposerElection.isValidProposalM proposal
     step₁ {s} bs vp
+
   step₁ bs vp =
     ifM‖ is-nothing (proposal ^∙ bAuthor) ≔
          logErr -- log: error: proposal does not have an author
@@ -135,12 +141,14 @@ module ProcessProposalM (proposal : Block) where
          logErr -- log: error: parentBlock < proposalRound
        ‖ otherwise≔ do
            executeAndVoteM proposal >>= step₂
+
   step₂ =  λ where
              (Left _)     → logErr -- log: error: <propagate error>
              (Right vote) → do
                RoundState.recordVote vote
                si ← BlockStore.syncInfoM
                step₃ vote si
+
   step₃ vote si = do
                recipient ← ProposerElection.getValidProposer
                            <$> use lProposerElection
@@ -157,7 +165,9 @@ module ExecuteAndVoteM (b : Block) where
   step₂ : ExecutedBlock → LBFT (Either FakeErr Vote)
   step₃ : Vote          → LBFT (Either FakeErr Vote)
 
-  step₀ = BlockStore.executeAndInsertBlockM b ∙?∙ step₁
+  step₀ =
+    BlockStore.executeAndInsertBlockM b ∙?∙ step₁
+
   step₁ eb = do
     cr ← use (lRoundState ∙ rsCurrentRound)
     vs ← use (lRoundState ∙ rsVoteSent)
@@ -167,10 +177,12 @@ module ExecuteAndVoteM (b : Block) where
        ‖ so ≔
          bail fakeErr -- error: sync-only set
        ‖ otherwise≔ step₂ eb
+
   step₂ eb = do
            let maybeSignedVoteProposal' = ExecutedBlock.maybeSignedVoteProposal eb
            SafetyRules.constructAndSignVoteM maybeSignedVoteProposal' {- ∙^∙ logging -}
              ∙?∙ step₃
+
   step₃ vote =   PersistentLivenessStorage.saveVoteM vote
              ∙?∙ λ _ → ok vote
 

--- a/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
@@ -1,0 +1,74 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+-- This module contains definitions of properties of only the behavior of the
+-- handlers, nothing concerning the system state.
+
+open import Optics.All
+open import LibraBFT.Prelude
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
+open import LibraBFT.ImplShared.Util.Util
+
+module LibraBFT.Impl.Consensus.RoundManager.PropertyDefs where
+
+NoOutputs : List Output → Set
+NoOutputs outs = outs ≡ []
+
+NoMsgOuts : List Output → Set
+NoMsgOuts outs = List-filter isOutputMsg? outs ≡ []
+
+-- Invariants that all peer handlers must observe.
+record Invariant₂ (pre post : RoundManager) : Set where
+  field
+    es≡₁ : (_rmEC pre) ≡L (_rmEC post) at rmEpoch
+    es≡₂ : pre ≡L post at lSafetyData ∙ sdEpoch
+
+-- For `processProposalMsg`, an emitted vote should satisfy the following
+-- properties in relation to the pre/poststate and the epoch and round of the
+-- proposal message.
+
+record VoteCorrectOld (pre post : RoundManager) (vote : Vote) : Set where
+  -- In the implementation, it is implicitly assumed that the epoch of
+  -- `sdLastVote` is the same as the peer's.
+  field
+    lvr≡ : pre ≡L post at lSafetyData ∙ sdLastVotedRound
+    lv≡  : pre ≡L post at lSafetyData ∙ sdLastVote
+
+record VoteCorrectNew (pre post : RoundManager) (epoch : Epoch) (vote : Vote) : Set where
+  field
+    epoch≡   : vote ^∙ vEpoch ≡ epoch
+    lvr<     : pre [ _<_ ]L post at lSafetyData ∙ sdLastVotedRound
+    postLvr≡ : vote ^∙ vRound ≡ post ^∙ lSafetyData ∙ sdLastVotedRound
+
+record VoteCorrect (pre post : RoundManager) (epoch : Epoch) (round : Round) (vote : Vote) : Set where
+  field
+    round≡  : vote ^∙ vRound ≡ round
+    postLv≡ : just vote ≡ post ^∙ lSafetyData ∙ sdLastVote
+    voteSrc : VoteCorrectOld pre post vote
+              ⊎ VoteCorrectNew pre post epoch vote
+
+record NoVoteCorrect (pre post : RoundManager) : Set where
+  field
+    lv≡  : pre ≡L post at lSafetyData ∙ sdLastVote
+    lvr≤ : pre ^∙ lSafetyData ∙ sdLastVotedRound ≤ post ^∙ lSafetyData ∙ sdLastVotedRound
+
+substVoteCorrect
+  : ∀ {pre₁ pre₂ post₁ post₂ e r v}
+    → pre₁  ≡L pre₂  at (lSafetyData ∙ sdLastVote)
+    → pre₁  ≡L pre₂  at (lSafetyData ∙ sdLastVotedRound)
+    → post₁ ≡L post₂ at (lSafetyData ∙ sdLastVote)
+    → post₁ ≡L post₂ at (lSafetyData ∙ sdLastVotedRound)
+    → VoteCorrect pre₁ post₁ e r v
+    → VoteCorrect pre₂ post₂ e r v
+substVoteCorrect refl refl refl refl record { round≡ = round≡ ; postLv≡ = postLv≡ ; voteSrc = vs@(Left record { lvr≡ = lvr≡ ; lv≡ = lv≡ }) } =
+  record { round≡ = round≡ ; postLv≡ = postLv≡ ; voteSrc = Left (record { lvr≡ = lvr≡ ; lv≡ = lv≡ }) }
+substVoteCorrect refl refl refl refl record { round≡ = round≡ ; postLv≡ = postLv≡ ; voteSrc = (Right record { epoch≡ = epoch≡ ; lvr< = lvr< ; postLvr≡ = postLvr≡ }) } =
+  record { round≡ = round≡ ; postLv≡ = postLv≡ ; voteSrc = Right (record { epoch≡ = epoch≡ ; lvr< = lvr< ; postLvr≡ = postLvr≡ }) }

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -1,0 +1,717 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import Optics.All
+open import LibraBFT.Prelude
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
+import      LibraBFT.ImplShared.Util.Crypto                         as Crypto
+open import LibraBFT.ImplShared.Util.Util
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Block      as Block
+import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert as QuorumCert
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote       as Vote
+import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData   as VoteData
+open import LibraBFT.Impl.Consensus.RoundManager.PropertyDefs
+open import LibraBFT.Impl.Consensus.SafetyRules.SafetyRules
+open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.Impl.Types.ValidatorSigner               as ValidatorSigner
+
+module LibraBFT.Impl.Consensus.SafetyRules.Properties.SafetyRules where
+
+module verifyAndUpdatePreferredRoundMSpec (quorumCert : QuorumCert) (safetyData : SafetyData) where
+  preferredRound = safetyData ^∙ sdPreferredRound
+  oneChainRound  = quorumCert ^∙ qcCertifiedBlock ∙ biRound
+  twoChainRound  = quorumCert ^∙ qcParentBlock ∙ biRound
+
+  C₁ = oneChainRound < preferredRound
+  C₂ = twoChainRound > preferredRound
+  C₃ = twoChainRound < preferredRound
+  C₄ = twoChainRound ≡ preferredRound
+
+  safetyData' = safetyData & sdPreferredRound ∙~ twoChainRound
+
+  -- Before proving this, we should consider whether to add explicit support for <-cmp to our RWST
+  -- support, to make this proof unroll more "automatically".
+
+  postulate
+    contract
+      : ∀ P pre
+        → ((1cr<pr : C₁) → P (inj₁ fakeErr) pre [])
+        → ((1cr≥pr : ¬ C₁)
+           → ((2cr>pr : C₂) → P (inj₂ safetyData') pre [])
+              × ((2cr<pr : C₃) → P (inj₂ safetyData) pre [])
+              × ((2cr=pr : C₄) → P (inj₂ safetyData) pre []))
+        → LBFT-weakestPre (verifyAndUpdatePreferredRoundM quorumCert safetyData) P pre
+
+module extensionCheckMSpec (voteProposal : VoteProposal) where
+  proposedBlock = voteProposal ^∙ vpBlock
+  voteData = VoteData.new (Block.genBlockInfo proposedBlock) (proposedBlock ^∙ bQuorumCert ∙ qcCertifiedBlock)
+
+  -- TODO-1: This contract requires refinement once `extensionCheckM` is fully
+  -- implemented.
+  contract
+    : ∀ P pre
+      → P (inj₁ fakeErr) pre []
+      → P (inj₂ voteData) pre []
+      → LBFT-weakestPre (extensionCheckM voteProposal) P pre
+  contract Post pre prfBail prfOk = prfOk
+
+module constructLedgerInfoMSpec (proposedBlock : Block) (consensusDataHash : HashValue) where
+  -- TODO-1: This is a place-holder contract that requires refinement once
+  -- `constructLedgerInfoM is implemented.
+  postulate
+    contract
+      : ∀ P pre
+        → P (inj₁ fakeErr) pre []
+        → (∀ ledgerInfo → P (inj₂ ledgerInfo) pre [])
+        → LBFT-weakestPre (constructLedgerInfoM proposedBlock consensusDataHash) P pre
+
+-- TUTORIAL: Weakest preconditions generated from conditionals, translating a
+-- boolean equality test to proofs of (in)equality.
+module verifyEpochMSpec (epoch : Epoch) (safetyData : SafetyData) where
+  -- The body of `verifyEpochM` is:
+  -- > ifM not ⌊ epoch ≟ℕ safetyData ^∙ sdEpoch ⌋
+  -- >   then bail fakeErr -- log: error: incorrect epoch
+  -- >   else ok unit
+  contract
+    : ∀ P pre
+      → (epoch ≢ safetyData ^∙ sdEpoch → P (inj₁ fakeErr) pre [])
+      → (epoch ≡ safetyData ^∙ sdEpoch → P (inj₂ unit) pre [])
+      → LBFT-weakestPre (verifyEpochM epoch safetyData) P pre
+  -- The outermost node of the AST of `verifyEpochM` is `ifM_then_else_ ...`, so
+  -- our goal is to return a product: one proof corresponding to the "then" case
+  -- one and one proof corresponding to the "else" case.
+  --
+  -- 1. In the "then" case, we recieve a proof `e≢` that
+  --    > toBool (not ⌊ epoch ≟ℕ safetyData ^∙ sdEpoch ⌋) ≡ true
+  proj₁ (contract Post pre pfBail pfOk) e≢
+  --    - abstract over the expression that prevents us from analyzing this evidence
+     with epoch ≟ℕ safetyData ^∙ sdEpoch
+  --    - Agda can tell that `yes pf` is not an option, since e≢ would have type
+  --      `false ≡ true` in that case
+  ...| no  pf = pfBail pf
+  -- 2. In the "else" case, we receive a proof `e≡` that
+  --    > toBool (not ⌊ epoch ≟ℕ safetyData ^∙ sdEpoch ⌋) ≡ false
+  proj₂ (contract Post pre pfBail pfOk) e≡
+  --    - perform the same `with` abstraction as the previous case
+     with epoch ≟ℕ safetyData ^∙ sdEpoch
+  --    - Agda can tell that `no pf` is not an option
+  ...| yes pf = pfOk pf
+
+
+-- TUTORIAL: Translating boolean comparison tests to proofs.
+module verifyAndUpdateLastVoteRoundMSpec (round : Round) (safetyData : SafetyData) where
+  safetyData' = safetyData & sdLastVotedRound ∙~ round
+  -- This example shows that we could have further simplified the proof of the
+  -- contract for `verifyEpochM`. In `LibraBFT.Prelude`, we define lemmas
+  -- > toWitnessT : ∀{ℓ}{P : Set ℓ}{d : Dec P} → ⌊ d ⌋ ≡ true → P
+  -- > toWitnessF : ∀{ℓ}{P : Set ℓ}{d : Dec P} → ⌊ d ⌋ ≡ false → ¬ P
+  -- which extract the underlying proof used to construct `d` given evidence
+  -- that "lowering" `d` to a boolean produces `true` or `false`.
+  contract
+    : ∀ P pre
+      → ((r>lvr : round > safetyData ^∙ sdLastVotedRound) → P (Right safetyData') pre [])
+      → ((r≤lvr : ¬ (round > safetyData ^∙ sdLastVotedRound)) → P (Left fakeErr) pre [])
+      → LBFT-weakestPre (verifyAndUpdateLastVoteRoundM round safetyData) P pre
+  proj₁ (contract Post pre pfOk pfBail) r>lvr = pfOk (toWitnessT r>lvr)
+  proj₂ (contract Post pre pfOk pfBail) ¬r>lvr = pfBail (toWitnessF ¬r>lvr)
+
+
+module verifyQcMSpec (qc : QuorumCert) where
+  postulate
+    -- TODO-1: This contract needs refinement.
+    contract
+      : ∀ P pre
+        → (P (inj₁ fakeErr) pre [])
+        → (P (inj₂ unit) pre [])
+        → LBFT-weakestPre (verifyQcM qc) P pre
+
+module constructAndSignVoteMSpec where
+
+  ResultCorrect : (pre post : RoundManager) (epoch : Epoch) (round : Round) (r : Either FakeErr Vote) → Set
+  ResultCorrect pre post epoch round (Left e) = NoVoteCorrect pre post
+  ResultCorrect pre post epoch round (Right v) = VoteCorrect pre post epoch round v
+
+  record Contract (pre : RoundManager) (epoch : Epoch) (round : Round) (r : Either FakeErr Vote) (post : RoundManager) (outs : List Output) : Set where
+    field
+      noOuts        : NoMsgOuts outs
+      inv           : Invariant₂ pre post
+      resultCorrect : ResultCorrect pre post epoch round r
+
+  private
+    contractEasy : ∀ {pre e epoch round} → Contract pre epoch round (Left e) pre []
+    Contract.noOuts contractEasy = refl
+    Invariant₂.es≡₁ (Contract.inv contractEasy) = refl
+    Invariant₂.es≡₂ (Contract.inv contractEasy) = refl
+    NoVoteCorrect.lv≡ (Contract.resultCorrect contractEasy) = refl
+    NoVoteCorrect.lvr≤ (Contract.resultCorrect contractEasy) = ≤-refl
+
+
+  module continue2
+    (voteProposal : VoteProposal) (validatorSigner : ValidatorSigner)
+    (proposedBlock : Block) (safetyData : SafetyData) where
+
+    open constructAndSignVoteM-continue2 voteProposal validatorSigner proposedBlock safetyData
+
+    record Requirements (pre : RoundManager) : Set where
+      field
+        es≡  : (pre ^∙ lSafetyData) ≡L safetyData at sdEpoch -- pre ^∙ lSafetyData ∙ sdEpoch ≡ safetyData ^∙ sdEpoch at (lSafetyData ∙ sdEpoch , sdEpoch)
+        lv≡  : (pre ^∙ lSafetyData) ≡L safetyData at sdLastVote
+        lvr≡ : (pre ^∙ lSafetyData) ≡L safetyData at sdLastVotedRound
+        vp≡pb : proposedBlock ≡ voteProposal ^∙ vpBlock
+
+    epoch = voteProposal ^∙ vpBlock ∙ bEpoch
+    round = voteProposal ^∙ vpBlock ∙ bRound
+
+    contract
+      : ∀ pre
+        → Requirements pre
+        → LBFT-weakestPre
+            (constructAndSignVoteM-continue2 voteProposal validatorSigner proposedBlock safetyData)
+            (Contract pre epoch round) pre
+    contract pre reqs =
+      verifyAndUpdateLastVoteRoundMSpec.contract (proposedBlock ^∙ bRound) safetyData
+        (RWST-weakestPre-ebindPost unit step₁ (Contract pre epoch round)) pre
+          (λ where
+            r>lvr safetyData1@._ refl ._ refl .unit refl →
+              extensionCheckMSpec.contract voteProposal
+                (RWST-weakestPre-ebindPost unit (step₂ safetyData1) (Contract pre epoch round)) (pre & lSafetyData ∙~ safetyData1)
+                  (bailAfterSetSafetyData r>lvr)
+                  λ where
+                    voteData@._ refl →
+                      let author = validatorSigner ^∙ vsAuthor
+                          st₁    = pre & (lSafetyData ∙~ safetyData1) in
+                      constructLedgerInfoMSpec.contract proposedBlock (hashVD voteData)
+                        (RWST-weakestPre-bindPost unit
+                          (either (bail ∘ withErrCtxt) ok)
+                          (RWST-weakestPre-ebindPost unit (step₃ safetyData1 voteData author) (Contract pre epoch round))) st₁
+                          (λ where .(Left fakeErr) refl → bailAfterSetSafetyData r>lvr)
+                          λ where
+                            ledgerInfo ._ refl ._ refl ._ refl .unit refl .unit refl →
+                              record { noOuts = refl
+                                     ; inv =
+                                       record { es≡₁ = refl
+                                              ; es≡₂ = Requirements.es≡ reqs }
+                                     ; resultCorrect =
+                                       record { round≡ = refl
+                                              ; postLv≡ = refl
+                                              ; voteSrc =
+                                                Right (record { epoch≡ = refl
+                                                              ; lvr< = lvr<pbr r>lvr
+                                                              ; postLvr≡ = vpr≡pbr })}})
+          λ r≤lvr → contractEasy
+      where
+      vpr≡pbr : (voteProposal ^∙ vpBlock) ≡L proposedBlock at bRound
+      vpr≡pbr rewrite Requirements.vp≡pb reqs = refl
+
+      lvr<pbr : proposedBlock ^∙ bRound > safetyData ^∙ sdLastVotedRound
+                → pre ^∙ lSafetyData ∙ sdLastVotedRound < proposedBlock ^∙ bRound
+      lvr<pbr r>lvr rewrite (Requirements.lvr≡ reqs) = r>lvr
+
+      lvr≤pbr : proposedBlock ^∙ bRound > safetyData ^∙ sdLastVotedRound
+                → pre ^∙ lSafetyData ∙ sdLastVotedRound ≤ proposedBlock ^∙ bRound
+      lvr≤pbr r>lvr = <⇒≤ (lvr<pbr r>lvr)
+
+      bailAfterSetSafetyData
+        : proposedBlock ^∙ bRound > safetyData ^∙ sdLastVotedRound
+          → Contract pre epoch round (Left fakeErr) (pre & lSafetyData ∙~ verifyAndUpdateLastVoteRoundMSpec.safetyData' (proposedBlock ^∙ bRound) safetyData) []
+      Contract.noOuts (bailAfterSetSafetyData r>lvr) = refl
+      Invariant₂.es≡₁ (Contract.inv (bailAfterSetSafetyData r>lvr)) = refl
+      Invariant₂.es≡₂ (Contract.inv (bailAfterSetSafetyData r>lvr)) = Requirements.es≡ reqs
+      NoVoteCorrect.lv≡ (Contract.resultCorrect (bailAfterSetSafetyData r>lvr)) = Requirements.lv≡ reqs
+      NoVoteCorrect.lvr≤ (Contract.resultCorrect (bailAfterSetSafetyData r>lvr)) = lvr≤pbr r>lvr
+
+
+  module continue1
+    (voteProposal  : VoteProposal) (validatorSigner : ValidatorSigner)
+    (proposedBlock : Block)        (safetyData0     : SafetyData) where
+
+    open constructAndSignVoteM-continue1 voteProposal validatorSigner proposedBlock safetyData0
+
+    epoch = voteProposal ^∙ vpBlock ∙ bEpoch
+    round = voteProposal ^∙ vpBlock ∙ bRound
+
+    record Requirements (pre : RoundManager) : Set where
+      field
+        sd≡   : pre ^∙ lSafetyData ≡ safetyData0
+        vp≡pb : proposedBlock ≡ voteProposal ^∙ vpBlock
+
+    private
+      convReq₁ : ∀ {pre}
+                → Requirements pre
+                → continue2.Requirements voteProposal validatorSigner proposedBlock safetyData0 pre
+      convReq₁ record { sd≡ = refl ; vp≡pb = vp≡pb } =
+        record { es≡ = refl ; lv≡ = refl ; lvr≡ = refl ; vp≡pb = vp≡pb }
+
+      convReq₂ : ∀ {pre}
+                 → Requirements pre
+                 → continue2.Requirements voteProposal validatorSigner proposedBlock
+                     (verifyAndUpdatePreferredRoundMSpec.safetyData' (proposedBlock ^∙ bQuorumCert) safetyData0)
+                     pre
+      convReq₂ record { sd≡ = refl ; vp≡pb = vp≡pb } =
+        record { es≡ = refl ; lv≡ = refl ; lvr≡ = refl ; vp≡pb = vp≡pb }
+
+    contract
+      : ∀ pre
+        → Requirements pre
+        → LBFT-weakestPre
+            (constructAndSignVoteM-continue1 voteProposal validatorSigner proposedBlock safetyData0)
+            (Contract pre epoch round) pre
+    contract pre reqs =
+      verifyQcMSpec.contract (proposedBlock ^∙ bQuorumCert)
+        (RWST-weakestPre-ebindPost unit (λ _ → step₁) (Contract pre epoch round)) pre
+          contractEasy
+          λ where
+            ._ refl validatorVerifier@._ refl →
+              either{C = λ x → RWST-weakestPre (pure x ∙?∙ λ _ → step₃) (Contract pre epoch round) _ _}
+                (λ _ → contractEasy)
+                (λ where
+                  unit .unit refl →
+                    verifyAndUpdatePreferredRoundMSpec.contract (proposedBlock ^∙ bQuorumCert) safetyData0
+                      (RWST-weakestPre-ebindPost unit
+                        (constructAndSignVoteM-continue2 voteProposal validatorSigner proposedBlock)
+                        (Contract pre epoch round))
+                      pre
+                      (λ r≤pr → contractEasy)
+                      λ r>pr →
+                        (  λ where
+                            2cr>pr safetyData1@._ refl →
+                              continue2.contract voteProposal validatorSigner proposedBlock safetyData1 pre
+                                reqs₂)
+                        , (λ where
+                             2cr<pr safetyData1@._ refl →
+                               continue2.contract voteProposal validatorSigner proposedBlock safetyData1 pre
+                                 reqs₁)
+                        , λ where
+                            2cr=pr safetyData1@._ refl →
+                              continue2.contract voteProposal validatorSigner proposedBlock safetyData1 pre
+                                reqs₁)
+                (Block.validateSignature proposedBlock validatorVerifier)
+      where
+      reqs₁ : continue2.Requirements voteProposal validatorSigner proposedBlock safetyData0 pre
+      reqs₁
+         with Requirements.sd≡ reqs
+      ...| refl = record { es≡ = refl ; lv≡ = refl ; lvr≡ = refl ; vp≡pb = Requirements.vp≡pb reqs }
+
+      reqs₂ : continue2.Requirements voteProposal validatorSigner proposedBlock
+                (verifyAndUpdatePreferredRoundMSpec.safetyData' (proposedBlock ^∙ bQuorumCert) safetyData0)
+                pre
+      reqs₂
+         with Requirements.sd≡ reqs
+      ...| refl = record { es≡ = refl ; lv≡ = refl ; lvr≡ = refl ; vp≡pb = Requirements.vp≡pb reqs }
+
+  module continue0
+    (voteProposal  : VoteProposal) (validatorSigner : ValidatorSigner) where
+
+    open constructAndSignVoteM-continue0 voteProposal validatorSigner
+
+    epoch = voteProposal ^∙ vpBlock ∙ bEpoch
+    round = voteProposal ^∙ vpBlock ∙ bRound
+
+    contract
+      : ∀ pre
+        → LBFT-weakestPre
+            (constructAndSignVoteM-continue0 voteProposal validatorSigner) (Contract pre epoch round) pre
+    contract pre safetyData0@._ refl =
+      verifyEpochMSpec.contract (proposedBlock ^∙ bEpoch) safetyData0
+        (RWST-weakestPre-ebindPost unit (λ _ → step₁ safetyData0 ) (Contract pre epoch round)) pre
+        (λ e≢sde → contractEasy)
+        λ where
+          e≡sde .unit refl →
+            (λ ≡nothing →
+              continue1.contract voteProposal validatorSigner proposedBlock safetyData0 pre
+                (record { sd≡ = refl ; vp≡pb = refl }))
+            , λ vote vote≡ →
+              (λ lvr≡pbr →
+                record { noOuts = refl
+                       ; inv =
+                         record { es≡₁ = refl
+                                ; es≡₂ = refl }
+                                ; resultCorrect =
+                                  record { round≡ = toWitnessT lvr≡pbr
+                                         ; postLv≡ = sym vote≡
+                                         ; voteSrc = inj₁
+                                           (record { lvr≡ = refl
+                                                   ; lv≡ = refl }) } })
+              , λ lvr≢pbr →
+                continue1.contract voteProposal validatorSigner proposedBlock safetyData0 pre
+                  (record { sd≡ = refl ; vp≡pb = refl })
+
+  module _ (maybeSignedVoteProposal : MaybeSignedVoteProposal) where
+
+    voteProposal = maybeSignedVoteProposal ^∙ msvpVoteProposal
+    epoch = voteProposal ^∙ vpBlock ∙ bEpoch
+    round = voteProposal ^∙ vpBlock ∙ bRound
+
+    contract
+      : ∀ pre
+        → LBFT-weakestPre (constructAndSignVoteM maybeSignedVoteProposal) (Contract pre epoch round) pre
+    contract pre .unit refl nothing vs≡ ._ refl .unit refl =
+      record { noOuts = refl ; inv = record { es≡₁ = refl ; es≡₂ = refl } ; resultCorrect = record { lv≡ = refl ; lvr≤ = ≤-refl } }
+    contract pre .unit refl (just validatorSigner) vs≡ =
+      RWST-⇒
+        (Contract pre epoch round) Post pf
+        (constructAndSignVoteM-continue0 voteProposal validatorSigner) unit pre
+        (continue0.contract voteProposal validatorSigner pre)
+      where
+      Post : LBFT-Post (Either FakeErr Vote)
+      Post x post outs =
+        RWST-weakestPre-bindPost unit
+          (λ r → logInfo >> pure r) (Contract pre epoch round)
+          x post (LogInfo fakeInfo ∷ outs)
+
+      convNoOuts : ∀ {outs} → NoMsgOuts outs  → NoMsgOuts (LogInfo fakeInfo ∷ outs ++ LogInfo fakeInfo ∷ [])
+      convNoOuts{outs} pf rewrite List-filter-++ isOutputMsg? outs (LogInfo fakeInfo ∷ []) | pf = refl
+
+      pf : ∀ r st outs → Contract pre epoch round r st outs → Post r st outs
+      pf r st outs record { noOuts = noOuts ; inv = inv ; resultCorrect = resultCorrect } .r refl .unit refl =
+        record { noOuts = convNoOuts{outs} noOuts
+               ; inv = inv ; resultCorrect = resultCorrect }
+
+private
+  module Tutorial
+    (voteProposal : VoteProposal) (validatorSigner : ValidatorSigner)
+    (proposedBlock : Block)       (safetyData : SafetyData) where
+
+    -- After some experience with these proofs, it (allegedly)
+    -- becomes fairly straightforward to let Agda do a lot of the
+    -- work, and unfold the proof as we go.  However, it is
+    -- important to understand what's going on under the hood to be
+    -- able to reliably do this.  For the proof below, we do it in
+    -- excruciating detail "by hand" in comments as an example to
+    -- help ourselves understand.
+
+    -- For this example, we will prove that `step₃` of (and old version of)
+    -- `constructAndSignVoteM-continue2` produces no output.
+
+    Contract : LBFT-Post (Either FakeErr Vote)
+    Contract x post outs = outs ≡ []
+
+    step₃ : SafetyData → VoteData → Author → LedgerInfo → LBFT (Either FakeErr Vote)
+    step₃ safetyData1 voteData author ledgerInfo = do
+      let signature = ValidatorSigner.sign validatorSigner ledgerInfo
+          vote      = Vote.newWithSignature voteData author ledgerInfo signature
+      lSafetyData ∙= (safetyData1 & sdLastVote ?~ vote)
+      ok vote
+
+    step₃-contract
+      : ∀ pre safetyData1 voteData author ledgerInfo
+        → LBFT-weakestPre
+            (step₃ safetyData1 voteData author ledgerInfo)
+            Contract pre
+    step₃-contract pre safetyData1 voteData author ledgerInfo
+    {-
+    The proof can be as simple as this:
+
+       = λ _ _ _ _ _ _ → refl
+
+    Easy, right?!  Oh, you want a little more detail?  Sure here you go:
+
+       = λ where .pre refl →
+                  λ where .unit refl →
+                           λ where .unit refl →
+                                    refl   -- Indenting important for parsing
+
+    Still not crystal clear?  OK, let's explore in a little more detail.
+
+    The initial goal looks like this:
+
+    RWST-weakestPre-bindPost unit
+      (λ st →
+         RWST-put
+         (LibraBFT.ImplShared.Consensus.Types.s st
+          ((λ { F rf f (SafetyRules∙new v vv vvv)
+                  → (rf Category.Functor.RawFunctor.<$>
+                     (λ y' → SafetyRules∙new y' vv vvv))
+                    (f v)
+              })
+           (λ x → x) Optics.Functorial.if
+           ((λ { F rf f (PersistentSafetyStorage∙new v vv)
+                   → (rf Category.Functor.RawFunctor.<$>
+                      (λ y' → PersistentSafetyStorage∙new y' vv))
+                     (f v)
+               })
+            (λ x → x) Optics.Functorial.if
+            (λ _ →
+               safetyData1 &
+               sdLastVote ?~
+               Vote.newWithSignature voteData author ledgerInfo
+               (ValidatorSigner.sign validatorSigner ledgerInfo)))
+           (LibraBFT.ImplShared.Consensus.Types.g st))))
+      (RWST-weakestPre-bindPost unit
+       (λ _ →
+          RWST-return
+          (inj₂
+           (Vote.newWithSignature voteData author ledgerInfo
+            (ValidatorSigner.sign validatorSigner ledgerInfo))))
+       Contract)
+      pre pre []
+
+   It looks a bit ugly, but if we use C-u C-c C-, we get a more
+   readable version that is exactly what we expect:
+
+     LBFT-weakestPre (step₃ safetyData1 voteData author ledgerInfo)
+                     Contract
+                     pre
+
+   Let's start refining by hand to understand.
+
+   By desugaring the definition of "step₃ safetyData voteData author
+   ledgerInfo" a bit, we can see that it is (using some shorthand in
+   "quotes" to keep it concise at the expense of accuracy):
+
+      (RWST-bind
+         (RWST-bind
+            (RWST-gets id)                                                                -- Fetch the state.
+            (λ st → RWST-put (st & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote")))-- Modify the state returned by RWST-get.
+         (λ _ → RWST-return (inj₂ "vote"))                                                -- The Unit returned by RWST-bind
+                                                                                          -- via RWST-put is ignored
+
+      Note that "vote" is: Vote.newWithSignature voteData author ledgerInfo
+                             (ValidatorSigner.sign validatorSigner ledgerInfo)
+
+   Rewriting our goal with this yields (the annotations on the right
+   show how we instantiate the rules in the next step):
+
+     RWST-weakestPre
+      (RWST-bind
+         (RWST-bind                                                              = m
+            (RWST-gets id)
+            (λ st → RWST-put (st & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote")))
+         (λ _ → RWST-return (inj₂ "vote"))                                       = f
+      Contract                                                                   = P
+      unit                                                                       = ev
+      pre                                                                        = st
+
+   Applying the definition of RWST-weakestPre (RWST-bind...), we need:
+
+     RWST-weakestPre
+       (RWST-bind
+            (RWST-gets id)                                                                 = m
+            (λ st → RWST-put (st & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote"))) = f
+       (RWST-weakestPre-bindPost unit                                                      = P
+         (λ _ → RWST-return (inj₂ vote))
+         Contract)
+       unit                                                                                = ev
+       pre                                                                                 = pre
+
+   Applying the definition of RWST-weakestPre (RWST-bind...) again, we have:
+
+     RWST-weakestPre
+       (RWST-gets id)
+       (RWST-weakestPre-bindPost unit                                            = P
+         (λ st → RWST-put (st & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote")))
+         (RWST-weakestPre-bindPost unit
+           (λ _ → RWST-return (inj₂ vote))
+           Contract))
+       unit                                                                      = ev
+       pre                                                                       = pre
+
+   Now applying the definition of RWST-weakestPre RWST-gets, we want:
+
+     (RWST-weakestPre-bindPost
+         unit                                                                           = ev
+         (λ st → RWST-put (st & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote"))) = f
+         (RWST-weakestPre-bindPost unit                                                 = Post
+           (λ _ → RWST-return (inj₂ "vote"))
+           Contract))
+       pre                                                                              = x
+       pre                                                                              = post
+       []                                                                               = outs
+
+   Take a moment to compare this with our initial goal above.  They
+   look identical, except for the shorthand.
+
+   Next, we apply the definition of RWST-weakestPre-bindPost:
+
+     ∀ r → r ≡ pre →
+       RWST-weakestPre
+         (RWST-put (r & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote")))
+         (RWST-Post++
+           (RWST-weakestPre-bindPost unit                                        = P
+             (λ _ → RWST-return (inj₂ "vote"))
+             Contract)
+           [])                                                                   = outs
+         unit
+         pre
+
+   Notice that our "f" (the put operation) is applied to the quantified variable
+   "r". This is to reduce the size of the refined goal after substitution
+   (instead of "pre", in general "r" could be equal to a much more complex expression).
+
+   Applying the definition of RWST-Post++, we have:
+
+     ∀ r → r ≡ pre →
+       RWST-weakestPre
+         (RWST-put (r & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote")))
+         (λ x post outs₁ → (RWST-weakestPre-bindPost unit
+                             (λ _ → RWST-return (inj₂ "vote"))
+                             Contract) x post ([] ++ outs₁))
+         unit
+         pre
+
+   Our proof begins by peeling of the two first parameters, the first
+   of which must be pre, due to the second:
+
+   -}
+
+       = λ where .pre refl →
+
+   {-
+
+   At this point, our goal looks like (using C-u C-c C-,):
+
+   RWST-weakestPre
+      (RWST-put
+       (over lSafetyData
+        (λ _ →
+           safetyData1 &
+           sdLastVote ?~
+           Vote.newWithSignature voteData author ledgerInfo
+           (ValidatorSigner.sign validatorSigner ledgerInfo))
+        pre))
+      (λ x post outs₁ →
+         RWST-weakestPre-bindPost unit
+         (λ _ →
+            RWST-return
+            (inj₂
+             (Vote.newWithSignature voteData author ledgerInfo
+              (ValidatorSigner.sign validatorSigner ledgerInfo))))
+         Contract x post ([] ++ outs₁))
+      unit pre
+
+   We can see that this is a more precise version of what we have above (without the shorthand),
+   repeated here:
+
+       RWST-weakestPre
+         (RWST-put (pre & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote"))) = post
+         (λ x post outs₁ → (RWST-weakestPre-bindPost unit                         = P
+                             (λ _ → RWST-return (inj₂ "vote"))
+                             Contract) x post ([] ++ outs₁))
+         unit
+         pre
+
+   Next, we apply the definition of RWST-weakestPre (RWST-put ...)
+
+      (λ x post outs₁ → (RWST-weakestPre-bindPost unit
+                          (λ _ → RWST-return (inj₂ "vote"))
+                          Contract) x post ([] ++ outs₁))
+      unit
+      (pre & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote"))
+      []
+
+    Instantiating,
+
+      RWST-weakestPre-bindPost
+       unit                                                                   = ev
+       (λ _ → RWST-return (inj₂ "vote"))                                      = f
+       Contract                                                               = Post
+       unit                                                                   = x
+       (pre & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote"))          = post
+       ([] ++ []))                                                            = outs
+
+    Applying the definition of RWST-weakestPre-bindPost once again, we have:
+
+      ∀ r → r ≡ unit → RWST-weakestPre
+                         (RWST-return (inj₂ "vote"))
+                         (RWST-Post++
+                           Contract                                           = P
+                           ([] ++ [])))                                       = outs
+                         unit
+                         (pre & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote"))
+
+    And applying the definition of RWST-Post++ yields:
+
+      ∀ r → r ≡ unit → RWST-weakestPre
+                         (RWST-return (inj₂ "vote"))
+                         (λ x post outs₁ → Contract rm x post ([] ++ [] ++ outs₁))
+                         unit
+                         (pre & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote"))
+
+    Peeling off another couple of parameters (the first must be unit because of the second):
+ -}
+
+                      λ where .unit refl →
+
+
+ {-
+
+ The goal now looks like (using C-c C-,):
+
+    Contract
+      (inj₂
+       (Vote.newWithSignature voteData author ledgerInfo
+        (ValidatorSigner.sign validatorSigner ledgerInfo)))
+      (LibraBFT.ImplShared.Consensus.Types.s pre
+       ((λ { F rf f (SafetyRules∙new v vv vvv)
+               → (rf Category.Functor.RawFunctor.<$>
+                  (λ y' → SafetyRules∙new y' vv vvv))
+                 (f v)
+           })
+        (λ x → x) Optics.Functorial.if
+        ((λ { F rf f (PersistentSafetyStorage∙new v vv)
+                → (rf Category.Functor.RawFunctor.<$>
+                   (λ y' → PersistentSafetyStorage∙new y' vv))
+                  (f v)
+            })
+         (λ x → x) Optics.Functorial.if
+         (λ _ →
+            safetyData1 &
+            sdLastVote ?~
+            Vote.newWithSignature voteData author ledgerInfo
+            (ValidatorSigner.sign validatorSigner ledgerInfo)))
+        (LibraBFT.ImplShared.Consensus.Types.g pre)))
+      []
+
+ Applying our shorthand, this yields:
+
+    Contract
+      (inj₂ "vote")
+      (pre & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote"))
+      []
+
+ Or (using C-u C-c C-,), we have the following goal:
+
+    RWST-weakestPre
+      (RWST-return
+       (inj₂
+        (Vote.newWithSignature voteData author ledgerInfo
+         (ValidatorSigner.sign validatorSigner ledgerInfo))))
+      (λ x post outs₁ → Contract x post (([] ++ []) ++ outs₁)) unit
+      (over lSafetyData
+       (λ _ →
+          safetyData1 &
+          sdLastVote ?~
+          Vote.newWithSignature voteData author ledgerInfo
+          (ValidatorSigner.sign validatorSigner ledgerInfo))
+       pre)
+
+ Applying our shorthand, this yields:
+
+     RWST-weakestPre
+       (RWST-return (inj₂ "vote"))                                       = x
+       (λ x post outs₁ → Contract x post ([] ++ [] ++ outs₁))            = P
+       unit                                                              = ev
+       (pre & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote"))     = pre
+
+   Again, this looks like what we expect from above, so we can press
+   on.  Now, applying the definition of RWST-weakestPre (RWST-return ...):
+
+     (λ x post outs₁ → Contract x post ([] ++ [] ++ outs₁))
+        (RWST-return (inj₂ "vote"))
+        (pre & lSafetyData ∙~ ("safetyData1" & sdLastVote ?~ "vote"))
+        []
+
+   Finally, this reduces to the goal of:
+
+     [] ≡ []
+
+   which we prove with
+   -}
+                               refl

--- a/LibraBFT/Impl/OBM/Logging/Logging.agda
+++ b/LibraBFT/Impl/OBM/Logging/Logging.agda
@@ -18,6 +18,11 @@ logErr = tell1 (LogErr fakeErr)
 logInfo : LBFT Unit
 logInfo = tell1 (LogInfo fakeInfo)
 
+-- NOTE: The logging functionality below has been added because, in the future,
+-- we may wish to model and reason about errors and logging in more detail.
+-- Logging operations change the structure of the program, and proofs about peer
+-- operations are sensitive to this structure. Therefore, we add a "skeleton" of
+-- logging operations so that future refinements do not break existing proofs.
 withErrCtxt : FakeErr → FakeErr
 withErrCtxt = id
 

--- a/LibraBFT/Impl/OBM/Logging/Logging.agda
+++ b/LibraBFT/Impl/OBM/Logging/Logging.agda
@@ -12,8 +12,14 @@ open import LibraBFT.Prelude
 
 module LibraBFT.Impl.OBM.Logging.Logging where
 
-  logErr : LBFT Unit
-  logErr = tell1 (LogErr fakeErr)
+logErr : LBFT Unit
+logErr = tell1 (LogErr fakeErr)
 
-  logInfo : LBFT Unit
-  logInfo = tell1 (LogInfo fakeInfo)
+logInfo : LBFT Unit
+logInfo = tell1 (LogInfo fakeInfo)
+
+withErrCtxt : FakeErr → FakeErr
+withErrCtxt = id
+
+logEE : ∀ {A} → LBFT A → LBFT A
+logEE f = logInfo >> f >>= λ r → logInfo >> pure r

--- a/LibraBFT/ImplShared/Interface/Output.agda
+++ b/LibraBFT/ImplShared/Interface/Output.agda
@@ -31,11 +31,25 @@ module LibraBFT.ImplShared.Interface.Output where
   IsSendVote : Output → Set
   IsSendVote out = ∃₂ λ mv pid → out ≡ SendVote mv pid
 
+  IsBroadcastProposal : Output → Set
+  IsBroadcastProposal out = ∃[ pm ] (out ≡ BroadcastProposal pm)
+
   isSendVote? : (out : Output) → Dec (IsSendVote out)
   isSendVote? (BroadcastProposal _) = no λ ()
   isSendVote? (LogErr _)            = no λ ()
   isSendVote? (LogInfo _)           = no λ ()
   isSendVote? (SendVote mv pid)     = yes (mv , pid , refl)
+
+  isBroadcastProposal? : (out : Output) →  Dec (IsBroadcastProposal out)
+  isBroadcastProposal? (BroadcastProposal pm) = yes (pm , refl)
+  isBroadcastProposal? (LogErr _) = no λ ()
+  isBroadcastProposal? (LogInfo _) = no λ ()
+  isBroadcastProposal? (SendVote _ _) = no λ ()
+
+  IsOutputMsg : Output → Set
+  IsOutputMsg = IsBroadcastProposal ∪ IsSendVote
+
+  isOutputMsg? = isBroadcastProposal? ∪? isSendVote?
 
   SendVote∉Output : ∀ {vm pid outs} → List-filter isSendVote? outs ≡ [] → ¬ (SendVote vm pid ∈ outs)
   SendVote∉Output () (here refl)

--- a/LibraBFT/ImplShared/Interface/Output.agda
+++ b/LibraBFT/ImplShared/Interface/Output.agda
@@ -29,22 +29,28 @@ module LibraBFT.ImplShared.Interface.Output where
   SendVote-inj-si refl = refl
 
   IsSendVote : Output → Set
-  IsSendVote out = ∃₂ λ mv pid → out ≡ SendVote mv pid
+  IsSendVote (BroadcastProposal _) = ⊥
+  IsSendVote (LogErr _) = ⊥
+  IsSendVote (LogInfo _) = ⊥
+  IsSendVote (SendVote _ _) = ⊤
 
   IsBroadcastProposal : Output → Set
-  IsBroadcastProposal out = ∃[ pm ] (out ≡ BroadcastProposal pm)
+  IsBroadcastProposal (BroadcastProposal _) = ⊤
+  IsBroadcastProposal (LogErr _) = ⊥
+  IsBroadcastProposal (LogInfo _) = ⊥
+  IsBroadcastProposal (SendVote _ _) = ⊥
 
   isSendVote? : (out : Output) → Dec (IsSendVote out)
   isSendVote? (BroadcastProposal _) = no λ ()
   isSendVote? (LogErr _)            = no λ ()
   isSendVote? (LogInfo _)           = no λ ()
-  isSendVote? (SendVote mv pid)     = yes (mv , pid , refl)
+  isSendVote? (SendVote mv pid)     = yes tt
 
   isBroadcastProposal? : (out : Output) →  Dec (IsBroadcastProposal out)
-  isBroadcastProposal? (BroadcastProposal pm) = yes (pm , refl)
-  isBroadcastProposal? (LogErr _) = no λ ()
-  isBroadcastProposal? (LogInfo _) = no λ ()
-  isBroadcastProposal? (SendVote _ _) = no λ ()
+  isBroadcastProposal? (BroadcastProposal _) = yes tt
+  isBroadcastProposal? (LogErr _)            = no λ ()
+  isBroadcastProposal? (LogInfo _)           = no λ ()
+  isBroadcastProposal? (SendVote _ _)        = no λ ()
 
   IsOutputMsg : Output → Set
   IsOutputMsg = IsBroadcastProposal ∪ IsSendVote

--- a/LibraBFT/ImplShared/Util/RWST/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/RWST/Syntax.agda
@@ -107,6 +107,10 @@ m ∙^∙ f = do
   x ← m
   either (bail ∘ f) ok x
 
+RWST-weakestPre-∙^∙Post : (ev : Ev) (e : C → C) → RWST-Post Wr St (C ⊎ A) → RWST-Post Wr St (C ⊎ A)
+RWST-weakestPre-∙^∙Post ev e Post =
+  RWST-weakestPre-bindPost ev (either (bail ∘ e) ok) Post
+
 -- Lens functionality
 --
 -- If we make RWST work for different level State types, we will break use and

--- a/LibraBFT/ImplShared/Util/RWST/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/RWST/Syntax.agda
@@ -105,9 +105,7 @@ infixl 4 _∙^∙_
 _∙^∙_ : RWST Ev Wr St (Either B A) → (B → B) → RWST Ev Wr St (Either B A)
 m ∙^∙ f = do
   x ← m
-  caseM⊎ x of λ where
-    (Left e) → pure (Left (f e))
-    (Right r) → pure (Right r)
+  either (bail ∘ f) ok x
 
 -- Lens functionality
 --

--- a/LibraBFT/ImplShared/Util/Util.agda
+++ b/LibraBFT/ImplShared/Util/Util.agda
@@ -56,9 +56,11 @@ module LibraBFT.ImplShared.Util.Util where
     put (record st { _rmWithEC = stec₁ })
     return r₁
 
+  LBFT-Pre  = RoundManager → Set
+  LBFT-Post = RWST-Post Output RoundManager
+
   LBFT-weakestPre : ∀ {A} (m : LBFT A)
-                    → (Post : RWST-Post Output RoundManager A)
-                    → RoundManager → Set
+                    → LBFT-Post A → LBFT-Pre
   LBFT-weakestPre m Post pre = RWST-weakestPre m Post unit pre
 
   LBFT-Contract : ∀ {A} (m : LBFT A) → Set₁

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -18,7 +18,7 @@ module LibraBFT.Prelude where
     public
 
   open import Function
-    using (_∘_; id; case_of_; _on_; typeOf; flip; const; _∋_)
+    using (_∘_; id; case_of_; _on_; typeOf; flip; const; _∋_; _$_)
     public
 
   infixl 1 _&_
@@ -45,7 +45,7 @@ module LibraBFT.Prelude where
     public
 
   open import Data.List.Properties
-    renaming (≡-dec to List-≡-dec; length-map to List-length-map; map-compose to List-map-compose)
+    renaming (≡-dec to List-≡-dec; length-map to List-length-map; map-compose to List-map-compose; filter-++ to List-filter-++)
     using (∷-injective; length-++; map-++-commute; sum-++-commute; map-tabulate; ++-identityʳ)
     public
 
@@ -231,6 +231,14 @@ module LibraBFT.Prelude where
     using (Setoid; IsPreorder)
     public
 
+  open import Relation.Unary
+    using (_∪_)
+    public
+
+  open import Relation.Unary.Properties
+    using (_∪?_)
+    public
+
   -- Evidence that a function is not injective
   NonInjective : ∀{a b c}{A : Set a}{B : Set b}
                → (_≈_ : Rel A c)
@@ -324,6 +332,12 @@ module LibraBFT.Prelude where
 
     ToBool-Dec : ∀{a}{A : Set a} → ToBool (Dec A)
     ToBool-Dec = record { toBool = ⌊_⌋ }
+
+  toWitnessT : ∀{ℓ}{P : Set ℓ}{d : Dec P} → ⌊ d ⌋ ≡ true → P
+  toWitnessT {d = yes proof} _ = proof
+
+  toWitnessF : ∀{ℓ}{P : Set ℓ}{d : Dec P} → ⌊ d ⌋ ≡ false → ¬ P
+  toWitnessF{d = no proof} _ = proof
 
   infix 3 _≔_
   data GuardClause {a}{b}(A : Set a) : Set (a ℓ⊔ ℓ+1 b) where

--- a/Optics/Functorial.agda
+++ b/Optics/Functorial.agda
@@ -71,3 +71,10 @@ module Optics.Functorial where
   infixr 30 _∙_
   _∙_ : ∀{S A B} → Lens S A → Lens A B → Lens S B
   (lens p) ∙ (lens q) = lens (λ F rf x x₁ → p F rf (q F rf x) x₁)
+
+  -- Relation between the same field of two states
+  _[_]L_at_ : ∀ {ℓ} {S A} → S → (A → A → Set ℓ) → S → Lens S A → Set ℓ
+  s₁ [ _~_ ]L s₂ at l = (s₁ ^∙ l) ~ (s₂ ^∙ l)
+
+  _≡L_at_ : ∀ {S A} → (s₁ s₂ : S) → Lens S A → Set
+  _≡L_at_ = _[ _≡_ ]L_at_


### PR DESCRIPTION
This PR adds info logging to the functions in `SafetyRules`, and re-does the proofs from `chris-dijkstra-monad` to account for these changes.