### PR TITLE
RoundManager proofs (`executeAndVoteM`, `processProposalM`)

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -35,8 +35,6 @@ executeAndInsertBlockM b = do
       ok eb
 
 syncInfoM : LBFT SyncInfo
-syncInfoM =
-  -- IMPL-DIFF: See commment NO-DEPENDENT-LENSES
-  SyncInfo∙new <$> (get >>= pure ∘ bsHighestQuorumCert _ ∘ rmGetBlockStore)
-               <*> (get >>= pure ∘ bsHighestCommitCert _ ∘ rmGetBlockStore)
-               -- <*> (get >>= pure ∘ bsHighestTimeoutCert _ ∘ rmGetBlockStore)
+syncInfoM = liftEC $
+  SyncInfo∙new <$> use (lBlockStore ∙ bsHighestQuorumCert _)
+               <*> use (lBlockStore ∙ bsHighestCommitCert _)

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -23,7 +23,6 @@ postulate
   insertTimeoutCertificateM : TimeoutCertificate → LBFT (Either ErrLog Unit)
   getBlock : ∀ {𝓔 : EpochConfig} → HashValue → BlockStore 𝓔 → Maybe ExecutedBlock
   getQuorumCertForBlock : ∀ {𝓔 : EpochConfig} → HashValue → BlockStore 𝓔 → Maybe QuorumCert
-  syncInfoM : LBFT SyncInfo
 
 executeAndInsertBlockM : Block → LBFT (Either ErrLog ExecutedBlock)
 executeAndInsertBlockM b = do
