### PR TITLE
Proof that the two Epoch fields of `RoundManager` stay the same, and misc.

### DIFF
--- a/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
@@ -30,4 +30,4 @@ isValidProposalM b =
 
 isValidProposerM a r = isValidProposer <$> use lProposerElection <*> pure a <*> pure r
 
-isValidProposer pe a r = toBool $ getValidProposer pe r == a
+isValidProposer pe a r = getValidProposer pe r == a

--- a/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
@@ -30,4 +30,4 @@ isValidProposalM b =
 
 isValidProposerM a r = isValidProposer <$> use lProposerElection <*> pure a <*> pure r
 
-isValidProposer pe a r = ⌊ getValidProposer pe r ≟ℕ a ⌋
+isValidProposer pe a r = toBool $ getValidProposer pe r == a

--- a/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
@@ -26,7 +26,7 @@ module LibraBFT.Impl.Consensus.Liveness.RoundState where
 processCertificatesM : Instant → SyncInfo → LBFT (Maybe NewRoundEvent)
 processCertificatesM now syncInfo = do
   rshcr <- use (lRoundState ∙ rsHighestCommittedRound)
-  if-dec (syncInfo ^∙ siHighestCommitRound <? rshcr) -- TODO : define and use 'when'
+  ifM (syncInfo ^∙ siHighestCommitRound <? rshcr) -- TODO : define and use 'when'
     then pure unit -- IMPL-TODO ((lRoundState ∙ rsHighestCommittedRound) :=  (syncInfo ^∙ siHighestCommitRound))
     else pure unit
   pure nothing
@@ -36,7 +36,7 @@ processCertificatesM now syncInfo = do
 insertVoteM : Vote → ValidatorVerifier → LBFT VoteReceptionResult
 insertVoteM vote verifier = do
   currentRound ← use (lRoundState ∙ rsCurrentRound)
-  if-dec vote ^∙ vVoteData ∙ vdProposed ∙ biRound ≟ℕ currentRound
+  ifM vote ^∙ vVoteData ∙ vdProposed ∙ biRound == currentRound
     then PendingVotes.insertVoteM vote verifier
     else pure (UnexpectedRound (vote ^∙ vVoteData ∙ vdProposed ∙ biRound) currentRound)
 

--- a/LibraBFT/Impl/Consensus/Network/Properties.agda
+++ b/LibraBFT/Impl/Consensus/Network/Properties.agda
@@ -1,0 +1,24 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.Types
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.NetworkMsg
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Impl.Consensus.Network
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.Network.Properties where
+
+module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : ValidatorVerifier) where
+  postulate
+    contract
+      : case (processProposal proposal myEpoch vv) of λ where
+          (inj₁ _) → Unit
+          (inj₂ _) → proposal ^∙ pmProposal ∙ bEpoch ≡ myEpoch
+

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -70,7 +70,11 @@ module processProposalMsgM (now : Instant) (pm : ProposalMsg) where
             currentRound ← use (lRoundState ∙ rsCurrentRound)
             logInfo              -- log: info: dropping proposal for old round
 
-processProposalMsgM = processProposalMsgM.step₀
+abstract
+  processProposalMsgM = processProposalMsgM.step₀
+
+  processProposalMsgM≡ : processProposalMsgM ≡ processProposalMsgM.step₀
+  processProposalMsgM≡ = refl
 
 ------------------------------------------------------------------------------
 

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -231,7 +231,7 @@ addVoteM now vote = do
   s ← get -- IMPL-DIFF: see comment NO-DEPENDENT-LENSES
   let bs = rmGetBlockStore s
   maybeS-RWST (bsHighestTimeoutCert _ bs) continue λ tc →
-    ifM vote ^∙ vRound ≟ℕ tc ^∙ tcRound
+    ifM vote ^∙ vRound == tc ^∙ tcRound
       then logInfo -- "block already has TC", "dropping unneeded vote"
       else continue
  where

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -54,7 +54,6 @@ module processProposalMsgM (now : Instant) (pm : ProposalMsg) where
   step₂ : Either ErrLog Bool → LBFT Unit
 
   step₀ =
-
     caseMM pm ^∙ pmProposer of λ where
       nothing → logInfo -- log: info: proposal with no author
       (just pAuthor) → step₁ pAuthor
