### PR TITLE
Eliminate metadata from state to solve issues with lack of dependent lenses

### DIFF
--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -4,10 +4,14 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Concrete.System
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochDep
 open import LibraBFT.Prelude
 open import LibraBFT.Yasm.Base
 

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -4,11 +4,14 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Concrete.Obligations
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochDep
 open import LibraBFT.Prelude
 
 open        EpochConfig
@@ -28,6 +31,7 @@ module LibraBFT.Concrete.Properties
          (impl-correct : ImplObligations iiah 𝓔)
          where
 
+    open WithEC
     open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
     open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
     import      LibraBFT.Concrete.Obligations.VotesOnce          𝓔 (ConcreteVoteEvidence 𝓔) as VO-obl

--- a/LibraBFT/Concrete/Properties/Common.agda
+++ b/LibraBFT/Concrete/Properties/Common.agda
@@ -4,19 +4,21 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import Optics.All
-open import LibraBFT.Prelude
-open import LibraBFT.Lemmas
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open        EpochConfig
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
+open import LibraBFT.Concrete.System
+open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Hash
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
-open import LibraBFT.Concrete.System.Parameters
-open        EpochConfig
-open import LibraBFT.Concrete.System
+open import LibraBFT.Lemmas
+open import LibraBFT.Prelude
 open import LibraBFT.Yasm.Base
+open import Optics.All
 
 -- This module contains definitions and proofs used by both the VotesOnce and PreferredRoundRule
 -- proofs.

--- a/LibraBFT/Concrete/Properties/PreferredRound.agda
+++ b/LibraBFT/Concrete/Properties/PreferredRound.agda
@@ -4,12 +4,15 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochDep
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
@@ -25,6 +28,7 @@ open        EpochConfig
 -- simpler VotesOnce property to settle down the structural aspects
 -- before tackling the harder semantic issues.
 module LibraBFT.Concrete.Properties.PreferredRound (iiah : SystemInitAndHandlers ℓ-RoundManager ConcSysParms) (𝓔 : EpochConfig) where