@@ -35,3 +34,9 @@ executeAndInsertBlockM b = do
       put (rmSetBlockStore s bs')
       ok eb
 
+syncInfoM : LBFT SyncInfo
+syncInfoM =
+  -- IMPL-DIFF: See commment NO-DEPENDENT-LENSES
+  SyncInfo∙new <$> (get >>= pure ∘ bsHighestQuorumCert _ ∘ rmGetBlockStore)
+               <*> (get >>= pure ∘ bsHighestCommitCert _ ∘ rmGetBlockStore)
+               -- <*> (get >>= pure ∘ bsHighestTimeoutCert _ ∘ rmGetBlockStore)

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -19,8 +19,19 @@ open import Optics.All
 module LibraBFT.Impl.Consensus.BlockStorage.BlockStore where
 
 postulate
-  executeAndInsertBlockM : Block → LBFT (Either ErrLog ExecutedBlock)
+  executeAndInsertBlockE : ∀ {𝓔} → BlockStore 𝓔 → Block → Either ErrLog (BlockStore 𝓔 × ExecutedBlock)
   insertTimeoutCertificateM : TimeoutCertificate → LBFT (Either ErrLog Unit)
   getBlock : ∀ {𝓔 : EpochConfig} → HashValue → BlockStore 𝓔 → Maybe ExecutedBlock
   getQuorumCertForBlock : ∀ {𝓔 : EpochConfig} → HashValue → BlockStore 𝓔 → Maybe QuorumCert
   syncInfoM : LBFT SyncInfo
+
+executeAndInsertBlockM : Block → LBFT (Either ErrLog ExecutedBlock)
+executeAndInsertBlockM b = do
+  s ← get
+  let bs = rmGetBlockStore s
+  caseM⊎ executeAndInsertBlockE bs b of λ where
+    (Left e) → bail e
+    (Right (bs' , eb)) → do
+      put (rmSetBlockStore s bs')
+      ok eb
+

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -22,3 +22,12 @@ module LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockStore where
 module executeAndInsertBlockESpec {𝓔 : EpochConfig} (bs : BlockStore 𝓔) (b : Block) where
   postulate
     ebBlock≡ : ∀ {bs' eb} → executeAndInsertBlockE bs b ≡ Right (bs' , eb) → eb ^∙ ebBlock ≡ b
+
+module syncInfoMSpec where
+  syncInfo : RoundManager → SyncInfo
+  syncInfo pre =
+    SyncInfo∙new   (bsHighestQuorumCert _ ∘ rmGetBlockStore $ pre)
+                 $  bsHighestCommitCert _ ∘ rmGetBlockStore $ pre
+
+  contract : ∀ pre Post → (Post (syncInfo pre) pre []) → LBFT-weakestPre syncInfoM Post pre
+  contract pre Post pf ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl = pf

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -1,0 +1,24 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote as Vote
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Crypto
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockStore where
+
+module executeAndInsertBlockESpec {𝓔 : EpochConfig} (bs : BlockStore 𝓔) (b : Block) where
+  postulate
+    ebBlock≡ : ∀ {bs' eb} → executeAndInsertBlockE bs b ≡ Right (bs' , eb) → eb ^∙ ebBlock ≡ b

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -26,8 +26,8 @@ module executeAndInsertBlockESpec {𝓔 : EpochConfig} (bs : BlockStore 𝓔) (b
 module syncInfoMSpec where
   syncInfo : RoundManager → SyncInfo
   syncInfo pre =
-    SyncInfo∙new   (bsHighestQuorumCert _ ∘ rmGetBlockStore $ pre)
-                 $  bsHighestCommitCert _ ∘ rmGetBlockStore $ pre
+    SyncInfo∙new   (rmGetBlockStore pre ^∙ bsHighestQuorumCert _)
+                 $ (rmGetBlockStore pre ^∙ bsHighestCommitCert _)
 
   contract : ∀ pre Post → (Post (syncInfo pre) pre []) → LBFT-weakestPre syncInfoM Post pre
-  contract pre Post pf ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl = pf
+  contract pre Post pf ._ refl .unit refl .unit refl = pf

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/ExecutedBlock.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/ExecutedBlock.agda
@@ -12,6 +12,8 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock where
 
-postulate
-  maybeSignedVoteProposal : ExecutedBlock → MaybeSignedVoteProposal
+maybeSignedVoteProposal : ExecutedBlock → MaybeSignedVoteProposal
+maybeSignedVoteProposal self =
+  MaybeSignedVoteProposal∙new
+    (VoteProposal∙new (self ^∙ ebBlock))
 

--- a/LibraBFT/Impl/Consensus/Liveness/Properties/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/Properties/ProposerElection.agda
@@ -43,8 +43,8 @@ module isValidProposalMSpec (b : Block) where
   --    - we push the pure value `b ^∙ bRound` (`r` and `r≡`) into the LBFT
   --      monad, and the returned value is the result of applying `isvp-pe-a` to
   --      this
-  --    - now out of `isValidProposalM`, we are given an alias `r'` for ``
-  -- > proj₂ (contract Post pre prfF prfT) a ma≡just-a isvp isvp≡ pe pe≡ isvp-pe isvp-pe≡ .a refl isvp-pe-a isvp-pe-a≡ r r≡ r' r'≡ = {!!}
+  --    - now out of `isValidProposalM`, we are given an alias `r'` for `r`
+  -- > proj₂ (contract Post pre pfNone pf≢ pfOk) a ma≡just-a isvp isvp≡ pe pe≡ isvp-pe isvp-pe≡ .a refl isvp-pe-a isvp-pe-a≡ r r≡ r' r'≡ = {!!}
   -- 4. Since the returned value we want to reason about is directly related to
   --    the behavior of these bound functions which are partial applications of
   --    `isValidProposer`, we perform case-analysis on each of the equality

--- a/LibraBFT/Impl/Consensus/Liveness/Properties/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/Properties/ProposerElection.agda
@@ -1,0 +1,66 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import Optics.All
+open import LibraBFT.Base.Types
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Impl.Consensus.Liveness.ProposerElection
+open import LibraBFT.Lemmas
+open import LibraBFT.Prelude
+
+module LibraBFT.Impl.Consensus.Liveness.Properties.ProposerElection where
+
+-- TUTORIAL
+module isValidProposalMSpec (b : Block) where
+  contract
+    : ∀ Post pre
+      → let pe = pre ^∙ lProposerElection
+            ma = b ^∙ bAuthor
+            r  = b ^∙ bRound in
+        (ma ≡ nothing ⊎ Maybe-Any (getValidProposer pe r ≢_) ma → Post false pre [])
+        → (Maybe-Any (getValidProposer pe r ≡_) ma → Post true pre [])
+        → RWST-weakestPre (isValidProposalM b) Post unit pre
+  -- 1. `isValidProposalM` begins with `caseMM`, so we must provide two cases:
+  --    one where `b ^∙ bAuthor` is `nothing` and one where it is `just`
+  --    something
+  -- 2. When it is nothing, we appeal to the assumed proof for the false case
+  proj₁ (contract Post pre prfF prfT) ma≡nothing = prfF (inj₁ ma≡nothing)
+  -- 3. When it is something, we step into `isValidProposerM`. This means:
+  --    - we use the proposer election of the round manager (`pe` and `pe≡`)
+  --    - we apply `isValidProposer` to `pe`  (`isvp-pe` and `isvp-pe≡`)
+  --    - we push the pure value `a` into the LBFT monad and apply `isvp-pe` to
+  --      it (`.a`, `isvp-pe-a`, and `isvp-pe-a≡`)
+  --    - we push the pure value `b ^∙ bRound` (`r` and `r≡`) into the LBFT
+  --      monad, and the returned value is the result of applying `isvp-pe-a` to
+  --      this
+  -- > proj₂ (contract Post pre prfF prfT) a ma≡just-a isvp isvp≡ pe pe≡ isvp-pe isvp-pe≡ .a refl isvp-pe-a isvp-pe-a≡ r r≡ = {!!}
+  -- 4. Since the returned value we want to reason about is directly related to
+  --    the behavior of these bound functions which are partial applications of
+  --    `isValidProposer`, we perform case-analysis on each of the equality
+  --    proofs (we can't pattern match on `ma≡just-a` directly)
+  proj₂ (contract Post pre prfF prfT) a ma≡just-a ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl
+  -- 5. To proceed, abstract over the expression that is blocking case analysis
+  --    on `ma≡just-a`, and inspect it for later. That way, when we analyze the
+  --    boolean expression, we can remember that it came from testing whether
+  --    `a` is the valid proposer for the round.
+     with isValidProposer (pre ^∙ lProposerElection) a (b ^∙ bRound)
+     |    inspect (isValidProposer (pre ^∙ lProposerElection) a ) (b ^∙ bRound)
+  -- 6. The types of `prfT` and `prfF` are still "stuck" on the expression
+  -- > b ^∙ bAuthor
+  --   in both the `false` and `true` cases we rewrite by `ma≡just-a`, which
+  --   tells us that the result is `just a`
+  ...| false | [ vp≡ ]
+    rewrite ma≡just-a =
+  -- 7. `prfF ∘ Right ∘ just` wants evidence that
+  -- > getValidProposer (pre ^∙ lProposerElection) (b ^∙ bRound) ≡ a
+  --    but `vp≡` tells us that
+  -- > ⌊ getValidProposer (pre ^∙ lProposerElection) (b ^∙ bRound) ≟ℕ a ⌋ ≡ true
+  --    To finish, we use `toWitnessF` to convert between the two forms of evidence.
+    prfF (Right (just (toWitnessF vp≡)))
+  -- 8. A similar situation holds for the `true` case and `prfT`
+  ...| true  | [ vp≡ ] rewrite ma≡just-a = prfT (just (toWitnessT vp≡))

--- a/LibraBFT/Impl/Consensus/Liveness/Properties/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/Properties/ProposerElection.agda
@@ -17,19 +17,24 @@ module LibraBFT.Impl.Consensus.Liveness.Properties.ProposerElection where
 
 -- TUTORIAL
 module isValidProposalMSpec (b : Block) where
+
+  pe      = _^∙ lProposerElection
+  mAuthor = b ^∙ bAuthor
+  round   = b ^∙ bRound
+
   contract
-    : ∀ Post pre
-      → let pe = pre ^∙ lProposerElection
-            ma = b ^∙ bAuthor
-            r  = b ^∙ bRound in
-        (ma ≡ nothing ⊎ Maybe-Any (getValidProposer pe r ≢_) ma → Post false pre [])
-        → (Maybe-Any (getValidProposer pe r ≡_) ma → Post true pre [])
-        → RWST-weakestPre (isValidProposalM b) Post unit pre
+    : ∀ pre Post
+      → (mAuthor ≡ nothing → Post (Left ProposalDoesNotHaveAnAuthor) pre [])
+      → (Maybe-Any (getValidProposer (pe pre) round ≢_) mAuthor
+         → Post (Left ProposerForBlockIsNotValidForThisRound) pre [])
+      → (Maybe-Any (getValidProposer (pe pre) round ≡_) mAuthor
+         → Post (Right unit) pre [])
+      → LBFT-weakestPre (isValidProposalM b) Post pre
   -- 1. `isValidProposalM` begins with `caseMM`, so we must provide two cases:
   --    one where `b ^∙ bAuthor` is `nothing` and one where it is `just`
   --    something
-  -- 2. When it is nothing, we appeal to the assumed proof for the false case
-  proj₁ (contract Post pre prfF prfT) ma≡nothing = prfF (inj₁ ma≡nothing)
+  -- 2. When it is nothing, we appeal to the assumed proof
+  proj₁ (contract pre Post pfNone pf≢ pfOk) mAuthor≡nothing = pfNone mAuthor≡nothing
   -- 3. When it is something, we step into `isValidProposerM`. This means:
   --    - we use the proposer election of the round manager (`pe` and `pe≡`)
   --    - we apply `isValidProposer` to `pe`  (`isvp-pe` and `isvp-pe≡`)
@@ -38,29 +43,22 @@ module isValidProposalMSpec (b : Block) where
   --    - we push the pure value `b ^∙ bRound` (`r` and `r≡`) into the LBFT
   --      monad, and the returned value is the result of applying `isvp-pe-a` to
   --      this
-  -- > proj₂ (contract Post pre prfF prfT) a ma≡just-a isvp isvp≡ pe pe≡ isvp-pe isvp-pe≡ .a refl isvp-pe-a isvp-pe-a≡ r r≡ = {!!}
+  --    - now out of `isValidProposalM`, we are given an alias `r'` for ``
+  -- > proj₂ (contract Post pre prfF prfT) a ma≡just-a isvp isvp≡ pe pe≡ isvp-pe isvp-pe≡ .a refl isvp-pe-a isvp-pe-a≡ r r≡ r' r'≡ = {!!}
   -- 4. Since the returned value we want to reason about is directly related to
   --    the behavior of these bound functions which are partial applications of
   --    `isValidProposer`, we perform case-analysis on each of the equality
   --    proofs (we can't pattern match on `ma≡just-a` directly)
-  proj₂ (contract Post pre prfF prfT) a ma≡just-a ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl
-  -- 5. To proceed, abstract over the expression that is blocking case analysis
-  --    on `ma≡just-a`, and inspect it for later. That way, when we analyze the
-  --    boolean expression, we can remember that it came from testing whether
-  --    `a` is the valid proposer for the round.
-     with isValidProposer (pre ^∙ lProposerElection) a (b ^∙ bRound)
-     |    inspect (isValidProposer (pre ^∙ lProposerElection) a ) (b ^∙ bRound)
-  -- 6. The types of `prfT` and `prfF` are still "stuck" on the expression
+  -- > proj₂ (contract pre Post pfNone pf≢ pfOk) a ma≡just-a ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl = {!!}
+  -- 5. Now we encounter an `ifM`, which means we must provide two cases, one corresponding to each branch.
+  proj₁ (proj₂ (contract pre Post pfNone pf≢ pfOk) a ma≡just-a ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl) vp≡true
+  -- 6. The types of `pfOk` and `pf≢` are still "stuck" on the expression
   -- > b ^∙ bAuthor
-  --   in both the `false` and `true` cases we rewrite by `ma≡just-a`, which
-  --   tells us that the result is `just a`
-  ...| false | [ vp≡ ]
+  --    So, both the `false` and `true` cases we rewrite by `ma≡just-a`, which
+  --    tells us that the result is `just a`
     rewrite ma≡just-a =
-  -- 7. `prfF ∘ Right ∘ just` wants evidence that
-  -- > getValidProposer (pre ^∙ lProposerElection) (b ^∙ bRound) ≡ a
-  --    but `vp≡` tells us that
-  -- > ⌊ getValidProposer (pre ^∙ lProposerElection) (b ^∙ bRound) ≟ℕ a ⌋ ≡ true
-  --    To finish, we use `toWitnessF` to convert between the two forms of evidence.
-    prfF (Right (just (toWitnessF vp≡)))
-  -- 8. A similar situation holds for the `true` case and `prfT`
-  ...| true  | [ vp≡ ] rewrite ma≡just-a = prfT (just (toWitnessT vp≡))
+  -- 7. To finish, we use `toWitnessF` to convert between the two forms of evidence.
+    pfOk (just (toWitnessT vp≡true))
+  proj₂ (proj₂ (contract pre Post pfNone pf≢ pfOk) a ma≡just-a ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl) vp≡false
+    rewrite ma≡just-a =
+    pf≢ (just (toWitnessF vp≡false))

--- a/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
@@ -27,7 +27,6 @@ isValidProposalM b =
     ifM vp
       then ok unit
       else bail ProposerForBlockIsNotValidForThisRound
-  -- maybeS-RWST (b ^∙ bAuthor) (pure false) (λ a → isValidProposerM a (b ^∙ bRound))
 
 isValidProposerM a r = isValidProposer <$> use lProposerElection <*> pure a <*> pure r
 

--- a/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
@@ -44,5 +44,5 @@ insertVoteM vote verifier = do
 -- TODO-1: Implement this.
 -- > recordVote v = rsVoteSent ∙= just v
 recordVote : Vote → LBFT Unit
-recordVote v = pure unit
+recordVote v = rsVoteSent-rm ∙= just v
 

--- a/LibraBFT/Impl/Consensus/PersistentLivenessStorage/Properties.agda
+++ b/LibraBFT/Impl/Consensus/PersistentLivenessStorage/Properties.agda
@@ -11,6 +11,7 @@ open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.PersistentLivenessStorage
+open import LibraBFT.Impl.Consensus.RoundManager.PropertyDefs
 
 module LibraBFT.Impl.Consensus.PersistentLivenessStorage.Properties where
 
@@ -19,6 +20,7 @@ module saveVoteMSpec (vote : Vote) where
   postulate
     contract
       : ∀ P pre
-        → P (inj₁ fakeErr) pre []
-        → (∀ blockStore → P (inj₂ unit) (rmSetBlockStore pre blockStore) [])
+        → (∀ outs → NoMsgOuts outs → NoErrOuts outs → P (inj₁ fakeErr) pre outs)
+        → (∀ outs blockStore → NoMsgOuts outs → NoErrOuts outs
+           → P (inj₂ unit) (rmSetBlockStore pre blockStore) outs)
         → RWST-weakestPre (saveVoteM vote) P unit pre

--- a/LibraBFT/Impl/Consensus/PersistentLivenessStorage/Properties.agda
+++ b/LibraBFT/Impl/Consensus/PersistentLivenessStorage/Properties.agda
@@ -1,0 +1,24 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import Optics.All
+open import LibraBFT.Prelude
+open import LibraBFT.Base.Types
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Impl.Consensus.PersistentLivenessStorage
+
+module LibraBFT.Impl.Consensus.PersistentLivenessStorage.Properties where
+
+module saveVoteMSpec (vote : Vote) where
+  -- TODO-2: This contract needs refining (after `saveVoteM` is implemented)
+  postulate
+    contract
+      : ∀ P pre
+        → P (inj₁ fakeErr) pre []
+        → (∀ blockStore → P (inj₂ unit) (rmSetBlockStore pre blockStore) [])
+        → RWST-weakestPre (saveVoteM vote) P unit pre

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -118,7 +118,7 @@ processCertificatesM now = do
 -- Haskell prototype and Agda model easier.
 module processProposalM (proposal : Block) where
   step₀ : LBFT Unit
-  step₁ : ∀ {pre} → BlockStore (α-EC-RM pre) → Bool → LBFT Unit
+  step₁ : ∀ {pre} → BlockStore (α-EC-RM pre) → (Either ObmNotValidProposerReason Unit) → LBFT Unit
   step₂ : Either ErrLog Vote → LBFT Unit
   step₃ : Vote → SyncInfo → LBFT Unit
 
@@ -129,9 +129,7 @@ module processProposalM (proposal : Block) where
     step₁ {s} bs vp
 
   step₁ bs vp =
-    ifM‖ is-nothing (proposal ^∙ bAuthor) ≔
-         logErr -- log: error: proposal does not have an author
-       ‖ not vp ≔
+    ifM‖ isLeft vp ≔
          logErr -- log: error: proposer for block is not valid for this round
        ‖ is-nothing (BlockStore.getQuorumCertForBlock (proposal ^∙ bParentId) bs) ≔
          logErr -- log: error: QC of parent is not in BS

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -116,7 +116,7 @@ processCertificatesM now = do
 -- This function is broken into smaller pieces to aid in the verification
 -- effort. The style of indentation used is to make side-by-side reading of the
 -- Haskell prototype and Agda model easier.
-module ProcessProposalM (proposal : Block) where
+module processProposalM (proposal : Block) where
   step₀ : LBFT Unit
   step₁ : ∀ {pre} → BlockStore (α-EC-RM pre) → Bool → LBFT Unit
   step₂ : Either ErrLog Vote → LBFT Unit
@@ -156,17 +156,17 @@ module ProcessProposalM (proposal : Block) where
                act (SendVote (VoteMsg∙new vote si) (recipient ∷ []))
                -- TODO-2:                           mkNodesInOrder1 recipient
 
-processProposalM = ProcessProposalM.step₀
+processProposalM = processProposalM.step₀
 
 ------------------------------------------------------------------------------
-module ExecuteAndVoteM (b : Block) where
+module executeAndVoteM (b : Block) where
   step₀ :                 LBFT (Either ErrLog Vote)
   step₁ : ExecutedBlock → LBFT (Either ErrLog Vote)
   step₂ : ExecutedBlock → LBFT (Either ErrLog Vote)
   step₃ : Vote          → LBFT (Either ErrLog Vote)
 
   step₀ =
-    BlockStore.executeAndInsertBlockM b ∙?∙ step₁
+    BlockStore.executeAndInsertBlockM b ∙^∙ withErrCtxt ∙?∙ step₁
 
   step₁ eb = do
     cr ← use (lRoundState ∙ rsCurrentRound)
@@ -186,7 +186,7 @@ module ExecuteAndVoteM (b : Block) where
   step₃ vote =   PersistentLivenessStorage.saveVoteM vote
              ∙?∙ λ _ → ok vote
 
-executeAndVoteM = ExecuteAndVoteM.step₀
+executeAndVoteM = executeAndVoteM.step₀
 
 ------------------------------------------------------------------------------
 

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -88,16 +88,17 @@ module executeAndVoteMSpec (b : Block) where
       mkContract noOuts (mkNoEpochChange es≡₁ es≡₂) (inj₁ (mkNoVoteCorrect lv≡ lvr≤))
     pf (Right vote) st outs (constructAndSignVoteMSpec.mkContract noOuts nec vc) ._ refl =
       PersistentLivenessStorageProps.saveVoteMSpec.contract vote
-        (RWST-weakestPre-ebindPost unit (λ _ → ok vote) Contract-++outs) st
-        (mkContract
-          (++-NoMsgOuts outs [] noOuts refl)
+      (RWST-weakestPre-ebindPost unit (λ _ → ok vote) Contract-++outs) st
+      (λ outs₁ noMsgOuts₁ noErrOuts₁ →
+        mkContract (++-NoMsgOuts outs outs₁ noOuts noMsgOuts₁)
           (transNoEpochChange noEpochChange-pre-preUpdated nec)
           (Right voteNotSaved))
-        λ where
-          _ .unit refl →
-            mkContract (++-NoMsgOuts outs [] noOuts refl)
-              (transNoEpochChange (noEpochChange-pre-preUpdated) (transNoEpochChange nec (mkNoEpochChange refl refl)))
-              voteSaved
+      λ where
+        outs₁ bs noMsgOuts₁ noErrOuts₁ .unit refl →
+          mkContract
+            (++-NoMsgOuts outs _ noOuts (++-NoMsgOuts outs₁ [] noMsgOuts₁ refl))
+            (transNoEpochChange noEpochChange-pre-preUpdated (transNoEpochChange nec (mkNoEpochChange refl refl)))
+            voteSaved
       where
       Contract-++outs = RWST-Post++ (Contract pre) outs
 

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -1,0 +1,116 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+{-# OPTIONS --allow-unsolved-metas #-}
+
+-- This module contains properties that are only about the behavior of the handlers, nothing to do
+-- with system state
+
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
+open import LibraBFT.ImplShared.Util.Util
+import      LibraBFT.Impl.Consensus.BlockStorage.BlockStore            as BlockStore
+import      LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockStore as BlockStoreProps
+import      LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock       as ExecutedBlock
+import      LibraBFT.Impl.Consensus.Liveness.RoundState                as RoundState
+import      LibraBFT.Impl.Consensus.Liveness.ProposerElection          as ProposerElection
+import      LibraBFT.Impl.Consensus.PersistentLivenessStorage          as PersistentLivenessStorage
+import      LibraBFT.Impl.Consensus.PersistentLivenessStorage.Properties as PersistentLivenessStorageProps
+open import LibraBFT.Impl.Consensus.RoundManager
+open import LibraBFT.Impl.Consensus.RoundManager.PropertyDefs
+import      LibraBFT.Impl.Consensus.SafetyRules.SafetyRules            as SafetyRules
+import      LibraBFT.Impl.Consensus.SafetyRules.Properties.SafetyRules as SafetyRulesProps
+open import LibraBFT.Lemmas
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.RoundManager.Properties where
+
+module executeAndVoteMSpec (b : Block) where
+
+  open executeAndVoteM b
+  open SafetyRulesProps
+
+  epoch = b ^∙ bEpoch
+  round = b ^∙ bRound
+
+  ResultCorrect : (pre post : RoundManager) (r : Either ErrLog Vote) → Set
+  ResultCorrect pre post (Left e) = NoVoteCorrect pre post ⊎ VoteNotSaved pre post epoch round
+  ResultCorrect pre post (Right v) = VoteCorrect pre post epoch round v
+
+  record Contract (pre : RoundManager) (r : Either ErrLog Vote) (post : RoundManager) (outs : List Output) : Set where
+    constructor mkContract
+    field
+      noOuts        : NoMsgOuts outs
+      inv           : NoEpochChange pre post
+      resultCorrect : ResultCorrect pre post r
+
+  contract'
+    : ∀ pre
+      → LBFT-weakestPre (executeAndVoteM b) (Contract pre) pre
+  proj₁ (contract' pre ._ refl) err isErr ._ refl =
+    mkContract refl (mkNoEpochChange refl refl) (inj₁ (mkNoVoteCorrect refl ≤-refl))
+  proj₁ (proj₂ (contract' pre ._ refl) (bs' , eb) isOk ._ refl ._ refl .eb refl cr cr≡ vs vs≡ so so≡) _ =
+    mkContract refl (mkNoEpochChange refl refl) (inj₁ (mkNoVoteCorrect refl ≤-refl))
+  proj₁ (proj₂ (proj₂ (contract' pre ._ refl) (bs' , eb) isOk ._ refl ._ refl .eb refl cr cr≡ vs vs≡ so so≡) _) _ =
+    mkContract refl (mkNoEpochChange refl refl) (inj₁ (mkNoVoteCorrect refl ≤-refl))
+  proj₂ (proj₂ (proj₂ (contract' pre ._ refl) (bs' , eb) isOk ._ refl ._ refl .eb refl cr cr≡ vs vs≡ so so≡) _) _ =
+    constructAndSignVoteMSpec.contract maybeSignedVoteProposal' preUpdated
+      (RWST-weakestPre-ebindPost unit step₃ (Contract pre))
+      pf
+    where
+    maybeSignedVoteProposal' = ExecutedBlock.maybeSignedVoteProposal eb
+    preUpdated = rmSetBlockStore pre bs'
+
+    constructAndSignVoteMSpec-Contract =
+      constructAndSignVoteMSpec.Contract preUpdated
+        (constructAndSignVoteMSpec.epoch maybeSignedVoteProposal')
+        (constructAndSignVoteMSpec.round maybeSignedVoteProposal')
+
+    noEpochChange-pre-preUpdated : NoEpochChange pre preUpdated
+    noEpochChange-pre-preUpdated = mkNoEpochChange refl refl
+
+    eb≡b = (BlockStoreProps.executeAndInsertBlockESpec.ebBlock≡ (rmGetBlockStore pre) b isOk)
+
+    eb≡b-epoch : (eb ^∙ ebBlock) ≡L b at bEpoch
+    eb≡b-epoch rewrite eb≡b = refl
+
+    eb≡b-round : (eb ^∙ ebBlock) ≡L b at bRound
+    eb≡b-round rewrite eb≡b = refl
+
+    pf : ∀ r st outs → constructAndSignVoteMSpec-Contract r st outs → RWST-weakestPre-ebindPost unit step₃ (Contract pre) r st outs
+    pf (Left _) st outs (constructAndSignVoteMSpec.mkContract noOuts (mkNoEpochChange es≡₁ es≡₂) (mkNoVoteCorrect lv≡ lvr≤)) =
+      mkContract noOuts (mkNoEpochChange es≡₁ es≡₂) (inj₁ (mkNoVoteCorrect lv≡ lvr≤))
+    pf (Right vote) st outs (constructAndSignVoteMSpec.mkContract noOuts nec vc) ._ refl =
+      PersistentLivenessStorageProps.saveVoteMSpec.contract vote
+        (RWST-weakestPre-ebindPost unit (λ _ → ok vote) Contract-++outs) st
+        (mkContract
+          (++-NoMsgOuts outs [] noOuts refl)
+          (transNoEpochChange noEpochChange-pre-preUpdated nec)
+          (Right voteNotSaved))
+        λ where
+          _ .unit refl →
+            mkContract (++-NoMsgOuts outs [] noOuts refl)
+              (transNoEpochChange (noEpochChange-pre-preUpdated) (transNoEpochChange nec (mkNoEpochChange refl refl)))
+              voteSaved
+      where
+      Contract-++outs = RWST-Post++ (Contract pre) outs
+
+      voteNotSaved : VoteNotSaved pre st epoch round
+      voteNotSaved = vote , substVoteCorrect refl refl refl refl eb≡b-epoch eb≡b-round vc
+
+      voteSaved : ∀ {bs} → VoteCorrect pre (rmSetBlockStore st bs) epoch round vote
+      voteSaved = substVoteCorrect refl refl refl refl eb≡b-epoch eb≡b-round vc
+
+  contract
+    : ∀ pre Post
+      → (∀ r st outs → Contract pre r st outs → Post r st outs)
+      → LBFT-weakestPre (executeAndVoteM b) Post pre
+  contract pre Post pf =
+    RWST-⇒ (Contract pre) Post pf (executeAndVoteM b) unit pre (contract' pre)

--- a/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
@@ -38,6 +38,9 @@ VoteMsgOuts outs vm pids = List-filter isOutputMsg? outs ≡ (SendVote vm pids �
   |       nmo
   |       vmo = refl
 
+NoErrOuts : List Output → Set
+NoErrOuts outs = List-filter isLogErr? outs ≡ []
+
 record NoEpochChange (pre post : RoundManager) : Set where
   constructor mkNoEpochChange
   field

--- a/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
@@ -32,11 +32,20 @@ NoMsgOuts outs = List-filter isOutputMsg? outs ≡ []
 VoteMsgOuts : List Output → VoteMsg → List Author → Set
 VoteMsgOuts outs vm pids = List-filter isOutputMsg? outs ≡ (SendVote vm pids ∷ [])
 
+++-NoMsgOuts-VoteMsgOuts : ∀ xs ys vm pids → NoMsgOuts xs → VoteMsgOuts ys vm pids → VoteMsgOuts (xs ++ ys) vm pids
+++-NoMsgOuts-VoteMsgOuts xs ys vm pids nmo vmo
+  rewrite List-filter-++ isOutputMsg? xs ys
+  |       nmo
+  |       vmo = refl
+
 record NoEpochChange (pre post : RoundManager) : Set where
   constructor mkNoEpochChange
   field
     es≡₁ : (_rmEC pre) ≡L (_rmEC post) at rmEpoch
     es≡₂ : pre ≡L post at lSafetyData ∙ sdEpoch
+
+reflNoEpochChange : ∀ {pre} → NoEpochChange pre pre
+reflNoEpochChange = mkNoEpochChange refl refl
 
 transNoEpochChange : ∀ {s₁ s₂ s₃} → NoEpochChange s₁ s₂ → NoEpochChange s₂ s₃ → NoEpochChange s₁ s₃
 transNoEpochChange (mkNoEpochChange es≡₁ es≡₂) (mkNoEpochChange es≡₃ es≡₄) =
@@ -89,6 +98,9 @@ record NoVoteCorrect (pre post : RoundManager) : Set where
   field
     lv≡  : pre ≡L post at lSafetyData ∙ sdLastVote
     lvr≤ : pre [ _≤_ ]L post at lSafetyData ∙ sdLastVotedRound
+
+reflNoVoteCorrect : ∀ {pre} → NoVoteCorrect pre pre
+reflNoVoteCorrect = mkNoVoteCorrect refl ≤-refl
 
 transNoVoteCorrect : ∀ {s₁ s₂ s₃} → NoVoteCorrect s₁ s₂ → NoVoteCorrect s₂ s₃ → NoVoteCorrect s₁ s₃
 transNoVoteCorrect (mkNoVoteCorrect lv≡ lvr≤) (mkNoVoteCorrect lv≡₁ lvr≤₁) =

--- a/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
@@ -7,8 +7,6 @@
 -- This module contains definitions of properties of only the behavior of the
 -- handlers, nothing concerning the system state.
 
-open import Optics.All
-open import LibraBFT.Prelude
 open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
@@ -16,6 +14,9 @@ open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Lemmas
+open import LibraBFT.Prelude
+open import Optics.All
 
 module LibraBFT.Impl.Consensus.RoundManager.PropertyDefs where
 
@@ -25,15 +26,31 @@ NoOutputs outs = outs ≡ []
 NoMsgOuts : List Output → Set
 NoMsgOuts outs = List-filter isOutputMsg? outs ≡ []
 
+++-NoMsgOuts : ∀ xs ys → NoMsgOuts xs → NoMsgOuts ys → NoMsgOuts (xs ++ ys)
+++-NoMsgOuts xs ys nmo₁ nmo₂ = filter-++-[] xs ys isOutputMsg? nmo₁ nmo₂
+
+VoteMsgOuts : List Output → VoteMsg → List Author → Set
+VoteMsgOuts outs vm pids = List-filter isOutputMsg? outs ≡ (SendVote vm pids ∷ [])
+
 record NoEpochChange (pre post : RoundManager) : Set where
   constructor mkNoEpochChange
   field
     es≡₁ : (_rmEC pre) ≡L (_rmEC post) at rmEpoch
     es≡₂ : pre ≡L post at lSafetyData ∙ sdEpoch
 
+transNoEpochChange : ∀ {s₁ s₂ s₃} → NoEpochChange s₁ s₂ → NoEpochChange s₂ s₃ → NoEpochChange s₁ s₃
+transNoEpochChange (mkNoEpochChange es≡₁ es≡₂) (mkNoEpochChange es≡₃ es≡₄) =
+  mkNoEpochChange (trans es≡₁ es≡₃) (trans es≡₂ es≡₄)
+
 -- For `processProposalMsg`, an emitted vote should satisfy the following
 -- properties in relation to the pre/poststate and the epoch and round of the
 -- proposal message.
+
+record VoteCorrectInv (post : RoundManager) (round : Round) (vote : Vote) : Set where
+  constructor mkVoteCorrectInv
+  field
+    round≡  : vote ^∙ vRound ≡ round
+    postLv≡ : just vote ≡ post ^∙ lSafetyData ∙ sdLastVote
 
 record VoteCorrectOld (pre post : RoundManager) (vote : Vote) : Set where
   constructor mkVoteCorrectOld
@@ -42,6 +59,13 @@ record VoteCorrectOld (pre post : RoundManager) (vote : Vote) : Set where
     -- `sdLastVote` is the same as the peer's epoch.
     lvr≡ : pre ≡L post at lSafetyData ∙ sdLastVotedRound
     lv≡  : pre ≡L post at lSafetyData ∙ sdLastVote
+
+transVoteCorrectOld
+  : ∀ {s₁ s₂ s₃ v}
+    → VoteCorrectOld s₁ s₂ v → VoteCorrectOld s₂ s₃ v
+    → VoteCorrectOld s₁ s₃ v
+transVoteCorrectOld (mkVoteCorrectOld lvr≡ lv≡) (mkVoteCorrectOld lvr≡₁ lv≡₁) =
+  mkVoteCorrectOld (trans lvr≡ lvr≡₁) (trans lv≡ lv≡₁)
 
 record VoteCorrectNew (pre post : RoundManager) (epoch : Epoch) (vote : Vote) : Set where
   constructor mkVoteCorrectNew
@@ -53,10 +77,12 @@ record VoteCorrectNew (pre post : RoundManager) (epoch : Epoch) (vote : Vote) : 
 record VoteCorrect (pre post : RoundManager) (epoch : Epoch) (round : Round) (vote : Vote) : Set where
   constructor mkVoteCorrect
   field
-    round≡  : vote ^∙ vRound ≡ round
-    postLv≡ : just vote ≡ post ^∙ lSafetyData ∙ sdLastVote
+    inv     : VoteCorrectInv post round vote
     voteSrc : VoteCorrectOld pre post vote
               ⊎ VoteCorrectNew pre post epoch vote
+
+VoteNotSaved : (pre post : RoundManager) (epoch : Epoch) (round : Round) → Set
+VoteNotSaved pre post epoch round = ∃[ v ] VoteCorrect pre post epoch round v
 
 record NoVoteCorrect (pre post : RoundManager) : Set where
   constructor mkNoVoteCorrect
@@ -64,15 +90,20 @@ record NoVoteCorrect (pre post : RoundManager) : Set where
     lv≡  : pre ≡L post at lSafetyData ∙ sdLastVote
     lvr≤ : pre [ _≤_ ]L post at lSafetyData ∙ sdLastVotedRound
 
+transNoVoteCorrect : ∀ {s₁ s₂ s₃} → NoVoteCorrect s₁ s₂ → NoVoteCorrect s₂ s₃ → NoVoteCorrect s₁ s₃
+transNoVoteCorrect (mkNoVoteCorrect lv≡ lvr≤) (mkNoVoteCorrect lv≡₁ lvr≤₁) =
+  mkNoVoteCorrect (trans lv≡ lv≡₁) (≤-trans lvr≤ lvr≤₁)
+
 substVoteCorrect
-  : ∀ {pre₁ pre₂ post₁ post₂ e r v}
+  : ∀ {pre₁ pre₂ post₁ post₂ e₁ e₂ r₁ r₂ v}
     → pre₁  ≡L pre₂  at (lSafetyData ∙ sdLastVote)
     → pre₁  ≡L pre₂  at (lSafetyData ∙ sdLastVotedRound)
     → post₁ ≡L post₂ at (lSafetyData ∙ sdLastVote)
     → post₁ ≡L post₂ at (lSafetyData ∙ sdLastVotedRound)
-    → VoteCorrect pre₁ post₁ e r v
-    → VoteCorrect pre₂ post₂ e r v
-substVoteCorrect refl refl refl refl (mkVoteCorrect round≡ postLv≡ (Left (mkVoteCorrectOld lvr≡ lv≡))) =
-  mkVoteCorrect round≡ postLv≡ (Left (mkVoteCorrectOld lvr≡ lv≡))
-substVoteCorrect refl refl refl refl (mkVoteCorrect round≡ postLv≡ (Right (mkVoteCorrectNew epoch≡ lvr< postLvr≡))) =
-  mkVoteCorrect round≡ postLv≡ (Right (mkVoteCorrectNew epoch≡ lvr< postLvr≡))
+    → e₁ ≡ e₂ → r₁ ≡ r₂
+    → VoteCorrect pre₁ post₁ e₁ r₁ v
+    → VoteCorrect pre₂ post₂ e₂ r₂ v
+substVoteCorrect refl refl refl refl refl refl (mkVoteCorrect (mkVoteCorrectInv round≡ postLv≡) (Left (mkVoteCorrectOld lvr≡ lv≡))) =
+  mkVoteCorrect (mkVoteCorrectInv round≡ postLv≡) (Left (mkVoteCorrectOld lvr≡ lv≡))
+substVoteCorrect refl refl refl refl refl refl (mkVoteCorrect (mkVoteCorrectInv round≡ postLv≡) (Right (mkVoteCorrectNew epoch≡ lvr< postLvr≡))) =
+  mkVoteCorrect (mkVoteCorrectInv round≡ postLv≡) (Right (mkVoteCorrectNew epoch≡ lvr< postLvr≡))

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -235,6 +235,9 @@ module LibraBFT.ImplShared.Consensus.Types where
     s : RoundManager → RoundState → RoundManager
     s rm rs = record rm { _rmEC = (_rmEC rm) & rmRoundState ∙~ rs }
 
+  rsVoteSent-rm : Lens RoundManager (Maybe Vote)
+  rsVoteSent-rm = lRoundState ∙ rsVoteSent
+
   lSyncOnly : Lens RoundManager Bool
   lSyncOnly = mkLens' g s
     where

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -207,6 +207,9 @@ module LibraBFT.ImplShared.Consensus.Types where
   rmSetBlockStore : (rm : RoundManager) → BlockStore (α-EC-RM rm) → RoundManager
   rmSetBlockStore rm bs = record rm { _rmWithEC = RoundManagerWithEC∙new bs }
 
+  lBlockStore : ∀ {ec} → Lens (RoundManagerWithEC ec) (BlockStore ec)
+  lBlockStore = epBlockStore _
+
   -- In some cases, the getting operation is not dependent but a lens still
   -- cannot be defined because the *setting* operation would require dependent
   -- types. Below, `rmGetValidatorVerifier` is an example of this situation, and

--- a/LibraBFT/ImplShared/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochDep.agda
@@ -177,6 +177,14 @@ module LibraBFT.ImplShared.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
              (bsInner ∷ [])
 
   -- IMPL-DIFF : this is a getter only in Haskell
+  bsHighestCommitCert : BlockStore → QuorumCert
+  bsHighestCommitCert = _^∙ bsInner ∙ btHighestCommitCert
+
+  -- IMPL-DIFF : this is a getter only in Haskell
+  bsHighestQuorumCert : BlockStore → QuorumCert
+  bsHighestQuorumCert = _^∙ bsInner ∙ btHighestQuorumCert
+
+  -- IMPL-DIFF : this is a getter only in Haskell
   bsHighestTimeoutCert : BlockStore → Maybe TimeoutCertificate
   bsHighestTimeoutCert =  _^∙ bsInner ∙ btHighestTimeoutCert
 

--- a/LibraBFT/ImplShared/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochDep.agda
@@ -177,12 +177,12 @@ module LibraBFT.ImplShared.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
              (bsInner ∷ [])
 
   -- IMPL-DIFF : this is a getter only in Haskell
-  bsHighestCommitCert : BlockStore → QuorumCert
-  bsHighestCommitCert = _^∙ bsInner ∙ btHighestCommitCert
+  bsHighestCommitCert : Lens BlockStore QuorumCert
+  bsHighestCommitCert = bsInner ∙ btHighestCommitCert
 
   -- IMPL-DIFF : this is a getter only in Haskell
-  bsHighestQuorumCert : BlockStore → QuorumCert
-  bsHighestQuorumCert = _^∙ bsInner ∙ btHighestQuorumCert
+  bsHighestQuorumCert : Lens BlockStore QuorumCert
+  bsHighestQuorumCert = bsInner ∙ btHighestQuorumCert
 
   -- IMPL-DIFF : this is a getter only in Haskell
   bsHighestTimeoutCert : BlockStore → Maybe TimeoutCertificate

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -323,10 +323,9 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     constructor MaybeSignedVoteProposal∙new
     field
       _msvpVoteProposal : VoteProposal
-      _msvpSignature : Maybe Signature
   open MaybeSignedVoteProposal public
-  unquoteDecl  msvpVoteProposal   msvpSignature = mkLens (quote MaybeSignedVoteProposal)
-              (msvpVoteProposal ∷ msvpSignature ∷ [])
+  unquoteDecl  msvpVoteProposal = mkLens (quote MaybeSignedVoteProposal)
+              (msvpVoteProposal ∷ [])
 
   record SyncInfo : Set where
     constructor mkSyncInfo -- Bare constructor to enable pattern matching against SyncInfo; "smart"

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -560,6 +560,9 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl vciPublicKey   vciVotingPower = mkLens (quote ValidatorConsensusInfo)
              (vciPublicKey ∷ vciVotingPower ∷ [])
 
+  data ObmNotValidProposerReason : Set where
+    ProposalDoesNotHaveAnAuthor ProposerForBlockIsNotValidForThisRound NotValidProposer : ObmNotValidProposerReason
+
   record ProposerElection : Set where
     constructor ProposerElection∙new
     -- field

--- a/LibraBFT/ImplShared/Interface/Output.agda
+++ b/LibraBFT/ImplShared/Interface/Output.agda
@@ -40,6 +40,12 @@ module LibraBFT.ImplShared.Interface.Output where
   IsBroadcastProposal (LogInfo _) = ⊥
   IsBroadcastProposal (SendVote _ _) = ⊥
 
+  IsLogErr : Output → Set
+  IsLogErr (BroadcastProposal _) = ⊥
+  IsLogErr (LogErr _)            = ⊤
+  IsLogErr (LogInfo _)           = ⊥
+  IsLogErr (SendVote _ _)        = ⊥
+
   isSendVote? : (out : Output) → Dec (IsSendVote out)
   isSendVote? (BroadcastProposal _) = no λ ()
   isSendVote? (LogErr _)            = no λ ()
@@ -51,6 +57,12 @@ module LibraBFT.ImplShared.Interface.Output where
   isBroadcastProposal? (LogErr _)            = no λ ()
   isBroadcastProposal? (LogInfo _)           = no λ ()
   isBroadcastProposal? (SendVote _ _)        = no λ ()
+
+  isLogErr? : (out : Output) → Dec (IsLogErr out)
+  isLogErr? (BroadcastProposal x) = no λ ()
+  isLogErr? (LogErr x)            = yes tt
+  isLogErr? (LogInfo x)           = no λ ()
+  isLogErr? (SendVote x x₁)       = no λ ()
 
   IsOutputMsg : Output → Set
   IsOutputMsg = IsBroadcastProposal ∪ IsSendVote

--- a/LibraBFT/ImplShared/Util/Util.agda
+++ b/LibraBFT/ImplShared/Util/Util.agda
@@ -47,11 +47,11 @@ module LibraBFT.ImplShared.Util.Util where
 
   -- Lifting a function that does not alter the pieces that
   -- define the epoch config is easy
-  liftEC : {A : Set}(f : ∀ ec → LBFT-ec ec A) → LBFT A
+  liftEC : {A : Set}(f : ∀ {ec} → LBFT-ec ec A) → LBFT A
   liftEC f = do
     st ← get
     let ec                 = α-EC (_rmEC st , _rmEC-correct st)
-        r₁ , stec₁ , outs₁ = RWST-run (f ec) unit (_rmWithEC st)
+        r₁ , stec₁ , outs₁ = RWST-run (f {ec}) unit (_rmWithEC st)
     tell outs₁
     put (record st { _rmWithEC = stec₁ })
     return r₁

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -40,6 +40,12 @@ module LibraBFT.Lemmas where
  ++-abs [] ()
  ++-abs (x ∷ m) imp ()
 
+ filter-++-[]
+   : ∀ {a p} {A : Set a} {P : (a : A) → Set p}
+     → ∀ xs ys (p : (a : A) → Dec (P a))
+     → List-filter p xs ≡ [] → List-filter p ys ≡ []
+     → List-filter p (xs ++ ys) ≡ []
+ filter-++-[] xs ys p pf₁ pf₂ rewrite List-filter-++ p xs ys | pf₁ | pf₂ = refl
 
  data All-vec {ℓ} {A : Set ℓ} (P : A → Set ℓ) : ∀ {n} → Vec {ℓ} A n → Set (Level.suc ℓ) where
    []  : All-vec P []

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -298,6 +298,13 @@ module LibraBFT.Prelude where
   pattern Left  x = inj₁ x
   pattern Right x = inj₂ x
 
+  isLeft : ∀ {a b} {A : Set a} {B : Set b} → Either A B → Bool
+  isLeft (Left _)  = true
+  isLeft (Right _) = false
+
+  isRight : ∀ {a b} {A : Set a} {B : Set b} → Either A B → Bool
+  isRight = not ∘ isLeft
+
   -- TODO-1: Maybe this belongs somewhere else?  It's in a similar
   -- category as Optics, so maybe should similarly be in a module that
   -- is separate from the main project?


### PR DESCRIPTION
This PR contains proofs for the above-mentioned functions in `RoundManager.agda`, meant to help in proving `VotesOnce`. It also contains an change to the implementation that mirrors a change made today in the Haskell prototype.