@@ -98,7 +97,7 @@ module ensureRoundAndSyncUpM
 
   step₂ = do
           currentRound' ← use (lRoundState ∙ rsCurrentRound)
-          ifM not ⌊ messageRound ≟ℕ currentRound' ⌋
+          ifM messageRound /= currentRound'
             then bail fakeErr -- error: after sync, round does not match local
             else ok true
 

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -143,8 +143,8 @@ module processProposalMSpec (proposal : Block) where
   record Contract (pre : RoundManager) (_ : Unit) (post : RoundManager) (outs : List Output) : Set where
     constructor mkContract
     field
-      noOuts        : OutsCorrect pre post outs
-      inv           : NoEpochChange pre post
+      outsCorrect : OutsCorrect pre post outs
+      inv         : NoEpochChange pre post
 
   contract : ∀ pre → LBFT-weakestPre (processProposalM proposal) (Contract pre) pre
   contract pre ._ refl =

--- a/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
@@ -23,8 +23,14 @@ module LibraBFT.Impl.Consensus.RoundManager.PropertyDefs where
 NoOutputs : List Output → Set
 NoOutputs outs = outs ≡ []
 
+NoVoteOuts : List Output → Set
+NoVoteOuts outs = List-filter isSendVote? outs ≡ []
+
 NoMsgOuts : List Output → Set
 NoMsgOuts outs = List-filter isOutputMsg? outs ≡ []
+
+NoMsgOuts⇒NoVoteOuts : ∀ {outs} → NoMsgOuts outs → NoVoteOuts outs
+NoMsgOuts⇒NoVoteOuts{outs} pf = filter-∪?-[]₂ outs isBroadcastProposal? isSendVote? pf
 
 ++-NoMsgOuts : ∀ xs ys → NoMsgOuts xs → NoMsgOuts ys → NoMsgOuts (xs ++ ys)
 ++-NoMsgOuts xs ys nmo₁ nmo₂ = filter-++-[] xs ys isOutputMsg? nmo₁ nmo₂

--- a/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
@@ -36,12 +36,12 @@ NoMsgOuts⇒NoVoteOuts{outs} pf = filter-∪?-[]₂ outs isBroadcastProposal? is
 ++-NoMsgOuts xs ys nmo₁ nmo₂ = filter-++-[] xs ys isOutputMsg? nmo₁ nmo₂
 
 VoteMsgOuts : List Output → VoteMsg → List Author → Set
-VoteMsgOuts outs vm pids = List-filter isOutputMsg? outs ≡ (SendVote vm pids ∷ [])
+VoteMsgOuts outs vm pids = List-filter isSendVote? outs ≡ (SendVote vm pids ∷ [])
 
 ++-NoMsgOuts-VoteMsgOuts : ∀ xs ys vm pids → NoMsgOuts xs → VoteMsgOuts ys vm pids → VoteMsgOuts (xs ++ ys) vm pids
 ++-NoMsgOuts-VoteMsgOuts xs ys vm pids nmo vmo
-  rewrite List-filter-++ isOutputMsg? xs ys
-  |       nmo
+  rewrite List-filter-++ isSendVote? xs ys
+  |       filter-∪?-[]₂ xs isBroadcastProposal? isSendVote? nmo
   |       vmo = refl
 
 NoErrOuts : List Output → Set

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -72,7 +72,7 @@ verifyAndUpdatePreferredRoundM quorumCert safetyData = do
 
 verifyEpochM : Epoch → SafetyData → LBFT (Either ErrLog Unit)
 verifyEpochM epoch safetyData =
-  ifM not ⌊ epoch ≟ℕ safetyData ^∙ sdEpoch ⌋
+  ifM epoch /= safetyData ^∙ sdEpoch
     then bail fakeErr -- incorrect epoch
     else ok unit
 