+ open        WithEC
  import      LibraBFT.Abstract.Records UID _≟UID_ NodeId  𝓔 (ConcreteVoteEvidence 𝓔) as Abs
  open import LibraBFT.Concrete.Obligations.PreferredRound 𝓔 (ConcreteVoteEvidence 𝓔)
  open        SystemTypeParameters ConcSysParms

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -4,12 +4,17 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochDep
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
@@ -102,6 +107,7 @@ module LibraBFT.Concrete.Properties.VotesOnce (iiah : SystemInitAndHandlers ℓ-
    open PerReachableState r
    open PerEpoch 𝓔
    open ConcreteCommonProperties st r sps-corr Impl-gvr Impl-nvr≢0
+   open WithEC
 
    open import LibraBFT.Concrete.Obligations.VotesOnce 𝓔 (ConcreteVoteEvidence 𝓔) as VO
 

--- a/LibraBFT/Concrete/Records.agda
+++ b/LibraBFT/Concrete/Records.agda
@@ -26,7 +26,8 @@ open        WithAbsVote
 -- for a given EpochConfig.
 --
 module LibraBFT.Concrete.Records (𝓔 : EpochConfig) where
- open import LibraBFT.ImplShared.Consensus.Types.EpochDep 𝓔
+ open import LibraBFT.ImplShared.Consensus.Types.EpochDep
+ open WithEC 𝓔
  open import LibraBFT.Abstract.Abstract UID _≟UID_ NodeId 𝓔 ConcreteVoteEvidence as Abs hiding (bId; qcVotes; Block)
  open        EpochConfig 𝓔
  --------------------------------

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -11,12 +11,14 @@ open import LibraBFT.Base.Types
 open import LibraBFT.Hash
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochDep
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.Prelude
 open import LibraBFT.Lemmas
 open import Optics.All
 
-open        EpochConfig
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open EpochConfig
 
 -- This module defines an abstract system state (represented by a value of type
 -- 'IntermediateSystemState') for a given concrete state.  The culminaton of this
@@ -32,6 +34,7 @@ module LibraBFT.Concrete.System where
  module PerState (st : SystemState) where
     module PerEpoch (𝓔 : EpochConfig) where
 
+     open WithEC
      open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs hiding (qcVotes; Vote)
      open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
      open import LibraBFT.Concrete.Records                        𝓔

--- a/LibraBFT/Concrete/System/Parameters.agda
+++ b/LibraBFT/Concrete/System/Parameters.agda
@@ -7,10 +7,12 @@
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochDep
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.Prelude
 open import Optics.All
 
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open        EpochConfig
 open import LibraBFT.Yasm.Base ℓ-RoundManager
 

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -19,22 +19,21 @@ open import Optics.All
 module LibraBFT.Impl.Consensus.BlockStorage.BlockStore where
 
 postulate
-  executeAndInsertBlockE : ∀ {𝓔} → BlockStore 𝓔 → Block → Either ErrLog (BlockStore 𝓔 × ExecutedBlock)
+  executeAndInsertBlockE : BlockStore → Block → Either ErrLog (BlockStore × ExecutedBlock)
   insertTimeoutCertificateM : TimeoutCertificate → LBFT (Either ErrLog Unit)
-  getBlock : ∀ {𝓔 : EpochConfig} → HashValue → BlockStore 𝓔 → Maybe ExecutedBlock
-  getQuorumCertForBlock : ∀ {𝓔 : EpochConfig} → HashValue → BlockStore 𝓔 → Maybe QuorumCert
+  getBlock : HashValue → BlockStore → Maybe ExecutedBlock
+  getQuorumCertForBlock : HashValue → BlockStore → Maybe QuorumCert
 
 executeAndInsertBlockM : Block → LBFT (Either ErrLog ExecutedBlock)
 executeAndInsertBlockM b = do
-  s ← get
-  let bs = rmGetBlockStore s
+  bs ← use lBlockStore
   caseM⊎ executeAndInsertBlockE bs b of λ where
     (Left e) → bail e
     (Right (bs' , eb)) → do
-      put (rmSetBlockStore s bs')
+      lBlockStore ∙= bs'
       ok eb
 
 syncInfoM : LBFT SyncInfo
-syncInfoM = liftEC $
-  SyncInfo∙new <$> use (lBlockStore ∙ bsHighestQuorumCert _)
-               <*> use (lBlockStore ∙ bsHighestCommitCert _)
+syncInfoM =
+  SyncInfo∙new <$> use (lBlockStore ∙ bsHighestQuorumCert)
+               <*> use (lBlockStore ∙ bsHighestCommitCert)

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -19,7 +19,7 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockStore where
 
-module executeAndInsertBlockESpec {𝓔 : EpochConfig} (bs : BlockStore 𝓔) (b : Block) where
+module executeAndInsertBlockESpec (bs : BlockStore) (b : Block) where
   postulate
     ebBlock≡ : ∀ {bs' eb} → executeAndInsertBlockE bs b ≡ Right (bs' , eb) → eb ^∙ ebBlock ≡ b
 

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -26,8 +26,8 @@ module executeAndInsertBlockESpec (bs : BlockStore) (b : Block) where
 module syncInfoMSpec where
   syncInfo : RoundManager → SyncInfo
   syncInfo pre =
-    SyncInfo∙new   (rmGetBlockStore pre ^∙ bsHighestQuorumCert _)
-                 $ (rmGetBlockStore pre ^∙ bsHighestCommitCert _)
+    SyncInfo∙new (pre ^∙ lBlockStore ∙ bsHighestQuorumCert)
+                 (pre ^∙ lBlockStore ∙ bsHighestCommitCert)
 
   contract : ∀ pre Post → (Post (syncInfo pre) pre []) → LBFT-weakestPre syncInfoM Post pre
-  contract pre Post pf ._ refl .unit refl .unit refl = pf
+  contract pre Post pf ._ refl ._ refl ._ refl ._ refl = pf

--- a/LibraBFT/Impl/Consensus/PersistentLivenessStorage/Properties.agda
+++ b/LibraBFT/Impl/Consensus/PersistentLivenessStorage/Properties.agda
@@ -22,5 +22,5 @@ module saveVoteMSpec (vote : Vote) where
       : ∀ P pre
         → (∀ outs → NoMsgOuts outs → NoErrOuts outs → P (inj₁ fakeErr) pre outs)
         → (∀ outs blockStore → NoMsgOuts outs → NoErrOuts outs
-           → P (inj₂ unit) (rmSetBlockStore pre blockStore) outs)
+           → P (inj₂ unit) (pre & lBlockStore ∙~ blockStore) outs)
         → RWST-weakestPre (saveVoteM vote) P unit pre

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -55,11 +55,11 @@ module executeAndVoteMSpec (b : Block) where
       → LBFT-weakestPre (executeAndVoteM b) (Contract pre) pre
   proj₁ (contract' pre ._ refl) err isErr ._ refl =
     mkContract refl (mkNoEpochChange refl refl) (inj₁ (mkNoVoteCorrect refl ≤-refl))
-  proj₁ (proj₂ (contract' pre ._ refl) (bs' , eb) isOk ._ refl ._ refl .eb refl cr cr≡ vs vs≡ so so≡) _ =
+  proj₁ (proj₂ (contract' pre ._ refl) (bs' , eb) isOk ._ refl ._ refl ._ refl .eb refl cr cr≡ vs vs≡ so so≡) _ =
     mkContract refl (mkNoEpochChange refl refl) (inj₁ (mkNoVoteCorrect refl ≤-refl))
-  proj₁ (proj₂ (proj₂ (contract' pre ._ refl) (bs' , eb) isOk ._ refl ._ refl .eb refl cr cr≡ vs vs≡ so so≡) _) _ =
-    mkContract refl (mkNoEpochChange refl refl) (inj₁ (mkNoVoteCorrect refl ≤-refl))
-  proj₂ (proj₂ (proj₂ (contract' pre ._ refl) (bs' , eb) isOk ._ refl ._ refl .eb refl cr cr≡ vs vs≡ so so≡) _) _ =
+  proj₁ (proj₂ (proj₂ (contract' pre ._ refl) (bs' , eb) isOk ._ refl ._ refl ._ refl .eb refl cr cr≡ vs vs≡ so so≡) _) _
+    = mkContract refl (mkNoEpochChange refl refl) (inj₁ (mkNoVoteCorrect refl ≤-refl))
+  proj₂ (proj₂ (proj₂ (contract' pre ._ refl) (bs' , eb) isOk ._ refl ._ refl ._ refl .eb refl cr cr≡ vs vs≡ so so≡) _) _ =
     constructAndSignVoteMSpec.contract maybeSignedVoteProposal' preUpdated
       (RWST-weakestPre-ebindPost unit step₃ (Contract pre))
       pf

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -65,7 +65,7 @@ module executeAndVoteMSpec (b : Block) where
       pf
     where
     maybeSignedVoteProposal' = ExecutedBlock.maybeSignedVoteProposal eb
-    preUpdated = rmSetBlockStore pre bs'
+    preUpdated = record pre { _rmBlockStore = bs' }
 
     constructAndSignVoteMSpec-Contract =
       constructAndSignVoteMSpec.Contract preUpdated
@@ -75,7 +75,7 @@ module executeAndVoteMSpec (b : Block) where
     noEpochChange-pre-preUpdated : NoEpochChange pre preUpdated
     noEpochChange-pre-preUpdated = mkNoEpochChange refl refl
 
-    eb≡b = (BlockStoreProps.executeAndInsertBlockESpec.ebBlock≡ (rmGetBlockStore pre) b isOk)
+    eb≡b = (BlockStoreProps.executeAndInsertBlockESpec.ebBlock≡ (pre ^∙ lBlockStore) b isOk)
 
     eb≡b-epoch : (eb ^∙ ebBlock) ≡L b at bEpoch
     eb≡b-epoch rewrite eb≡b = refl
@@ -105,7 +105,7 @@ module executeAndVoteMSpec (b : Block) where
       voteNotSaved : VoteNotSaved pre st epoch round
       voteNotSaved = vote , substVoteCorrect refl refl refl refl eb≡b-epoch eb≡b-round vc
 
-      voteSaved : ∀ {bs} → VoteCorrect pre (rmSetBlockStore st bs) epoch round vote
+      voteSaved : ∀ {bs} → VoteCorrect pre (record st {_rmBlockStore =  bs}) epoch round vote
       voteSaved = substVoteCorrect refl refl refl refl eb≡b-epoch eb≡b-round vc
 
   contract
@@ -149,7 +149,7 @@ module processProposalMSpec (proposal : Block) where
   contract : ∀ pre → LBFT-weakestPre (processProposalM proposal) (Contract pre) pre
   contract pre ._ refl =
     isValidProposalMSpec.contract proposal pre
-      (RWST-weakestPre-bindPost unit (step₁{pre} (rmGetBlockStore pre)) (Contract pre))
+      (RWST-weakestPre-bindPost unit (step₁ (pre ^∙ lBlockStore)) (Contract pre))
       (λ where
         mAuthor≡nothing ._ refl  →
           (λ _ → contractBail refl)

--- a/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/PropertyDefs.agda
@@ -50,7 +50,7 @@ NoErrOuts outs = List-filter isLogErr? outs ≡ []
 record NoEpochChange (pre post : RoundManager) : Set where
   constructor mkNoEpochChange
   field
-    es≡₁ : (_rmEC pre) ≡L (_rmEC post) at rmEpoch
+    es≡₁ : pre ≡L post at rmEpoch
     es≡₂ : pre ≡L post at lSafetyData ∙ sdEpoch
 
 reflNoEpochChange : ∀ {pre} → NoEpochChange pre pre

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -90,7 +90,7 @@ verifyAndUpdateLastVoteRoundM round safetyData =
 
 verifyQcM : QuorumCert → LBFT (Either ErrLog Unit)
 verifyQcM qc = do
-  validatorVerifier ← gets rmGetValidatorVerifier -- See DEPENDENT-LENSES-COMMENT
+  validatorVerifier ← use (lRoundManager ∙ srValidatorVerifier)
   pure (QuorumCert.verify qc validatorVerifier) ∙^∙ withErrCtxt
 
 ------------------------------------------------------------------------------
@@ -140,7 +140,7 @@ module constructAndSignVoteM-continue1
     verifyQcM (proposedBlock ^∙ bQuorumCert) ∙?∙ λ _ → step₁
 
   step₁ = do
-      validatorVerifier ← gets rmGetValidatorVerifier -- IMPL-DIFF: see comment NO-DEPENDENT-LENSES
+      validatorVerifier ← use (lRoundManager ∙ srValidatorVerifier)
       step₂ validatorVerifier
 
   step₂ validatorVerifier =

--- a/LibraBFT/Impl/Consensus/Types/PendingVotesSpec.agda
+++ b/LibraBFT/Impl/Consensus/Types/PendingVotesSpec.agda
@@ -48,8 +48,7 @@ mkVote randomLiVd signers i mli =
 
 iv : Vote → LBFT VoteReceptionResult
 iv v = do
-  s ← get
-  let vv = rmGetEpochState s ^∙ esVerifier
+  vv ← use (lRoundManager ∙ rmEpochState ∙ esVerifier)
   PendingVotes.insertVoteM v vv
 
 {-

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -4,6 +4,9 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap as KVMap
@@ -13,7 +16,6 @@ open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Hash
 open import LibraBFT.Impl.IO.OBM.InputOutputHandlers
 open import LibraBFT.Impl.Consensus.RoundManager
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Crypto
@@ -42,6 +44,9 @@ postulate -- TODO-1: reasonable assumption that some RoundManager exists, though
   -- the initial RoundManager for every peer until it is initialised.
   fakeRM : RoundManager
 
+postulate -- TODO-2: define GenesisInfo to match implementation and write these functions
+  initVV  : GenesisInfo → ValidatorVerifier
+
 initSR : SafetyRules
 initSR =
   let sd = fakeRM ^∙ lSafetyRules
@@ -51,6 +56,7 @@ initSR =
 
 postulate -- TODO-1: Implement this.
   initPE : ProposerElection
+  initBS : BlockStore
 
 initPV : PendingVotes
 initPV = PendingVotes∙new KVMap.empty nothing KVMap.empty
@@ -58,16 +64,8 @@ initPV = PendingVotes∙new KVMap.empty nothing KVMap.empty
 initRS : RoundState
 initRS = RoundState∙new 0 0 initPV nothing
 
-initRMEC : RoundManagerEC
-initRMEC = RoundManagerEC∙new (EpochState∙new 1 (initVV genesisInfo)) initRS initPE initSR false
-
-postulate -- TODO-2 : prove these once initRMEC is defined directly
-  init-EC-epoch-1  : epoch (init-EC genesisInfo) ≡ 1
-  initRMEC-correct : RoundManagerEC-correct initRMEC
-  initRMWithEC     : RoundManagerWithEC (α-EC (initRMEC , initRMEC-correct))
-
 initRM : RoundManager
-initRM = RoundManager∙new initRMEC initRMEC-correct initRMWithEC
+initRM = RoundManager∙new (EpochState∙new 1 (initVV genesisInfo)) initBS initRS initPE initSR false
 
 -- Eventually, the initialization should establish some properties we care about, but for now we
 -- just initialise again to fakeRM, which means we cannot prove the base case for various

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -9,6 +9,9 @@
 -- This module provides some scaffolding to define the handlers for our
 -- implementation and connect them to the interface of the SystemModel.
 
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap
@@ -16,7 +19,6 @@ open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Hash
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Crypto

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -44,7 +44,7 @@ module LibraBFT.Impl.Handle.Properties where
 esEpoch≡sdEpoch
   : ∀ pid (pre : SystemState)
     → ReachableSystemState pre
-    → rmGetEpochState (peerStates pre pid) ^∙ esEpoch ≡ (peerStates pre pid) ^∙ lSafetyData ∙ sdEpoch
+    → (peerStates pre pid) ^∙ rmEpochState ∙ esEpoch ≡ (peerStates pre pid) ^∙ lSafetyData ∙ sdEpoch
 esEpoch≡sdEpoch pid pre@._ step-0 = refl
 esEpoch≡sdEpoch pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-cheat{pid'} cheatMsgConstraint)))
   rewrite cheatStepDNMPeerStates₁{pid'}{pid}{pre = pre'} step unit

--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -22,8 +22,8 @@ open import Optics.All
 module LibraBFT.Impl.IO.OBM.InputOutputHandlers where
 
 epvv : LBFT (Epoch × ValidatorVerifier)
-epvv = _,_ <$> gets (_^∙ rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch ∘ _rmEC)
-           <*> gets (_^∙ rmEpochState ∙ esVerifier ∘ _rmEC)
+epvv = _,_ <$> gets (_^∙ rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch)
+           <*> gets (_^∙ rmEpochState ∙ esVerifier)
 
 handleProposal : Instant → ProposalMsg → LBFT Unit
 handleProposal now pm = do

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -48,6 +48,7 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
   record Contract (pre : RoundManager) (_ : Unit) (post : RoundManager) (outs : List Output) : Set where
     constructor mkContract
     field
+      inv           : RMPreservesInvariant pre post
       noEpochChange : NoEpochChange pre post
       outsCorrect   : OutsCorrect pre post outs
 
@@ -60,3 +61,6 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
 
   contract!-NoEpochChange : ∀ pre → LBFT-Post-True (λ r st outs → NoEpochChange pre st) (handleProposal now pm) pre
   contract!-NoEpochChange pre = Contract.noEpochChange (contract! pre)
+
+  contract!-RMPreservesInvariant : ∀ pre → LBFT-Post-True (λ r st outs → RMPreservesInvariant pre st) (handleProposal now pm) pre
+  contract!-RMPreservesInvariant pre = Contract.inv (contract! pre)

--- a/LibraBFT/ImplFake/Consensus/RoundManager.agda
+++ b/LibraBFT/ImplFake/Consensus/RoundManager.agda
@@ -44,12 +44,10 @@ postulate -- TODO-1: these are temporary scaffolding for the fake implementation
 
 processProposalMsg : Instant → ProposalMsg → LBFT Unit
 processProposalMsg inst pm = do
-  st ← get
+  rm ← get
   --xx ← use rmHighestQC   -- Not used; just a demonstration that our RoundManager-specific "use" works
   --rmHighestQC ∙= xx -- Similarly for modify'
-  let RoundManager∙new rm rmc rmw = st
-      𝓔  = α-EC (rm , rmc)
-      e  = rm ^∙ rmEpoch
+  let e  = rm ^∙ rmEpoch
       nr = suc (rm ^∙ rmLastVotedRound)
       uv = Vote∙new
                   (VoteData∙new (fakeBlockInfo e nr pm) (fakeBlockInfo e 0 pm))
@@ -58,12 +56,10 @@ processProposalMsg inst pm = do
                   fakeSig
                   nothing
       sv = record uv { _vSignature = sign ⦃ sig-Vote ⦄ uv fakeSK}
-      bt = rmw ^∙ (lBlockTree 𝓔)
+      bt = rm ^∙ lBlockTree
       si = SyncInfo∙new (_btHighestQuorumCert bt) (_btHighestCommitCert bt)
       rm' = rm & rmLastVotedRound ∙~ nr
-      st' = RoundManager∙new rm' (RoundManagerEC-correct-≡ (_rmEC st) rm' refl rmc)
-                                 (subst RoundManagerWithEC (α-EC-≡ rm rm' refl refl rmc) rmw)
-  put st'
+  put rm'
   tell1 (SendVote (VoteMsg∙new sv si) (fakeAuthor ∷ []))
   pure unit
 

--- a/LibraBFT/ImplFake/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/ImplFake/Consensus/RoundManager/Properties.agda
@@ -23,8 +23,15 @@ module LibraBFT.ImplFake.Consensus.RoundManager.Properties where
 
   voteForCurrentEpoch : ∀ {ts pm pre vm αs}
                       → (SendVote vm αs) ∈ LBFT-outs (processProposalMsg ts pm) pre
-                      → (_rmEC pre) ^∙ rmEpoch ≡ vm ^∙ vmVote ∙ vEpoch
+                      → pre ^∙ rmEpoch ≡ vm ^∙ vmVote ∙ vEpoch
   voteForCurrentEpoch (here refl) = refl
+
+  -- These are used only by the property below, which itself is not used.
+  rmHighestQC : Lens RoundManager QuorumCert
+  rmHighestQC = lBlockStore ∙ bsInner ∙ btHighestQuorumCert
+
+  rmHighestCommitQC : Lens RoundManager QuorumCert
+  rmHighestCommitQC = lBlockStore ∙ bsInner ∙ btHighestCommitCert
 
   -- The quorum certificates sent in SyncInfo with votes are those from the peer state.
   -- This is no longer used because matching m∈outs parameters to here refl eliminated the need for
@@ -32,5 +39,5 @@ module LibraBFT.ImplFake.Consensus.RoundManager.Properties where
   -- when the real handler will be much more complicated and this proof may no longer be trivial.
   procPMCerts≡ : ∀ {ts pm pre vm αs}
                → (SendVote vm αs) ∈ LBFT-outs (processProposalMsg ts pm) pre
-               → vm ^∙ vmSyncInfo ≡ SyncInfo∙new (_rmHighestQC pre) (_rmHighestCommitQC pre)
+               → vm ^∙ vmSyncInfo ≡ SyncInfo∙new (pre ^∙ rmHighestQC) (pre ^∙ rmHighestCommitQC)
   procPMCerts≡ (here refl) = refl

--- a/LibraBFT/ImplFake/Handle.agda
+++ b/LibraBFT/ImplFake/Handle.agda
@@ -27,8 +27,6 @@ open import Optics.All
 module LibraBFT.ImplFake.Handle where
  open import LibraBFT.ImplFake.Consensus.RoundManager
 
- open EpochConfig
-
  postulate -- TODO-1: reasonable assumption that some RoundManager exists, though we could prove
            -- it by construction; eventually we will construct an entire RoundManager, so
            -- this won't be needed
@@ -36,6 +34,10 @@ module LibraBFT.ImplFake.Handle where
  -- This represents an uninitialised RoundManager, about which we know nothing, which we use as
  -- the initial RoundManager for every peer until it is initialised.
    fakeRM : RoundManager
+   initBS : BlockStore
+
+ postulate -- Only in fake implementation. 
+   initVV  : GenesisInfo → ValidatorVerifier
 
  initSR : SafetyRules
  initSR =  over (srPersistentStorage ∙ pssSafetyData ∙ sdEpoch) (const 1)

--- a/LibraBFT/ImplFake/Handle.agda
+++ b/LibraBFT/ImplFake/Handle.agda
@@ -42,7 +42,7 @@ module LibraBFT.ImplFake.Handle where
  initSR : SafetyRules
  initSR =  over (srPersistentStorage ∙ pssSafetyData ∙ sdEpoch) (const 1)
                 (over (srPersistentStorage ∙ pssSafetyData ∙ sdLastVotedRound) (const 0)
-                      (_rmSafetyRules (_rmEC fakeRM)))
+                      (_rmSafetyRules fakeRM))
 
  -- TODO-1: Implement this.
  initPE : ProposerElection
@@ -54,15 +54,8 @@ module LibraBFT.ImplFake.Handle where
  initRS : RoundState
  initRS = RoundState∙new 0 0 initPV nothing
 
- initRMEC : RoundManagerEC
- initRMEC = RoundManagerEC∙new (EpochState∙new 1 (initVV genesisInfo)) initRS initPE initSR false
-
- postulate -- TODO-2 : prove these once initRMEC is defined directly
-   init-EC-epoch-1  : epoch (init-EC genesisInfo) ≡ 1
-   initRMEC-correct : RoundManagerEC-correct initRMEC
-
  initRM : RoundManager
- initRM = fakeRM
+ initRM = RoundManager∙new (EpochState∙new 1 (initVV genesisInfo)) initBS initRS initPE initSR false
 
  -- Eventually, the initialization should establish some properties we care about, but for now we
  -- just initialise again to fakeRM, which means we cannot prove the base case for various

--- a/LibraBFT/ImplFake/Handle/Properties.agda
+++ b/LibraBFT/ImplFake/Handle/Properties.agda
@@ -92,8 +92,8 @@ module LibraBFT.ImplFake.Handle.Properties where
   ----- Properties that relate handler to system state -----
 
   data _∈RoundManager_ (qc : QuorumCert) (rm : RoundManager) : Set where
-    inHQC : qc ≡ _rmHighestQC rm       → qc ∈RoundManager rm
-    inHCC : qc ≡ _rmHighestCommitQC rm → qc ∈RoundManager rm
+    inHQC : qc ≡ rm ^∙ rmHighestQC       → qc ∈RoundManager rm
+    inHCC : qc ≡ rm ^∙ rmHighestCommitQC → qc ∈RoundManager rm
 
   postulate -- TODO-2: this will be proved for the implementation, confirming that honest
             -- participants only store QCs comprising votes that have actually been sent.
@@ -128,7 +128,7 @@ module LibraBFT.ImplFake.Handle.Properties where
                      → ppre ≡ peerStates pre pid
                      → StepPeerState pid (msgPool pre) (initialised pre) ppre (ppost , msgs)
                      → initialised pre pid ≡ initd
-                     → (_rmEC ppre) ^∙ rmEpoch ≡ (_rmEC ppost) ^∙ rmEpoch
+                     → ppre ^∙ rmEpoch ≡ ppost ^∙ rmEpoch
   noEpochIdChangeYet _ ppre≡ (step-init uni) ini = ⊥-elim (uninitd≢initd (trans (sym uni) ini))
   noEpochIdChangeYet _ ppre≡ (step-msg {(_ , m)} _ _) ini
      with m
@@ -177,8 +177,8 @@ module LibraBFT.ImplFake.Handle.Properties where
                                → Meta-Honest-PK pk
                                → v ⊂Msg m → send m ∈ outs → (sig : WithVerSig pk v)
                                → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
-                               → v ^∙ vEpoch ≡ (_rmEC (peerStates pre pid)) ^∙ rmEpoch
-                               × v ^∙ vRound ≡ ((_rmEC s') ^∙ rmLastVotedRound)     -- Last voted round is round of new vote
+                               → v ^∙ vEpoch ≡ (peerStates pre pid) ^∙ rmEpoch
+                               × v ^∙ vRound ≡ (s' ^∙ rmLastVotedRound)     -- Last voted round is round of new vote
   newVoteSameEpochGreaterRound {pre = pre} {pid} {v = v} {m} {pk} r (step-msg {(_ , P pm)} msg∈pool pinit) ¬init hpk v⊂m m∈outs sig vnew
      rewrite pinit
      with msgsToSendWereSent {pid} {P pm} {m} {peerStates pre pid} m∈outs
@@ -202,8 +202,8 @@ module LibraBFT.ImplFake.Handle.Properties where
                      → ppre ≡ peerStates pre pid
                      → StepPeerState pid (msgPool pre) (initialised pre) ppre (ppost , msgs)
                      → initialised pre pid ≡ initd
-                     → (_rmEC ppre) ^∙ rmEpoch ≡ (_rmEC ppost) ^∙ rmEpoch
-                     → (_rmEC ppre) ^∙ rmLastVotedRound ≤ (_rmEC ppost) ^∙ rmLastVotedRound
+                     → ppre ^∙ rmEpoch ≡ ppost ^∙ rmEpoch
+                     → ppre ^∙ rmLastVotedRound ≤ ppost ^∙ rmLastVotedRound
   lastVoteRound-mono _ ppre≡ (step-init uni) ini = ⊥-elim (uninitd≢initd (trans (sym uni) ini))
   lastVoteRound-mono _ ppre≡ (step-msg {(_ , m)} _ _) _
      with m

--- a/LibraBFT/ImplFake/Handle/Properties.agda
+++ b/LibraBFT/ImplFake/Handle/Properties.agda
@@ -8,6 +8,9 @@
 -- This module provides some scaffolding to define the handlers for our fake/simple "implementation"
 -- and connect them to the interface of the SystemModel.
 
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap
@@ -16,7 +19,6 @@ open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Hash
 open import LibraBFT.ImplFake.Consensus.RoundManager.Properties
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Util

--- a/LibraBFT/ImplFake/Properties.agda
+++ b/LibraBFT/ImplFake/Properties.agda
@@ -4,6 +4,9 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Concrete.Obligations
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
@@ -12,10 +15,8 @@ open import LibraBFT.ImplFake.Handle.Properties
 import      LibraBFT.ImplFake.Properties.VotesOnce      as Common
 import      LibraBFT.ImplFake.Properties.VotesOnce      as VO
 import      LibraBFT.ImplFake.Properties.PreferredRound as PR
-open import LibraBFT.ImplShared.Base.Types
-open import LibraBFT.ImplShared.Consensus.Types hiding (EpochConfig)
+open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
-open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
 -- This module collects the implementation obligations for our (fake/simple, for now)
 -- "implementation" into the structure required by Concrete.Properties.

--- a/LibraBFT/ImplFake/Properties/PreferredRound.agda
+++ b/LibraBFT/ImplFake/Properties/PreferredRound.agda
@@ -3,11 +3,14 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.ImplFake.Handle
 open import LibraBFT.ImplFake.Handle.Properties
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 

--- a/LibraBFT/ImplFake/Properties/VotesOnce.agda
+++ b/LibraBFT/ImplFake/Properties/VotesOnce.agda
@@ -5,7 +5,9 @@
 -}
 -- This module proves the two "VotesOnce" proof obligations for our fake handler
 
+open import LibraBFT.ImplShared.Base.Types
 
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Base.KVMap
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System
@@ -13,7 +15,6 @@ open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.ImplFake.Consensus.RoundManager.Properties
 open import LibraBFT.ImplFake.Handle
 open import LibraBFT.ImplFake.Handle.Properties
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Util

--- a/LibraBFT/ImplFake/Properties/VotesOnce.agda
+++ b/LibraBFT/ImplFake/Properties/VotesOnce.agda
@@ -44,8 +44,8 @@ module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
   -- sent, and that we can carry forward to subsequent states, so we can use it to prove
   -- VO.ImplObligation₁.
   LvrProp : CarrierProp
-  LvrProp v rm = (  v ^∙ vEpoch ≢ (_rmEC rm) ^∙ rmEpoch
-                 ⊎ (v ^∙ vEpoch ≡ (_rmEC rm) ^∙ rmEpoch × v ^∙ vRound ≤ (_rmEC rm) ^∙ rmLastVotedRound))
+  LvrProp v rm = (  v ^∙ vEpoch ≢ rm ^∙ rmEpoch
+                 ⊎ (v ^∙ vEpoch ≡ rm ^∙ rmEpoch × v ^∙ vRound ≤ rm ^∙ rmLastVotedRound))
 
   LvrCarrier = PropCarrier LvrProp
 
@@ -99,8 +99,8 @@ module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
                                        vpk'
                                        (inj₂ ( trans eids≡ (auxEid post≡)
                                              , ≤-reflexive (trans newlvr (auxLvr post≡))))
-                                       where auxEid = cong (_^∙ rmEpoch ∘ _rmEC)
-                                             auxLvr = cong (_^∙ rmLastVotedRound ∘ _rmEC)
+                                       where auxEid = cong (_^∙ rmEpoch)
+                                             auxLvr = cong (_^∙ rmLastVotedRound)
 
   ImplPreservesLvr : PeerStepPreserves LvrProp
   -- We don't have a real model for the initial peer state, so we can't prove this case yet.
@@ -115,7 +115,7 @@ module LibraBFT.ImplFake.Properties.VotesOnce (𝓔 : EpochConfig) where
      with preprop
   ...| inj₁ diffEpoch = inj₁ λ x → diffEpoch (trans x (sym eids≡))
   ...| inj₂ (sameEpoch , rnd≤ppre)
-     with (msgPart (carrSent prop)) ^∙ vEpoch ≟ (_rmEC (peerStates pre (msgSender (carrSent prop)))) ^∙ rmEpoch
+     with (msgPart (carrSent prop)) ^∙ vEpoch ≟ (peerStates pre (msgSender (carrSent prop))) ^∙ rmEpoch
   ...| no neq = ⊥-elim (neq sameEpoch)
   ...| yes refl
      with lastVoteRound-mono r refl (step-msg m∈pool inited) (carrInitd prop)

--- a/LibraBFT/ImplFake/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/ImplFake/Properties/VotesOnceDirect.agda
@@ -42,8 +42,8 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                        → v ⊂Msg m → send m ∈ outs → (sig : WithVerSig pk v)
                        → Meta-Honest-PK pk → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
                        → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool st)
-                       → v ^∙ vEpoch ≡ (_rmEC s') ^∙ rmEpoch
-                       → v ^∙ vRound ≡ (_rmEC s') ^∙ rmLastVotedRound
+                       → v ^∙ vEpoch ≡ s' ^∙ rmEpoch
+                       → v ^∙ vRound ≡ s' ^∙ rmLastVotedRound
   newVoteEpoch≡⇒Round≡ r step@(step-msg {_ , P pm} _ pinit) v⊂m (here refl)
                        sig pkH ¬gen vnew ep≡
      with v⊂m
@@ -163,8 +163,8 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                 → Meta-Honest-PK pk → (sig : WithVerSig pk v)
                 → ¬ ∈GenInfo-impl genesisInfo (ver-signature sig)
                 → MsgWithSig∈ pk (ver-signature sig) (msgPool st)
-                → (_rmEC s') ^∙ rmEpoch ≡ (v ^∙ vEpoch)
-                → (_rmEC (peerStates st pid)) ^∙ rmEpoch ≡ (v ^∙ vEpoch)
+                → s' ^∙ rmEpoch ≡ (v ^∙ vEpoch)
+                → (peerStates st pid) ^∙ rmEpoch ≡ (v ^∙ vEpoch)
   noEpochChange r (step-init uni) pcs pkH sig ∉gen msv eid≡
     = ⊥-elim (uninitd≢initd (trans (sym uni) (msg∈pool⇒initd r pcs pkH sig ∉gen msv)))
   noEpochChange r sm@(step-msg _ ini) pcs pkH sig ∉gen msv eid≡
@@ -176,8 +176,8 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                    → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
                    → MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
                    → PeerCanSignForPK pre v pid pk
-                   → (_rmEC (peerStates pre pid)) ^∙ rmEpoch ≡ (v ^∙ vEpoch)
-                   → v ^∙ vRound ≤ (_rmEC (peerStates pre pid)) ^∙ rmLastVotedRound
+                   → (peerStates pre pid) ^∙ rmEpoch ≡ (v ^∙ vEpoch)
+                   → v ^∙ vRound ≤ (peerStates pre pid) ^∙ rmLastVotedRound
   oldVoteRound≤lvr {pid'} (step-s r step@(step-peer {pid = pid} cheat@(step-cheat c)))
                    pkH sig ¬gen msv vspk eid≡
      with ¬cheatForgeNew cheat refl unit pkH msv (¬subst ¬gen (msgSameSig msv))

--- a/LibraBFT/ImplFake/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/ImplFake/Properties/VotesOnceDirect.agda
@@ -4,6 +4,9 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -4,8 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-{-# OPTIONS --allow-unsolved-metas #-}
-
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap as KVMap
 open import LibraBFT.Base.PKCS
@@ -34,10 +32,7 @@ module LibraBFT.ImplShared.Consensus.Types where
   open import LibraBFT.ImplShared.NetworkMsg                     public
   open import LibraBFT.ImplShared.Base.Types                     public
   open import LibraBFT.ImplShared.Consensus.Types.EpochIndep     public
-  open import LibraBFT.ImplShared.Consensus.Types.EpochDep       public
   open import LibraBFT.ImplShared.Util.Crypto                    public
-
-  open import LibraBFT.Abstract.Types.EpochConfig UID NodeId     public
 
   record EpochState : Set where
     constructor EpochState∙new
@@ -78,206 +73,74 @@ module LibraBFT.ImplShared.Consensus.Types where
 
   -- The parts of the state of a peer that are used to
   -- define the EpochConfig are the SafetyRules and ValidatorVerifier:
-  record RoundManagerEC : Set where
-    constructor RoundManagerEC∙new
+  record RoundManager : Set where
+    constructor RoundManager∙new
     field
       _rmEpochState       : EpochState
+      _rmBlockStore       : BlockStore
       _rmRoundState       : RoundState
       _rmProposerElection : ProposerElection
       _rmSafetyRules      : SafetyRules
       _rmSyncOnly         : Bool
-  open RoundManagerEC public
-  unquoteDecl rmEpochState   rmRoundState   rmProposerElection   rmSafetyRules   rmSyncOnly = mkLens (quote RoundManagerEC)
-             (rmEpochState ∷ rmRoundState ∷ rmProposerElection ∷ rmSafetyRules ∷ rmSyncOnly ∷ [])
+  open RoundManager public
+  unquoteDecl rmEpochState   rmBlockStore   rmRoundState   rmProposerElection   rmSafetyRules   rmSyncOnly = mkLens (quote RoundManager)
+             (rmEpochState ∷ rmBlockStore ∷ rmRoundState ∷ rmProposerElection ∷ rmSafetyRules ∷ rmSyncOnly ∷ [])
 
-  rmEpoch : Lens RoundManagerEC Epoch
+  rmEpoch : Lens RoundManager Epoch
   rmEpoch = rmEpochState ∙ esEpoch
 
-  rmLastVotedRound : Lens RoundManagerEC Round
+  rmLastVotedRound : Lens RoundManager Round
   rmLastVotedRound = rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdLastVotedRound
 
-  -- We need enough authors to withstand the desired number of
-  -- byzantine failures.  We enforce this with a predicate over
-  -- 'RoundManagerEC'.
-  ValidatorVerifier-correct : ValidatorVerifier → Set
-  ValidatorVerifier-correct vv =
-    let numAuthors = kvm-size (vv ^∙ vvAddressToValidatorInfo)
-        qsize      = vv ^∙ vvQuorumVotingPower
-        bizF       = numAuthors ∸ qsize
-     in suc (3 * bizF) ≤ numAuthors
+  lProposerElection : Lens RoundManager ProposerElection
+  lProposerElection = rmProposerElection
 
-  RoundManagerEC-correct : RoundManagerEC → Set
-  RoundManagerEC-correct rmec = ValidatorVerifier-correct (rmec ^∙ rmEpochState ∙ esVerifier)
+  lRoundState : Lens RoundManager RoundState
+  lRoundState = rmRoundState
 
-  RoundManagerEC-correct-≡ : (rmec1 : RoundManagerEC)
-                             → (rmec2 : RoundManagerEC)
-                             → (rmec1 ^∙ rmEpochState ∙ esVerifier) ≡ (rmec2 ^∙ rmEpochState ∙ esVerifier)
-                             → RoundManagerEC-correct rmec1
-                             → RoundManagerEC-correct rmec2
-  RoundManagerEC-correct-≡ rmec1 rmec2 refl = id
+  rsVoteSent-rm : Lens RoundManager (Maybe Vote)
+  rsVoteSent-rm = lRoundState ∙ rsVoteSent
 
-  -- Given a well-formed set of definitions that defines an EpochConfig,
-  -- α-EC will compute this EpochConfig by abstracting away the unecessary
-  -- pieces from RoundManagerEC.
-  -- TODO-2: update and complete when definitions are updated to more recent version
-  α-EC : Σ RoundManagerEC RoundManagerEC-correct → EpochConfig
-  α-EC (rmec , ok) =
-    let numAuthors = kvm-size (rmec ^∙ rmEpochState ∙ esVerifier ∙ vvAddressToValidatorInfo)
-        qsize      = rmec ^∙ rmEpochState ∙ esVerifier ∙ vvQuorumVotingPower
-        bizF       = numAuthors ∸ qsize
-     in (EpochConfig∙new {! someHash?!}
-                (rmec ^∙ rmEpoch) numAuthors {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!})
+  lSyncOnly : Lens RoundManager Bool
+  lSyncOnly = rmSyncOnly
 
-  postulate
-    α-EC-≡ : (rmec1  : RoundManagerEC)
-           → (rmec2  : RoundManagerEC)
-           → (vals≡  : rmec1 ^∙ rmEpochState ∙ esVerifier ≡ rmec2 ^∙ rmEpochState ∙ esVerifier)
-           →           rmec1 ^∙ rmEpoch      ≡ rmec2 ^∙ rmEpoch
-           → (rmec1-corr : RoundManagerEC-correct rmec1)
-           → α-EC (rmec1 , rmec1-corr) ≡ α-EC (rmec2 , RoundManagerEC-correct-≡ rmec1 rmec2 vals≡ rmec1-corr)
-  {-
-  α-EC-≡ rmec1 rmec2 refl refl rmec1-corr = refl
-  -}
+  lPendingVotes : Lens RoundManager PendingVotes
+  lPendingVotes = rmRoundState ∙ rsPendingVotes
 
-  -- Finally, the RoundManager is split in two pieces: those that are used to make an EpochConfig
-  -- versus those that use an EpochConfig.  The reason is that the *abstract* EpochConfig is a
-  -- function of some parts of the RoundManager (_rmEC), and some parts depend on the abstract
-  -- EpochConfig.  For example, _btIdToQuorumCert carries a proof that the QuorumCert is valid (for
-  -- the abstract EpochConfig).
-  record RoundManager : Set ℓ-RoundManager where
-    constructor RoundManager∙new
-    field
-      _rmEC           : RoundManagerEC
-      _rmEC-correct   : RoundManagerEC-correct _rmEC
-      _rmWithEC       : RoundManagerWithEC (α-EC (_rmEC , _rmEC-correct))
-     -- If we want to add pieces that neither contribute to the
-     -- construction of the EC nor need one, they should be defined in
-     -- RoundManager directly
-  open RoundManager public
+  lSafetyRules : Lens RoundManager SafetyRules
+  lSafetyRules = rmSafetyRules
 
-  -- TODO-2: We would need dependent lenses to have a lens from RoundManager to
-  -- RoundManagerEC, since setting _rmEC means updating the proofs _rmEC-correct
-  -- and _rmWithEC
+  lPersistentSafetyStorage : Lens RoundManager PersistentSafetyStorage
+  lPersistentSafetyStorage = lSafetyRules ∙ srPersistentStorage
 
-  α-EC-RM : RoundManager → EpochConfig
-  α-EC-RM rm = α-EC ((_rmEC rm) , (_rmEC-correct rm))
+  lSafetyData : Lens RoundManager SafetyData
+  lSafetyData = lPersistentSafetyStorage ∙ pssSafetyData
 
-  rmGetEpochState : (rm : RoundManager) → EpochState
-  rmGetEpochState rm = (_rmEC rm) ^∙ rmEpochState
+  lBlockStore : Lens RoundManager BlockStore
+  lBlockStore = rmBlockStore
 
-  _rmHighestQC : (rm : RoundManager) → QuorumCert
-  _rmHighestQC rm = _btHighestQuorumCert ((_rmWithEC rm) ^∙ (lBlockTree (α-EC-RM rm)))
+  lBlockTree : Lens RoundManager BlockTree
+  lBlockTree = lBlockStore ∙ bsInner
 
-  rmHighestQC : Lens RoundManager QuorumCert
-  rmHighestQC = mkLens' _rmHighestQC
-                        (λ (RoundManager∙new ec ecc (RoundManagerWithEC∙new (BlockStore∙new bsInner'))) qc
-                          → RoundManager∙new ec ecc (RoundManagerWithEC∙new (BlockStore∙new (record bsInner' {_btHighestQuorumCert = qc}))))
+  -- This is a trivial lens, which is used in the Haskell code, so we keep it here for consistency.
+  lRoundManager : Lens RoundManager RoundManager
+  lRoundManager = lens (λ _ _ f rm → f rm)
 
-  _rmHighestCommitQC : (rm : RoundManager) → QuorumCert
-  _rmHighestCommitQC rm = _btHighestCommitCert ((_rmWithEC rm) ^∙ (lBlockTree (α-EC-RM rm)))
+  srValidatorVerifier : Lens RoundManager ValidatorVerifier
+  srValidatorVerifier = rmEpochState ∙ esVerifier
 
-  rmHighestCommitQC : Lens RoundManager QuorumCert
-  rmHighestCommitQC = mkLens' _rmHighestCommitQC
-                        (λ (RoundManager∙new ec ecc (RoundManagerWithEC∙new (BlockStore∙new bsInner'))) qc
-                          → RoundManager∙new ec ecc (RoundManagerWithEC∙new (BlockStore∙new (record bsInner' {_btHighestCommitCert = qc}))))
 
-  -- NO-DEPENDENT-LENSES (don't change this without searching for other instances of it and treating
-  -- them consistently).
-  --
-  -- Because our RoundManager is in three pieces to enable constructing an abstract EpochConfig in
-  -- which parts of it depend, we would like to have something like:
-  --
-  --   Lens (rm : RoundManager) (BlockStore (α-EC-RM rm))
-  --
-  -- However, our rudimentary Lens support does not enable such dependent lenses.  Therefore, where
-  -- the Haskell code we are modeling defines a Lens from RoundManager to BlockStore (called
-  -- lBlockStore), enabling code like:
-  --
-  --   bs <- use lBlockStore
-  --
-  -- we instead define a function such as rmGetBlockStore below
-  -- and "use" it like this:
-  --
-  --   s ← get
-  --   let bs = rmGetBlockStore s
-
-  rmGetBlockStore : (rm : RoundManager) → BlockStore (α-EC-RM rm)
-  rmGetBlockStore rm = (_rmWithEC rm) ^∙ (epBlockStore (α-EC-RM rm))
-
-  rmSetBlockStore : (rm : RoundManager) → BlockStore (α-EC-RM rm) → RoundManager
-  rmSetBlockStore rm bs = record rm { _rmWithEC = RoundManagerWithEC∙new bs }
-
-  lBlockStore : ∀ {ec} → Lens (RoundManagerWithEC ec) (BlockStore ec)
-  lBlockStore = epBlockStore _
-
-  -- In some cases, the getting operation is not dependent but a lens still
+-- In some cases, the getting operation is not dependent but a lens still
   -- cannot be defined because the *setting* operation would require dependent
   -- types. Below, `rmGetValidatorVerifier` is an example of this situation, and
   -- we would "use" it like this
   --
   --    vv ← gets rmGetValidatorVerifier
 
-  rmGetValidatorVerifier : RoundManager → ValidatorVerifier
-  rmGetValidatorVerifier rm = _esVerifier (_rmEpochState (_rmEC rm))
-
-  lProposerElection : Lens RoundManager ProposerElection
-  lProposerElection = mkLens' g s
-    where
-    g : RoundManager → ProposerElection
-    g rm = _rmEC rm ^∙ rmProposerElection
-
-    s : RoundManager → ProposerElection → RoundManager
-    s rm pe = record rm { _rmEC = (_rmEC rm) & rmProposerElection ∙~ pe }
-
-  lRoundState : Lens RoundManager RoundState
-  lRoundState = mkLens' g s
-    where
-    g : RoundManager → RoundState
-    g rm = _rmEC rm ^∙ rmRoundState
-
-    s : RoundManager → RoundState → RoundManager
-    s rm rs = record rm { _rmEC = (_rmEC rm) & rmRoundState ∙~ rs }
-
-  rsVoteSent-rm : Lens RoundManager (Maybe Vote)
-  rsVoteSent-rm = lRoundState ∙ rsVoteSent
-
-  lSyncOnly : Lens RoundManager Bool
-  lSyncOnly = mkLens' g s
-    where
-    g : RoundManager → Bool
-    g rm = _rmEC rm ^∙ rmSyncOnly
-
-    s : RoundManager → Bool → RoundManager
-    s rm so = record rm { _rmEC = (_rmEC rm) & rmSyncOnly ∙~ so }
-
-  lPendingVotes : Lens RoundManager PendingVotes
-  lPendingVotes = mkLens' g s
-    where
-    g : RoundManager → PendingVotes
-    g rm = _rmEC rm ^∙ (rmRoundState ∙ rsPendingVotes)
-
-    s : RoundManager → PendingVotes → RoundManager
-    s rm pv = record rm { _rmEC = (_rmEC rm) & rmRoundState ∙ rsPendingVotes ∙~ pv }
-
-  lSafetyRules : Lens RoundManager SafetyRules
-  lSafetyRules = mkLens' g s
-    where
-    g : RoundManager → SafetyRules
-    g rm = _rmEC rm ^∙ rmSafetyRules
-
-    s : RoundManager → SafetyRules → RoundManager
-    s rm sr = record rm { _rmEC = (_rmEC rm) & rmSafetyRules ∙~ sr }
-
-  lPersistentSafetyStorage : Lens RoundManager PersistentSafetyStorage
-  lPersistentSafetyStorage = lSafetyRules ∙ srPersistentStorage
-
   -- IMPL-DIFF : this is defined as a lens getter only (no setter) in Haskell.
   rmPgAuthor : RoundManager → Maybe Author
   rmPgAuthor rm =
-    maybeS (_rmEC rm ^∙ rmSafetyRules ∙ srValidatorSigner) nothing (just ∘ (_^∙ vsAuthor))
-
-  lSafetyData : Lens RoundManager SafetyData
-  lSafetyData = lPersistentSafetyStorage ∙ pssSafetyData
+    maybeS (rm ^∙ rmSafetyRules ∙ srValidatorSigner) nothing (just ∘ (_^∙ vsAuthor))
 
   record GenesisInfo : Set where
     constructor mkGenInfo
@@ -293,17 +156,8 @@ module LibraBFT.ImplShared.Consensus.Types where
     -- TODO: construct one or write a function that generates one from some parameters.
     genesisInfo : GenesisInfo
 
-  postulate -- TODO-2: define GenesisInfo to match implementation and write these functions
-    initVV  : GenesisInfo → ValidatorVerifier
-    init-EC : GenesisInfo → EpochConfig
-
   data ∈GenInfo-impl (gi : GenesisInfo) : Signature → Set where
    inGenQC : ∀ {vs} → vs ∈ qcVotes (genQC gi) → ∈GenInfo-impl gi (proj₂ vs)
-
-  open import LibraBFT.Abstract.Records UID _≟UID_ NodeId
-                                        (init-EC genesisInfo)
-                                        (ConcreteVoteEvidence (init-EC genesisInfo))
-                                        as Abs using ()
 
   postulate -- TODO-1 : prove
     ∈GenInfo?-impl : (gi : GenesisInfo) (sig : Signature) → Dec (∈GenInfo-impl gi sig)

--- a/LibraBFT/ImplShared/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochDep.agda
@@ -3,12 +3,12 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-
+{-# OPTIONS --allow-unsolved-metas #-}
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap as KVMap
 open import LibraBFT.ImplShared.Base.Types
-open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
+open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
@@ -16,27 +16,73 @@ open import Optics.All
 
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
--- This module defines the types that depend on an EpochConfig,
--- but never inspect it. Consequently, we define everyting over
--- an abstract 𝓔 passed around as a module parameter.
---
--- Importantly, though, we are connecting abstract and concrete
+-- This module defines types for connecting abstract and concrete
 -- votes by defining what constitutes enough "evidence" that a
 -- vote was cast, which is passed around in the abstract model as
 -- the variable (𝓥 : VoteEvidence); here we instantiate it to
 -- 'ConcreteVoteEvidence'.
 --
--- TODO-3: update types to reflect more recent version of LibraBFT.
--- This is a substantial undertaking that should probably be led by
--- someone who can access our internal implementation.
---
--- TODO-4: Make the Optics.Reflection stuff work with record
--- parameters, so we can merge all modules back into Types.  For
--- now, this is the easiest way to avoid the issue that making a
--- module inside Consensus.Types called EpochDep will break
--- mkLens (not sure why).
+-- Some of the types in this module depend on an EpochConfig, but
+-- never inspect it. Consequently, we define everything over an
+-- abstract 𝓔 passed around as module parameter to an inner module
+-- WithEC.  Before that, we define some definitions relevant to
+-- constructing EpochConfigs from RoundManager.
 
-module LibraBFT.ImplShared.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
+module LibraBFT.ImplShared.Consensus.Types.EpochDep where
+
+-- Note that the definitions below are relevant only to the verificat, not the implementation.
+-- They should probably move somewhere else.
+
+-- We need enough authors to withstand the desired number of
+-- byzantine failures.  We enforce this with a predicate over
+-- 'RoundManager'.
+ValidatorVerifier-correct : ValidatorVerifier → Set
+ValidatorVerifier-correct vv =
+  let numAuthors = kvm-size (vv ^∙ vvAddressToValidatorInfo)
+      qsize      = vv ^∙ vvQuorumVotingPower
+      bizF       = numAuthors ∸ qsize
+   in suc (3 * bizF) ≤ numAuthors
+
+RoundManager-correct : RoundManager → Set
+RoundManager-correct rmec = ValidatorVerifier-correct (rmec ^∙ rmEpochState ∙ esVerifier)
+
+RoundManager-correct-≡ : (rmec1 : RoundManager)
+                           → (rmec2 : RoundManager)
+                           → (rmec1 ^∙ rmEpochState ∙ esVerifier) ≡ (rmec2 ^∙ rmEpochState ∙ esVerifier)
+                           → RoundManager-correct rmec1
+                           → RoundManager-correct rmec2
+RoundManager-correct-≡ rmec1 rmec2 refl = id
+
+-- Given a well-formed set of definitions that defines an EpochConfig,
+-- α-EC will compute this EpochConfig by abstracting away the unecessary
+-- pieces from RoundManager.
+-- TODO-2: update and complete when definitions are updated to more recent version
+α-EC : Σ RoundManager RoundManager-correct → EpochConfig
+α-EC (rmec , ok) =
+  let numAuthors = kvm-size (rmec ^∙ rmEpochState ∙ esVerifier ∙ vvAddressToValidatorInfo)
+      qsize      = rmec ^∙ rmEpochState ∙ esVerifier ∙ vvQuorumVotingPower
+      bizF       = numAuthors ∸ qsize
+   in (EpochConfig∙new {! someHash?!}
+              (rmec ^∙ rmEpoch) numAuthors {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!})
+
+postulate
+  α-EC-≡ : (rmec1  : RoundManager)
+         → (rmec2  : RoundManager)
+         → (vals≡  : rmec1 ^∙ rmEpochState ∙ esVerifier ≡ rmec2 ^∙ rmEpochState ∙ esVerifier)
+         →           rmec1 ^∙ rmEpoch      ≡ rmec2 ^∙ rmEpoch
+         → (rmec1-corr : RoundManager-correct rmec1)
+         → α-EC (rmec1 , rmec1-corr) ≡ α-EC (rmec2 , RoundManager-correct-≡ rmec1 rmec2 vals≡ rmec1-corr)
+{-
+α-EC-≡ rmec1 rmec2 refl refl rmec1-corr = refl
+-}
+
+α-EC-RM : (rm : RoundManager) → RoundManager-correct rm → EpochConfig
+α-EC-RM rm rmc = α-EC (rm , rmc)
+
+postulate -- TODO-2: define GenesisInfo to match implementation and write these functions
+  init-EC : GenesisInfo → EpochConfig
+
+module WithEC (𝓔 : EpochConfig) where
   open EpochConfig 𝓔
   open WithAbsVote 𝓔
 
@@ -141,64 +187,3 @@ module LibraBFT.ImplShared.Consensus.Types.EpochDep (𝓔 : EpochConfig) where
   vqcMember qc v {α , _ , _} as∈qc with All-lookup (_ivqcMetaVotesValid v) as∈qc
   ...| prf = _ivvMember prf
 
-  -- A block tree depends on a epoch config but works regardlesss of which
-  -- EpochConfig we have.
-  record BlockTree : Set where
-    constructor BlockTree∙new
-    field
-      _btIdToBlock               : KVMap HashValue LinkableBlock
-      _btRootId                  : HashValue
-      _btHighestCertifiedBlockId : HashValue
-      _btHighestQuorumCert       : QuorumCert
-      _btHighestTimeoutCert      : Maybe TimeoutCertificate
-      _btHighestCommitCert       : QuorumCert
-      _btPendingVotes            : PendingVotes
-      _btPrunedBlockIds          : List HashValue
-      _btMaxPrunedBlocksInMem    : ℕ
-      _btIdToQuorumCert          : KVMap HashValue (Σ QuorumCert MetaIsValidQC)
-  open BlockTree public
-  unquoteDecl btIdToBlock   btRootId   btHighestCertifiedBlockId   btHighestQuorumCert
-              btHighestTimeoutCert
-              btHighestCommitCert   btPendingVotes   btPrunedBlockIds
-              btMaxPrunedBlocksInMem btIdToQuorumCert = mkLens (quote BlockTree)
-             (btIdToBlock ∷ btRootId ∷ btHighestCertifiedBlockId ∷ btHighestQuorumCert ∷
-              btHighestTimeoutCert ∷
-              btHighestCommitCert ∷ btPendingVotes ∷ btPrunedBlockIds ∷
-              btMaxPrunedBlocksInMem ∷ btIdToQuorumCert ∷ [])
-
-  record BlockStore : Set where
-    constructor BlockStore∙new
-    field
-      _bsInner         : BlockTree
-      -- bsStateComputer : StateComputer
-      -- bsStorage       : CBPersistentStorage
-  open BlockStore public
-  unquoteDecl bsInner = mkLens (quote BlockStore)
-             (bsInner ∷ [])
-
-  -- IMPL-DIFF : this is a getter only in Haskell
-  bsHighestCommitCert : Lens BlockStore QuorumCert
-  bsHighestCommitCert = bsInner ∙ btHighestCommitCert
-
-  -- IMPL-DIFF : this is a getter only in Haskell
-  bsHighestQuorumCert : Lens BlockStore QuorumCert
-  bsHighestQuorumCert = bsInner ∙ btHighestQuorumCert
-
-  -- IMPL-DIFF : this is a getter only in Haskell
-  bsHighestTimeoutCert : BlockStore → Maybe TimeoutCertificate
-  bsHighestTimeoutCert =  _^∙ bsInner ∙ btHighestTimeoutCert
-
-  -- These are the parts of the RoundManager that depend on an
-  -- EpochConfig. We do not particularly care which EpochConfig
-  -- they care about yet.
-  --
-  record RoundManagerWithEC : Set where
-    constructor RoundManagerWithEC∙new
-    field
-      _epBlockStore   : BlockStore
-  open RoundManagerWithEC public
-  unquoteDecl epBlockStore = mkLens (quote RoundManagerWithEC)
-    (epBlockStore ∷ [])
-
-  lBlockTree : Lens RoundManagerWithEC BlockTree
-  lBlockTree = epBlockStore ∙ bsInner

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -606,3 +606,51 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     TooLittleVotingPower : U64 → U64 →     VerifyError
     TooManySignatures    : Usize → Usize → VerifyError
     InvalidSignature     :                 VerifyError
+
+  -- A block tree depends on a epoch config but works regardlesss of which
+  -- EpochConfig we have.
+  record BlockTree : Set where
+    constructor BlockTree∙new
+    field
+      _btIdToBlock               : KVMap HashValue LinkableBlock
+      _btRootId                  : HashValue
+      _btHighestCertifiedBlockId : HashValue
+      _btHighestQuorumCert       : QuorumCert
+      _btHighestTimeoutCert      : Maybe TimeoutCertificate
+      _btHighestCommitCert       : QuorumCert
+      _btPendingVotes            : PendingVotes
+      _btPrunedBlockIds          : List HashValue
+      _btMaxPrunedBlocksInMem    : ℕ
+      _btIdToQuorumCert          : KVMap HashValue QuorumCert
+  open BlockTree public
+  unquoteDecl btIdToBlock   btRootId   btHighestCertifiedBlockId   btHighestQuorumCert
+              btHighestTimeoutCert
+              btHighestCommitCert   btPendingVotes   btPrunedBlockIds
+              btMaxPrunedBlocksInMem btIdToQuorumCert = mkLens (quote BlockTree)
+             (btIdToBlock ∷ btRootId ∷ btHighestCertifiedBlockId ∷ btHighestQuorumCert ∷
+              btHighestTimeoutCert ∷
+              btHighestCommitCert ∷ btPendingVotes ∷ btPrunedBlockIds ∷
+              btMaxPrunedBlocksInMem ∷ btIdToQuorumCert ∷ [])
+
+  record BlockStore : Set where
+    constructor BlockStore∙new
+    field
+      _bsInner         : BlockTree
+      -- bsStateComputer : StateComputer
+      -- bsStorage       : CBPersistentStorage
+  open BlockStore public
+  unquoteDecl bsInner = mkLens (quote BlockStore)
+             (bsInner ∷ [])
+
+  -- IMPL-DIFF : this is a getter only in Haskell
+  bsHighestCommitCert : Lens BlockStore QuorumCert
+  bsHighestCommitCert = bsInner ∙ btHighestCommitCert
+
+  -- IMPL-DIFF : this is a getter only in Haskell
+  bsHighestQuorumCert : Lens BlockStore QuorumCert
+  bsHighestQuorumCert = bsInner ∙ btHighestQuorumCert
+
+  -- IMPL-DIFF : this is a getter only in Haskell
+  bsHighestTimeoutCert : Lens BlockStore (Maybe TimeoutCertificate)
+  bsHighestTimeoutCert = bsInner ∙ btHighestTimeoutCert
+

--- a/LibraBFT/ImplShared/Interface/Output.agda
+++ b/LibraBFT/ImplShared/Interface/Output.agda
@@ -83,7 +83,7 @@ module LibraBFT.ImplShared.Interface.Output where
                                                       (List-map proj₁
                                                                 (kvm-toList (_vvAddressToValidatorInfo
                                                                               (_esVerifier
-                                                                                (_rmEpochState (_rmEC rm))))))
+                                                                                (_rmEpochState rm)))))
   outputToActions _  (LogErr x)            = []
   outputToActions _  (LogInfo x)           = []
   outputToActions _  (SendVote vm toList)  = List-map (const (send (V vm))) toList

--- a/LibraBFT/ImplShared/Util/Util.agda
+++ b/LibraBFT/ImplShared/Util/Util.agda
@@ -35,27 +35,6 @@ module LibraBFT.ImplShared.Util.Util where
   LBFT-outs : ∀ {A} → LBFT A → RoundManager → List Output
   LBFT-outs m rm = proj₂ (proj₂ (LBFT-run m rm))
 
-  -- Local 'LBFT' monad; which operates only over the part of
-  -- the state that /depends/ on the ec; not the part
-  -- of the state that /defines/ the ec.
-  --
-  -- This is very convenient to define functions that
-  -- do not alter the ec.
-
-  LBFT-ec : EpochConfig → Set → Set₁
-  LBFT-ec ec = RWST Unit Output (RoundManagerWithEC ec)
-
-  -- Lifting a function that does not alter the pieces that
-  -- define the epoch config is easy
-  liftEC : {A : Set}(f : ∀ {ec} → LBFT-ec ec A) → LBFT A
-  liftEC f = do
-    st ← get
-    let ec                 = α-EC (_rmEC st , _rmEC-correct st)
-        r₁ , stec₁ , outs₁ = RWST-run (f {ec}) unit (_rmWithEC st)
-    tell outs₁
-    put (record st { _rmWithEC = stec₁ })
-    return r₁
-
   LBFT-Pre  = RoundManager → Set
   LBFT-Post = RWST-Post Output RoundManager
 


### PR DESCRIPTION
The pull request supersedes #68 because we have decided to give up on tracking proof metadata in the state, and instead maintain it in invariants we prove.  This eliminates some painful issues with the lack of dependent lenses, preventing us from faithfully modeling the code we are verifying.  Now:

* `Consensus.Types` is unaware of `EpochConfig`; definitions related to `EpochConfig` are now in `Types.EpochDep`, which now has an inner module `WithEC` that is parameterised by an `EpochConfig`
* We can have all the lenses, and the previous workarounds have been eliminated, which eliminates a number of differences between the Haskell and Agda codes.
* All the proofs are fixed up; only a couple required any thinking; these were due to the proof obligations changing slightly when we switch from patterns like:
```
st <- get
let x = _someSpecialFunction st
...
```
to
```
x <- use aRegularLens
```
