### PR TITLE
finish parts of RoundManager processVoteM

### DIFF
--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -225,13 +225,10 @@ processVoteM now vote =
 addVoteM now vote = do
   s ← get -- IMPL-DIFF: see comment NO-DEPENDENT-LENSES
   let bs = rmGetBlockStore s
-  -- CHRIS: could you uncomment this (and remove the continue below)
-  -- and then help me understand the type checking problems?
-  -- maybeS (bsHighestTimeoutCert bs) continue λ tc →
-  --   if-dec (vote ^∙ vRound) ≟ tc ^∙ tcRound
-  --     then logInfo -- "block already has TC", "dropping unneeded vote"
-  --     else continue
-  continue
+  maybeS-RWST (bsHighestTimeoutCert _ bs) continue λ tc →
+    ifM vote ^∙ vRound ≟ℕ tc ^∙ tcRound
+      then logInfo -- "block already has TC", "dropping unneeded vote"
+      else continue
  where
   continue : LBFT Unit
   continue = do

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -220,7 +220,11 @@ processVoteM now vote =
     let bs = rmGetBlockStore s
     ifM is-just (BlockStore.getQuorumCertForBlock blockId bs)
       then logInfo
-      else addVoteM now vote -- TODO-1: logging
+      else do
+      logInfo
+      addVoteM now vote
+      pvA ← use lPendingVotes
+      logInfo
 
 addVoteM now vote = do
   s ← get -- IMPL-DIFF: see comment NO-DEPENDENT-LENSES

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -265,6 +265,11 @@ module LibraBFT.ImplShared.Consensus.Types where
   lPersistentSafetyStorage : Lens RoundManager PersistentSafetyStorage
   lPersistentSafetyStorage = lSafetyRules ∙ srPersistentStorage
 
+  -- IMPL-DIFF : this is defined as a lens getter only (no setter) in Haskell.
+  rmPgAuthor : RoundManager → Maybe Author
+  rmPgAuthor rm =
+    maybeS (_rmEC rm ^∙ rmSafetyRules ∙ srValidatorSigner) nothing (just ∘ (_^∙ vsAuthor))
+
   lSafetyData : Lens RoundManager SafetyData
   lSafetyData = lPersistentSafetyStorage ∙ pssSafetyData
 

--- a/LibraBFT/ImplShared/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochDep.agda
@@ -150,7 +150,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
       _btRootId                  : HashValue
       _btHighestCertifiedBlockId : HashValue
       _btHighestQuorumCert       : QuorumCert
-      -- btHighestTimeoutCert      : Maybe TimeoutCertificate
+      _btHighestTimeoutCert      : Maybe TimeoutCertificate
       _btHighestCommitCert       : QuorumCert
       _btPendingVotes            : PendingVotes
       _btPrunedBlockIds          : List HashValue
@@ -158,9 +158,11 @@ module LibraBFT.ImplShared.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
       _btIdToQuorumCert          : KVMap HashValue (Σ QuorumCert MetaIsValidQC)
   open BlockTree public
   unquoteDecl btIdToBlock   btRootId   btHighestCertifiedBlockId   btHighestQuorumCert
+              btHighestTimeoutCert
               btHighestCommitCert   btPendingVotes   btPrunedBlockIds
               btMaxPrunedBlocksInMem btIdToQuorumCert = mkLens (quote BlockTree)
              (btIdToBlock ∷ btRootId ∷ btHighestCertifiedBlockId ∷ btHighestQuorumCert ∷
+              btHighestTimeoutCert ∷
               btHighestCommitCert ∷ btPendingVotes ∷ btPrunedBlockIds ∷
               btMaxPrunedBlocksInMem ∷ btIdToQuorumCert ∷ [])
 
@@ -173,6 +175,10 @@ module LibraBFT.ImplShared.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   open BlockStore public
   unquoteDecl bsInner = mkLens (quote BlockStore)
              (bsInner ∷ [])
+
+  -- IMPL-DIFF : this is a getter only in Haskell
+  bsHighestTimeoutCert : BlockStore → Maybe TimeoutCertificate
+  bsHighestTimeoutCert =  _^∙ bsInner ∙ btHighestTimeoutCert
 
   -- These are the parts of the RoundManager that depend on an
   -- EpochConfig. We do not particularly care which EpochConfig

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -417,8 +417,12 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   record Timeout : Set where
     constructor Timeout∙new
     field
-      -toEpoch : Epoch
-      -toRound : Round
+      _toEpoch : Epoch
+      _toRound : Round
+  open Timeout public
+  unquoteDecl toEpoch   toRound = mkLens (quote Timeout)
+             (toEpoch ∷ toRound ∷ [])
+  postulate instance enc-Timeout : Encoder Timeout
 
   record TimeoutCertificate : Set where
     constructor mkTimeoutCertificate
@@ -431,6 +435,14 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
 
   TimeoutCertificate∙new : Timeout → TimeoutCertificate
   TimeoutCertificate∙new to = mkTimeoutCertificate to KVMap.empty
+
+  -- IMPL-DIFF : only a getter in haskell
+  tcEpoch : Lens TimeoutCertificate Epoch
+  tcEpoch = tcTimeout ∙ toEpoch
+
+  -- IMPL-DIFF : only a getter in haskell
+  tcRound : Lens TimeoutCertificate Round
+  tcRound = tcTimeout ∙ toRound
 
   record PendingVotes : Set where
     constructor PendingVotes∙new

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -572,7 +572,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     field
       _srPersistentStorage  : PersistentSafetyStorage
       _srExecutionPublicKey : Maybe PK
-      _srValidatorSigner   : Maybe ValidatorSigner
+      _srValidatorSigner    : Maybe ValidatorSigner
   open SafetyRules public
   unquoteDecl srPersistentStorage   srExecutionPublicKey   srValidatorSigner = mkLens (quote SafetyRules)
              (srPersistentStorage ∷ srExecutionPublicKey ∷ srValidatorSigner ∷ [])


### PR DESCRIPTION
- `RoundManager.processVoteM`
  - replaced a stub with a real call to `ProposerElection.isValidProposer`
    - this required implementing `rmPgAuthor` in `ImplShared.Consensus.Types`
      - NOTE: in Haskell this is a getter only lens `pgAuthor` whereas in Agda I have made it a function.
      - Do we have a way to define getter only?
  - replaced a stub with a real call to `BlockStore.getQuorumCertForBlock`
    - the stub was written before `rmGetBlockStore` existed so now can be replaced
- `RoundManager.addVoteM`
  - use `rmGetBlockStore`
  - this required adding various fields, lens and functions to timeout data
  - CHRIS: there is a note in the code pointing out a type checking problem I could use help on.
