### PR TITLE
fix top level indent of 3 new Impl files

### DIFF
--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -21,21 +21,21 @@ open import Optics.All
 
 module LibraBFT.Impl.IO.OBM.InputOutputHandlers where
 
-  epvv : LBFT (Epoch × ValidatorVerifier)
-  epvv = _,_ <$> gets (_^∙ rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch ∘ _rmEC)
-             <*> gets (_^∙ rmEpochState ∙ esVerifier ∘ _rmEC)
+epvv : LBFT (Epoch × ValidatorVerifier)
+epvv = _,_ <$> gets (_^∙ rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch ∘ _rmEC)
+           <*> gets (_^∙ rmEpochState ∙ esVerifier ∘ _rmEC)
 
-  handleProposal : Instant → ProposalMsg → LBFT Unit
-  handleProposal now pm = do
-    (myEpoch , vv) ← epvv
-    caseM⊎ Network.processProposal {- {!!} -} pm myEpoch vv of λ where
-      (Left (Left _))  → logErr
-      (Left (Right _)) → logInfo
-      (Right _)        → RoundManager.processProposalMsgM now pm
+handleProposal : Instant → ProposalMsg → LBFT Unit
+handleProposal now pm = do
+  (myEpoch , vv) ← epvv
+  caseM⊎ Network.processProposal {- {!!} -} pm myEpoch vv of λ where
+    (Left (Left _))  → logErr
+    (Left (Right _)) → logInfo
+    (Right _)        → RoundManager.processProposalMsgM now pm
 
-  handle : NodeId → NetworkMsg → Instant → LBFT Unit
-  handle _self msg now =
-     case msg of λ where
-       (P pm) → handleProposal now pm
-       (V vm) → {!!} -- TODO-1: processVote now v
-       (C cm) → return unit    -- We don't do anything with commit messages, they are just for defining Correctness.
+handle : NodeId → NetworkMsg → Instant → LBFT Unit
+handle _self msg now =
+  case msg of λ where
+    (P pm) → handleProposal now pm
+    (V vm) → {!!} -- TODO-1: processVote now v
+    (C cm) → return unit    -- We don't do anything with commit messages, they are just for defining Correctness.

--- a/LibraBFT/Impl/Types/ValidatorSigner.agda
+++ b/LibraBFT/Impl/Types/ValidatorSigner.agda
@@ -8,7 +8,8 @@ open import LibraBFT.Base.Encode
 open import LibraBFT.Base.PKCS                           as PKCS hiding (sign)
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
+
 module LibraBFT.Impl.Types.ValidatorSigner where
 
-  sign : {C : Set} ⦃ enc : Encoder C ⦄ → ValidatorSigner → C → Signature
-  sign (ValidatorSigner∙new _ sk) c = PKCS.sign-encodable c sk
+sign : {C : Set} ⦃ enc : Encoder C ⦄ → ValidatorSigner → C → Signature
+sign (ValidatorSigner∙new _ sk) c = PKCS.sign-encodable c sk


### PR DESCRIPTION
We have agreed that ALL new files will not indent the top level module, e.g.,

```
module foo where

stuff (not indented)

more stuff
```

This commit "fixes" 3 new files that were still indenting.