@@ -120,7 +120,7 @@ module constructAndSignVoteM-continue0 (voteProposal : VoteProposal) (validatorS
   step₁ safetyData0 = do
       caseMM (safetyData0 ^∙ sdLastVote) of λ where
         (just vote) →
-          ifM vote ^∙ vVoteData ∙ vdProposed ∙ biRound ≟ℕ (proposedBlock ^∙ bRound)
+          ifM vote ^∙ vVoteData ∙ vdProposed ∙ biRound == proposedBlock ^∙ bRound
             then ok vote
             else constructAndSignVoteM-continue1 voteProposal validatorSigner proposedBlock safetyData0
         nothing → constructAndSignVoteM-continue1 voteProposal validatorSigner proposedBlock safetyData0

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -43,9 +43,11 @@ postulate -- TODO-1: reasonable assumption that some RoundManager exists, though
   fakeRM : RoundManager
 
 initSR : SafetyRules
-initSR =  over (srPersistentStorage ∙ pssSafetyData ∙ sdEpoch) (const 1)
-               (over (srPersistentStorage ∙ pssSafetyData ∙ sdLastVotedRound) (const 0)
-                     (_rmSafetyRules (_rmEC fakeRM)))
+initSR =
+  let sd = fakeRM ^∙ lSafetyRules
+      sd = sd & srPersistentStorage ∙ pssSafetyData ∙ sdLastVotedRound ∙~ 0
+      sd = sd & srPersistentStorage ∙ pssSafetyData ∙ sdEpoch          ∙~ 1 in
+  sd
 
 postulate -- TODO-1: Implement this.
   initPE : ProposerElection
@@ -62,9 +64,10 @@ initRMEC = RoundManagerEC∙new (EpochState∙new 1 (initVV genesisInfo)) initRS
 postulate -- TODO-2 : prove these once initRMEC is defined directly
   init-EC-epoch-1  : epoch (init-EC genesisInfo) ≡ 1
   initRMEC-correct : RoundManagerEC-correct initRMEC
+  initRMWithEC     : RoundManagerWithEC (α-EC (initRMEC , initRMEC-correct))
 
 initRM : RoundManager
-initRM = fakeRM
+initRM = RoundManager∙new initRMEC initRMEC-correct initRMWithEC
 
 -- Eventually, the initialization should establish some properties we care about, but for now we
 -- just initialise again to fakeRM, which means we cannot prove the base case for various

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -48,7 +48,7 @@ esEpoch≡sdEpoch pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-ch
   rewrite cheatStepDNMPeerStates₁{pid'}{pid}{pre = pre'} step unit
   = esEpoch≡sdEpoch pid pre' preach
 esEpoch≡sdEpoch pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-honest{pid'} sps)))
-  with pid == pid'
+  with pid ≟ pid'
 ...| no pid≢pid'
   rewrite sym (pids≢StepDNMPeerStates{pre = pre'} sps pid≢pid')
   = esEpoch≡sdEpoch pid pre' preach

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -60,8 +60,6 @@ esEpoch≡sdEpoch pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-ho
 ... | step-msg {fst , P pm} m∈pool ini
   with handleProposalSpec.contract!-NoEpochChange 0 pm (peerStates pre' pid)
 ... | mkNoEpochChange es≡₁ es≡₂
-  with esEpoch≡sdEpoch pid pre' preach
-... | ih
   rewrite override-target-≡{a = pid}{b = LBFT-post (handleProposal 0 pm) (peerStates pre' pid)}{f = peerStates pre'}
   = trans (sym es≡₁) (trans (esEpoch≡sdEpoch pid pre' preach) es≡₂)
 esEpoch≡sdEpoch pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-honest{pid'} _)))

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -1,0 +1,74 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+{-# OPTIONS --allow-unsolved-metas #-}
+
+-- This module provides some scaffolding to define the handlers for our
+-- implementation and connect them to the interface of the SystemModel.
+
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.Encode
+open import LibraBFT.Base.KVMap
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Concrete.System
+open import LibraBFT.Concrete.System.Parameters
+open import LibraBFT.Hash
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
+open import LibraBFT.ImplShared.Util.Crypto
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Impl.Consensus.RoundManager.Properties
+open import LibraBFT.Impl.Consensus.RoundManager.PropertyDefs
+open import LibraBFT.Impl.IO.OBM.InputOutputHandlers
+open import LibraBFT.Impl.IO.OBM.Properties.InputOutputHandlers
+open import LibraBFT.Lemmas
+open import LibraBFT.Prelude
+open import Optics.All
+
+open import LibraBFT.Impl.Consensus.RoundManager
+open import LibraBFT.Impl.Handle
+open        ParamsWithInitAndHandlers InitAndHandlers
+open        PeerCanSignForPK
+
+open        EpochConfig
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+
+module LibraBFT.Impl.Handle.Properties where
+
+esEpoch≡sdEpoch
+  : ∀ pid (pre : SystemState)
+    → ReachableSystemState pre
+    → rmGetEpochState (peerStates pre pid) ^∙ esEpoch ≡ (peerStates pre pid) ^∙ lSafetyData ∙ sdEpoch
+esEpoch≡sdEpoch pid pre@._ step-0 = refl
+esEpoch≡sdEpoch pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-cheat{pid'} cheatMsgConstraint)))
+  rewrite cheatStepDNMPeerStates₁{pid'}{pid}{pre = pre'} step unit
+  = esEpoch≡sdEpoch pid pre' preach
+esEpoch≡sdEpoch pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-honest{pid'} sps)))
+  with pid == pid'
+...| no pid≢pid'
+  rewrite sym (pids≢StepDNMPeerStates{pre = pre'} sps pid≢pid')
+  = esEpoch≡sdEpoch pid pre' preach
+...| yes refl
+  with sps
+... | step-init ini
+  rewrite override-target-≡{a = pid}{b = initRM}{f = peerStates pre'}
+  = refl
+... | step-msg {fst , P pm} m∈pool ini
+  with handleProposalSpec.contract!-NoEpochChange 0 pm (peerStates pre' pid)
+... | mkNoEpochChange es≡₁ es≡₂
+  with esEpoch≡sdEpoch pid pre' preach
+... | ih
+  rewrite override-target-≡{a = pid}{b = LBFT-post (handleProposal 0 pm) (peerStates pre' pid)}{f = peerStates pre'}
+  = trans (sym es≡₁) (trans (esEpoch≡sdEpoch pid pre' preach) es≡₂)
+esEpoch≡sdEpoch pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-honest{pid'} _)))
+  | yes refl | step-msg {fst , V x} m∈pool ini = {!!}
+esEpoch≡sdEpoch pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-honest{pid'} _)))
+  | yes refl | step-msg {fst , C x} m∈pool ini = {!!}
+
+-- TODO-3: Prove this
+postulate
+  impl-sps-avp : StepPeerState-AllValidParts

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -1,0 +1,65 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.Consensus.Network            as Network
+open import LibraBFT.Impl.Consensus.Network.Properties as NetworkProps
+open import LibraBFT.Impl.Consensus.RoundManager       as RoundManager
+open import LibraBFT.Impl.Consensus.RoundManager.PropertyDefs
+open import LibraBFT.Impl.Consensus.RoundManager.Properties
+open import LibraBFT.Impl.IO.OBM.InputOutputHandlers
+open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
+open import LibraBFT.ImplShared.NetworkMsg
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+-- This module defines the handler for our implementation.  For most message types, it does some
+-- initial validation before passing the message on to the proper handlers.
+
+module LibraBFT.Impl.IO.OBM.Properties.InputOutputHandlers where
+
+module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
+
+  epoch = pm ^∙ pmProposal ∙ bEpoch
+  round = pm ^∙ pmProposal ∙ bRound
+
+  record NoVoteOutsCorrect (pre post : RoundManager) (outs : List Output) : Set where
+    constructor mkNoOutsCorrect
+    field
+      noVoteOuts : NoVoteOuts outs
+      nvc⊎vns    : NoVoteCorrect pre post ⊎ VoteNotSaved pre post epoch round
+
+  record VoteMsgOutsCorrect (pre post : RoundManager) (outs : List Output)  : Set where
+    constructor mkVoteMsgOutsCorrect
+    field
+      vm          : VoteMsg
+      pid         : Author
+      voteMsgOuts : VoteMsgOuts outs vm (pid ∷ [])
+      outCorrect  : VoteCorrect pre post epoch round (vm ^∙ vmVote)
+      sdEpoch≡    : pre ^∙ lSafetyData ∙ sdEpoch ≡ epoch
+
+  OutsCorrect : (pre post : RoundManager) (outs : List Output) → Set
+  OutsCorrect pre post outs = NoVoteOutsCorrect pre post outs ⊎ VoteMsgOutsCorrect pre post outs
+
+  record Contract (pre : RoundManager) (_ : Unit) (post : RoundManager) (outs : List Output) : Set where
+    constructor mkContract
+    field
+      noEpochChange : NoEpochChange pre post
+      outsCorrect   : OutsCorrect pre post outs
+
+  -- TODO-2: Prove this
+  postulate
+    contract : ∀ pre → LBFT-weakestPre (handleProposal now pm) (Contract pre) pre
+
+  contract! : ∀ pre → LBFT-Post-True (Contract pre) (handleProposal now pm) pre
+  contract! pre = LBFT-contract (handleProposal now pm) (Contract pre) pre (contract pre)
+
+  contract!-NoEpochChange : ∀ pre → LBFT-Post-True (λ r st outs → NoEpochChange pre st) (handleProposal now pm) pre
+  contract!-NoEpochChange pre = Contract.noEpochChange (contract! pre)

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -20,9 +20,6 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 
--- This module defines the handler for our implementation.  For most message types, it does some
--- initial validation before passing the message on to the proper handlers.
-
 module LibraBFT.Impl.IO.OBM.Properties.InputOutputHandlers where
 
 module handleProposalSpec (now : Instant) (pm : ProposalMsg) where

--- a/LibraBFT/ImplShared/Util/Util.agda
+++ b/LibraBFT/ImplShared/Util/Util.agda
@@ -59,6 +59,11 @@ module LibraBFT.ImplShared.Util.Util where
   LBFT-Pre  = RoundManager → Set
   LBFT-Post = RWST-Post Output RoundManager
 
+  LBFT-Post-True : ∀ {A} → LBFT-Post A → LBFT A → RoundManager → Set
+  LBFT-Post-True Post m pre =
+    let (x , post , outs) = LBFT-run m pre in
+    Post x post outs
+
   LBFT-weakestPre : ∀ {A} (m : LBFT A)
                     → LBFT-Post A → LBFT-Pre
   LBFT-weakestPre m Post pre = RWST-weakestPre m Post unit pre
@@ -67,8 +72,7 @@ module LibraBFT.ImplShared.Util.Util where
   LBFT-Contract{A} m =
     (Post : RWST-Post Output RoundManager A)
     → (pre : RoundManager) → LBFT-weakestPre m Post pre
-    → let (x , post , outs) = LBFT-run m pre in
-      Post x post outs
+    → LBFT-Post-True Post m pre
 
   LBFT-contract : ∀ {A} (m : LBFT A) → LBFT-Contract m
   LBFT-contract m Post pre pf = RWST-contract m Post unit pre pf

--- a/LibraBFT/ImplShared/Util/Util.agda
+++ b/LibraBFT/ImplShared/Util/Util.agda
@@ -74,6 +74,21 @@ module LibraBFT.ImplShared.Util.Util where
   LBFT-contract m Post pre pf = RWST-contract m Post unit pre pf
 
   LBFT-⇒
-    : ∀ {A} (P Q : RWST-Post Output RoundManager A) → (∀ r st outs → P r st outs → Q r st outs)
+    : ∀ {A} (P Q : LBFT-Post A) → (RWST-Post-⇒ P Q)
     → ∀ m pre → LBFT-weakestPre m P pre → LBFT-weakestPre m Q pre
   LBFT-⇒ Post₁ Post₂ f m pre pf = RWST-⇒ Post₁ Post₂ f m unit pre pf
+
+  LBFT-⇒-bind
+    : ∀ {A B} (P : LBFT-Post A) (Q : LBFT-Post B) (f : A → LBFT B)
+      → (RWST-Post-⇒ P (RWST-weakestPre-bindPost unit f Q))
+      → ∀ m st → LBFT-weakestPre m P st → LBFT-weakestPre (m >>= f) Q st
+  LBFT-⇒-bind Post Q f pf m st con = RWST-⇒-bind Post Q f unit pf m st con
+
+  LBFT-⇒-ebind
+    : ∀ {A B C} (P : LBFT-Post (Either C A)) (Q : LBFT-Post (Either C B))
+      → (f : A → LBFT (Either C B))
+      → RWST-Post-⇒ P (RWST-weakestPre-ebindPost unit f Q)
+      → ∀ m st → LBFT-weakestPre m P st
+      → LBFT-weakestPre (m ∙?∙ f) Q st
+  LBFT-⇒-ebind Post Q f pf m st con =
+    RWST-⇒-ebind Post Q f unit pf m st con

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -47,6 +47,20 @@ module LibraBFT.Lemmas where
      → List-filter p (xs ++ ys) ≡ []
  filter-++-[] xs ys p pf₁ pf₂ rewrite List-filter-++ p xs ys | pf₁ | pf₂ = refl
 
+ filter-∪?-[]₂
+   : ∀ {a p} {A : Set a} {P Q : (a : A) → Set p}
+     → ∀ xs (p : (a : A) → Dec (P a)) (q : (a : A) → Dec (Q a))
+     → List-filter (p ∪? q) xs ≡ []
+     → List-filter q xs ≡ []
+ filter-∪?-[]₂ [] p q pf = refl
+ filter-∪?-[]₂ (x ∷ xs) p q pf
+   with p x
+ ...| no  proof₁
+   with q x
+ ...| no  proof₂ = filter-∪?-[]₂ xs p q pf
+ filter-∪?-[]₂ (x ∷ xs) p q () | no proof₁ | yes proof₂
+ filter-∪?-[]₂ (x ∷ xs) p q () | yes proof
+
  data All-vec {ℓ} {A : Set ℓ} (P : A → Set ℓ) : ∀ {n} → Vec {ℓ} A n → Set (Level.suc ℓ) where
    []  : All-vec P []
    _∷_ : ∀ {x n} {xs : Vec A n} (px : P x) (pxs : All-vec P xs) → All-vec P (x ∷ xs)

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -35,7 +35,7 @@ module LibraBFT.Prelude where
     public
 
   open import Data.Nat.Properties
-    hiding (≡-irrelevant)
+    hiding (≡-irrelevant ; _≟_)
     public
 
   open import Data.List
@@ -433,9 +433,12 @@ module LibraBFT.Prelude where
   open import LibraBFT.Base.Util public
 
   record Eq {a} (A : Set a) : Set a where
-    infix 4 _==_ _/=_
+    infix 4 _≟_ _==_ _/=_
     field
-      _==_ : (a b : A) → Dec (a ≡ b)
+      _≟_ : (a b : A) → Dec (a ≡ b)
+
+    _==_   : A → A → Bool
+    a == b = toBool $ a ≟ b
 
     _/=_ : A → A → Bool
     a /= b = not (a == b)
@@ -443,13 +446,13 @@ module LibraBFT.Prelude where
 
   instance
     Eq-Nat : Eq ℕ
-    Eq._==_ Eq-Nat = _≟ℕ_
+    Eq._≟_ Eq-Nat = _≟ℕ_
 
     Eq-Maybe : ∀ {a} {A : Set a} ⦃ _ : Eq A ⦄ → Eq (Maybe A)
-    Eq._==_ Eq-Maybe nothing nothing = yes refl
-    Eq._==_ Eq-Maybe (just _) nothing = no λ ()
-    Eq._==_ Eq-Maybe nothing (just _) = no λ ()
-    Eq._==_ Eq-Maybe (just a) (just b)
-       with a == b
+    Eq._≟_ Eq-Maybe nothing nothing = yes refl
+    Eq._≟_ Eq-Maybe (just _) nothing = no λ ()
+    Eq._≟_ Eq-Maybe nothing (just _) = no λ ()
+    Eq._≟_ Eq-Maybe (just a) (just b)
+       with a ≟ b
     ... | no  proof = no λ where refl → proof refl
     ... | yes refl = yes refl


### PR DESCRIPTION
This PR adds `LibraBFT.Impl.Handle.Properties`, and the main proof there is of the following system invariant: the two different `Epoch` fields in `RoundManager` remain the same. This relies on a postulated contract for `handleProposal` which is based on existing proofs for related `RoundManager` functions for processing a proposal.

This PR also adds:
- Some proof utilities for `RWST` and `LBFT`
- a `ToBool`-polymorphic `not`
- an `Eq` type class
- a new lemma about `List-filter`
- changes to the initial `RoundManager` for all peers (more fields populated)