### PR TITLE
Restate and prove contract for `verifyqQcM` plus more implementation and properties needed for that

### DIFF
--- a/LibraBFT/Impl/Consensus/ConsensusTypes/ExecutedBlock.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/ExecutedBlock.agda
@@ -4,6 +4,7 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Base.Types
+import      LibraBFT.Impl.Execution.ExecutorTypes.StateComputeResult as StateComputeResult
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util
@@ -15,5 +16,6 @@ module LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock where
 maybeSignedVoteProposal : ExecutedBlock → MaybeSignedVoteProposal
 maybeSignedVoteProposal self =
   MaybeSignedVoteProposal∙new
-    (VoteProposal∙new (self ^∙ ebBlock))
-
+    (VoteProposal∙new (StateComputeResult.extensionProof (self ^∙ ebStateComputeResult))
+                      (self ^∙ ebBlock)
+                      (self ^∙ ebStateComputeResult ∙ scrEpochState))

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Properties/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Properties/QuorumCert.agda
@@ -1,0 +1,97 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+ 
+open import LibraBFT.Base.Types
+open import LibraBFT.Base.KVMap as Map
+open import LibraBFT.Hash
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Properties.VoteData as VoteDataProps
+import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData            as VoteData
+import      LibraBFT.Impl.Types.LedgerInfoWithSignatures               as LedgerInfoWithSignatures
+import      LibraBFT.Impl.Types.Properties.LedgerInfoWithSignatures    as LedgerInfoWithSignaturesProps
+open import LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert          as QuorumCert
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.ConsensusTypes.Properties.QuorumCert (self : QuorumCert) (vv : ValidatorVerifier) where
+  voteHash = hashVD (self ^∙ qcVoteData)
+
+  record rnd≡0Props : Set where
+    field
+        par≡cert : self ^∙ qcParentBlock    ≡ self ^∙ qcCertifiedBlock
+        cert≡li  : self ^∙ qcCertifiedBlock ≡ self ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liCommitInfo
+        noSigs   : Map.kvm-size (self ^∙ qcLedgerInfo ∙ liwsSignatures) ≡ 0
+  open rnd≡0Props
+
+  record rnd≢0Props : Set where
+    field
+      sigProp : LedgerInfoWithSignatures.verifySignatures (self ^∙ qcLedgerInfo) vv ≡ Right unit
+      vdProp  : VoteDataProps.Contract (self ^∙ qcVoteData)
+  open rnd≢0Props
+
+  rnd≡0 = self ^∙ qcCertifiedBlock ∙ biRound ≡ 0
+
+  record Contract : Set where
+    field
+      lihash≡ : self ^∙ qcSignedLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash ≡ voteHash
+      rnd0    :   rnd≡0 → rnd≡0Props
+      ¬rnd0   : ¬ rnd≡0 → rnd≢0Props
+  open Contract
+
+  contract : ∀ (r : Either ErrLog Unit) → r ≡ Right unit
+           → QuorumCert.verify self vv ≡ r
+           → Contract
+  contract (Left fakeErr)
+     with (self ^∙ qcSignedLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash) ≟Hash
+          (hashVD (self ^∙ qcVoteData))
+  ...| no neq = λ ()
+  ...| yes refl
+     with self ^∙ qcCertifiedBlock ∙ biRound ≟ 0
+  ...| yes refl
+     with (self ^∙ qcParentBlock) ≟-BlockInfo (self ^∙ qcCertifiedBlock)
+  ...| no neq = λ ()
+  ...| yes refl
+     with (self ^∙ qcCertifiedBlock) ≟-BlockInfo (self ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liCommitInfo)
+  ...| no neq = λ ()
+  ...| yes refl
+     with Map.kvm-size (self ^∙ qcLedgerInfo ∙ liwsSignatures) ≟ 0
+  ...| yes noSigs = λ ()
+
+  contract (Right unit)
+     with (self ^∙ qcSignedLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash) ≟Hash (hashVD (self ^∙ qcVoteData))
+  ...| no neq = λ _ ()
+  ...| yes refl
+     with self ^∙ qcCertifiedBlock ∙ biRound ≟ 0
+  ...| yes refl
+     with (self ^∙ qcParentBlock) ≟-BlockInfo (self ^∙ qcCertifiedBlock)
+  ...| no neq = λ _ ()
+  ...| yes refl
+     with (self ^∙ qcCertifiedBlock) ≟-BlockInfo (self ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liCommitInfo)
+  ...| no neq = λ _ ()
+  ...| yes refl
+     with Map.kvm-size (self ^∙ qcLedgerInfo ∙ liwsSignatures) ≟ 0
+  ...| yes noSigs = λ _ _ →
+         record { lihash≡ = refl
+                ; rnd0    = λ _ → record { par≡cert = refl ; cert≡li = refl ; noSigs = noSigs }
+                ; ¬rnd0   = λ x → ⊥-elim (x refl) }
+  contract (Right unit)
+     | yes refl
+     | no neq
+     with  LedgerInfoWithSignatures.verifySignatures (self ^∙ qcLedgerInfo)  vv | inspect
+          (LedgerInfoWithSignatures.verifySignatures (self ^∙ qcLedgerInfo)) vv
+  ...| Left  err  | [ R ] = λ _ ()
+  ...| Right unit | [ R ]
+     with VoteData.verify (self ^∙ qcVoteData) | inspect
+          VoteData.verify (self ^∙ qcVoteData)
+  ...| Left err   | _ = λ _ ()
+  ...| Right unit | [ R' ] = λ _ _ →
+         record { lihash≡ = refl
+                ; rnd0    = ⊥-elim ∘ neq
+                ; ¬rnd0   = λ _ →
+                    record { sigProp = R
+                           ; vdProp  = VoteDataProps.contract (self ^∙ qcVoteData) R' }}

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Properties/VoteData.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Properties/VoteData.agda
@@ -1,0 +1,37 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.Types
+import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData as VoteData
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.ConsensusTypes.Properties.VoteData (self : VoteData) where
+
+  record Contract : Set where
+    field
+      ep≡     : self ^∙ vdParent ∙ biEpoch ≡ self ^∙ vdProposed ∙ biEpoch
+      parRnd< : self ^∙ vdParent ∙ biRound < self ^∙ vdProposed ∙ biRound
+      parVer≤ : (self ^∙ vdParent ∙ biVersion) ≤-Version (self ^∙ vdProposed ∙ biVersion)
+  open Contract
+
+  contract
+      : VoteData.verify self ≡ Right unit → Contract
+  contract
+     with self ^∙ vdParent ∙ biEpoch ≟ self ^∙ vdProposed ∙ biEpoch
+  ...| no neq = (λ ())
+  ...| yes refl
+     with self ^∙ vdParent ∙ biRound <? self ^∙ vdProposed ∙ biRound
+  ...| no ¬par<prop = (λ ())
+  ...| yes par<prop
+     with (self ^∙ vdParent ∙ biVersion) ≤?-Version (self ^∙ vdProposed ∙ biVersion)
+  ...| no ¬parVer≤ = (λ ())
+  ...| yes parVer≤ = (λ x → record { ep≡ = refl
+                                   ; parRnd< = par<prop
+                                   ; parVer≤ = parVer≤ })

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
@@ -23,9 +23,6 @@ module LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert where
     lcheck (self ^∙ qcSignedLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash == voteHash)
            -- (here ["Quorum Cert's hash mismatch LedgerInfo"])
 
-    -- TODO-?: It would be nice to be able to omit the ⌊ ⌋, similar to grd‖ (as in
-    -- Network.processProposal).  We do have ifM* but those are currently available only for the
-    -- RWST monad.
     if (self ^∙ qcCertifiedBlock ∙ biRound == 0)
       -- TODO-?: It would be nice not to require the parens around the do block
       then (do

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
@@ -3,7 +3,12 @@
    Copyright (c) 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+import      LibraBFT.Base.KVMap as Map
 open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData as VoteData
+import      LibraBFT.Impl.Types.LedgerInfoWithSignatures    as LedgerInfoWithSignatures
+open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util
@@ -12,6 +17,26 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert where
 
-postulate
   verify : QuorumCert → ValidatorVerifier → Either ErrLog Unit
+  verify self validator = do
+    let voteHash = hashVD (self ^∙ qcVoteData)
+    lcheck (self ^∙ qcSignedLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash == voteHash)
+           -- (here ["Quorum Cert's hash mismatch LedgerInfo"])
 
+    -- TODO-?: It would be nice to be able to omit the ⌊ ⌋, similar to grd‖ (as in
+    -- Network.processProposal).  We do have ifM* but those are currently available only for the
+    -- RWST monad.
+    if (self ^∙ qcCertifiedBlock ∙ biRound == 0)
+      -- TODO-?: It would be nice not to require the parens around the do block
+      then (do
+        lcheck (self ^∙ qcParentBlock == self ^∙ qcCertifiedBlock)
+               -- (here ["Genesis QC has inconsistent parent block with certified block"])
+        lcheck (self ^∙ qcCertifiedBlock == self ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liCommitInfo)
+               -- (here ["Genesis QC has inconsistent commit block with certified block"])
+        lcheck (Map.kvm-size (self ^∙ qcLedgerInfo ∙ liwsSignatures) == 0)
+               -- (here ["Genesis QC should not carry signatures"])
+        )
+      else do
+        -- TODO: withErrCtx'
+        (LedgerInfoWithSignatures.verifySignatures (self ^∙ qcLedgerInfo) validator)
+        VoteData.verify (self ^∙ qcVoteData)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/VoteData.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/VoteData.agda
@@ -3,13 +3,27 @@
    Copyright (c) 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-
-open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.VoteData where
+
+verify : VoteData → Either ErrLog Unit
+verify self = do
+  lcheck (self ^∙ vdParent ∙ biEpoch == self ^∙ vdProposed ∙ biEpoch)
+         -- ["parent and proposed epochs do not match"]
+  lcheck (⌊ self ^∙ vdParent ∙ biRound <?  self ^∙ vdProposed ∙ biRound ⌋)
+         -- ["proposed round is less than parent round"]
+  -- lcheck (self^.vdParent.biTimestamp <= self^.vdProposed.biTimestamp)
+  --       ["proposed happened before parent"]
+  lcheck (⌊ (self ^∙ vdParent ∙ biVersion) ≤?-Version (self ^∙ vdProposed ∙ biVersion) ⌋)
+         -- [ "proposed version is less than parent version"
+         -- , lsVersion (self^.vdProposed.biVersion), lsVersion (self^.vdParent.biVersion)]
 
 new : BlockInfo → BlockInfo → VoteData
 new = VoteData∙new

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -164,11 +164,13 @@ module verifyQcMSpec (self : QuorumCert) where
   ...| yes refl
      with Map.kvm-size (self ^∙ qcLedgerInfo ∙ liwsSignatures) ≟ 0
   ...| no neq = λ where _ refl → refl , refl
-  ...| yes noSigs = λ where _ refl → refl , refl , record { lihash≡ = refl
-                                                          ; rnd0    = λ _ → record { par≡cert = refl
-                                                                                   ; cert≡li = refl
-                                                                                   ; noSigs = noSigs }
-                                                          ; ¬rnd0   = λ x → ⊥-elim (x refl) }
+  ...| yes noSigs =
+         λ where _ refl →
+                  refl , refl , record { lihash≡ = refl
+                                       ; rnd≟0 = yes refl
+                                       ; parProp = record { par≡cert = refl
+                                                          ; cert≡li = refl
+                                                          ; noSigs = noSigs } }
   contract' pre vv refl
      | yes refl
      | no neq
@@ -179,13 +181,14 @@ module verifyQcMSpec (self : QuorumCert) where
      with VoteData.verify (self ^∙ qcVoteData) | inspect
           VoteData.verify (self ^∙ qcVoteData)
   ...| Left e     | _ = λ where _ refl → refl , refl
-  ...| Right unit | [ R' ] = λ where _ refl → refl , refl
-                                            , record { lihash≡ = refl
-                                                     ; rnd0    = ⊥-elim ∘ neq
-                                                     ; ¬rnd0   = λ _ → record { sigProp = R
-                                                                              ; vdProp = VoteDataProps.contract
-                                                                                           (self ^∙ qcVoteData)
-                                                                                           R' }}
+  ...| Right unit | [ R' ] =
+         λ where _ refl →
+                  refl , refl , record { lihash≡ = refl
+                                       ; rnd≟0   = no neq
+                                       ; parProp = record { sigProp = R
+                                                          ; vdProp = VoteDataProps.contract
+                                                                       (self ^∙ qcVoteData)
+                                                                       R' }}
 
   -- Suppose verifyQcM runs from prestate pre, and we wish to ensure that postcondition Post holds
   -- afterwards.  If P holds provided verifyQcM does not modify the state and does not produce any

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -194,7 +194,7 @@ module verifyQcMSpec (self : QuorumCert) where
   -- prestate, then verifyQcM ensures P holds.  Proving this directly is painful because it's
   -- difficult to construct a QuorumCertProps.Contract self (getVv pre) that Agda understands allows
   -- us to invoke the rPrf (condition on P in case verifyQcM succeeds).  Therefore, we restate the
-  -- conditions on P (as P', above) and prove that P' implies P, and then use RWST-impl to achieve
+  -- conditions on P (as P', above) and prove that P' implies P, and then use LBFT-⇒ to achieve
   -- the desired result.
   contract
     : ∀ P pre
@@ -202,7 +202,7 @@ module verifyQcMSpec (self : QuorumCert) where
     → (QuorumCertProps.Contract self (getVv pre) → P (Right unit) pre [])
     → RWST-weakestPre (verifyQcM self) P unit pre
   contract Post pre lPrf rPrf = LBFT-⇒ (P' pre) Post
-                                       (λ { (Left x₁) st outs (refl , refl)          →  lPrf
+                                       (λ { (Left x₁) st outs (refl , refl)          → lPrf
                                           ; (Right unit) st outs (refl , refl , prf) → rPrf prf })
                                        (verifyQcM self)
                                        pre

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -10,6 +10,7 @@ import      LibraBFT.Impl.Consensus.ConsensusTypes.Block      as Block
 import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert as QuorumCert
 import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote       as Vote
 import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData   as VoteData
+import      LibraBFT.Impl.OBM.Crypto                          as Crypto
 open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.Impl.Types.ValidatorSigner               as ValidatorSigner
 open import LibraBFT.ImplShared.Base.Types
@@ -35,14 +36,15 @@ signer self = maybeS (self ^∙ srValidatorSigner) (Left fakeErr {- error: signe
 extensionCheckM : VoteProposal → LBFT (Either ErrLog VoteData)
 extensionCheckM voteProposal = do
   let proposedBlock = voteProposal ^∙ vpBlock
-   {- obmAEP        = voteProposal ^∙ vpAccumulatorExtensionProof -}
+      obmAEP        = voteProposal ^∙ vpAccumulatorExtensionProof
   -- IMPL-TODO: verify .accumulator_extension_proof().verify ...
   ok (VoteData.new
        (Block.genBlockInfo
          proposedBlock
          -- OBM-LBFT-DIFF: completely different
-         {- (Crypto.obmHashVersion (obmAEP ^∙ aepObmNumLeaves)) -}
-         {- (voteProposal ^∙ vpNextEpochState) -})
+         (Crypto.obmHashVersion (obmAEP ^∙ aepObmNumLeaves))
+         (obmAEP ^∙ aepObmNumLeaves)
+         (voteProposal ^∙ vpNextEpochState))
        (proposedBlock ^∙ bQuorumCert ∙ qcCertifiedBlock))
 
 ------------------------------------------------------------------------------

--- a/LibraBFT/Impl/Execution/ExecutorTypes/StateComputeResult.agda
+++ b/LibraBFT/Impl/Execution/ExecutorTypes/StateComputeResult.agda
@@ -1,20 +1,17 @@
 {- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
-
+\
    Copyright (c) 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 open import LibraBFT.Base.Types
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 
-module LibraBFT.Impl.Consensus.ConsensusTypes.Block where
+module LibraBFT.Impl.Execution.ExecutorTypes.StateComputeResult where
 
-postulate
-  validateSignature : Block → ValidatorVerifier → Either ErrLog Unit
-
-genBlockInfo : Block → HashValue → Version → Maybe EpochState → BlockInfo
-genBlockInfo b executedStateId version nextEpochState = BlockInfo∙new
-  (b ^∙ bEpoch) (b ^∙ bRound) (b ^∙ bId) executedStateId version nextEpochState
+extensionProof : StateComputeResult → AccumulatorExtensionProof
+extensionProof self = AccumulatorExtensionProof∙new (self ^∙ scrObmNumLeaves)

--- a/LibraBFT/Impl/OBM/Crypto.agda
+++ b/LibraBFT/Impl/OBM/Crypto.agda
@@ -11,6 +11,9 @@ open import LibraBFT.Prelude
 
 module LibraBFT.Impl.OBM.Crypto where
 
+postulate -- TODO-1: implement it
+  obmHashVersion : Version → HashValue
+
 record CryptoHash (A : Set) : Set where
   field
     sign        : SK → A → Signature

--- a/LibraBFT/Impl/OBM/Logging/Logging.agda
+++ b/LibraBFT/Impl/OBM/Logging/Logging.agda
@@ -28,3 +28,8 @@ withErrCtxt = id
 
 logEE : ∀ {A} → LBFT A → LBFT A
 logEE f = logInfo >> f >>= λ r → logInfo >> pure r
+
+lcheck : ∀ {ℓ} {A : Set ℓ} ⦃ _ : ToBool A ⦄ → A → {- List String → -} Either ErrLog Unit
+lcheck b {- t -} = case check (toBool b) [] of λ where
+  (Left e)  → Left fakeErr
+  (Right r) → Right r

--- a/LibraBFT/Impl/Types/Properties/LedgerInfoWithSignatures.agda
+++ b/LibraBFT/Impl/Types/Properties/LedgerInfoWithSignatures.agda
@@ -1,0 +1,25 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.Types
+open import LibraBFT.Base.KVMap as Map
+open import LibraBFT.Hash
+import      LibraBFT.Impl.Types.LedgerInfoWithSignatures    as LedgerInfoWithSignatures
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Types.Properties.LedgerInfoWithSignatures (self : LedgerInfoWithSignatures) (vv : ValidatorVerifier) where
+
+  -- See comments in LibraBFT.Impl.Consensus.ConsensusTypes.Properties.QuorumCert
+
+  postulate -- TODO-2: define and prove
+
+    Contract : Set
+
+    contract : LedgerInfoWithSignatures.verifySignatures self vv ≡ Right unit → Contract

--- a/LibraBFT/ImplFake/Consensus/RoundManager.agda
+++ b/LibraBFT/ImplFake/Consensus/RoundManager.agda
@@ -32,15 +32,16 @@ processCommitM finalityProof = pure []
 fakeAuthor : Author
 fakeAuthor = 0
 
+postulate -- TODO-1: these are temporary scaffolding for the fake implementation
+  fakeSK   : SK
+  fakeSig  : Signature
+  fakeHash : Hash
+
 fakeBlockInfo : Epoch → Round → ProposalMsg → BlockInfo
-fakeBlockInfo eid rnd pm = BlockInfo∙new eid rnd (pm ^∙ pmProposal ∙ bId)
+fakeBlockInfo eid rnd pm = BlockInfo∙new eid rnd (pm ^∙ pmProposal ∙ bId) fakeHash (mkVersion 0 0) nothing
 
 fakeLedgerInfo : BlockInfo → ProposalMsg → LedgerInfo
 fakeLedgerInfo bi pm = LedgerInfo∙new bi (pm ^∙ pmProposal ∙ bId)
-
-postulate -- TODO-1: these are temporary scaffolding for the fake implementation
-  fakeSK  : SK
-  fakeSig : Signature
 
 processProposalMsg : Instant → ProposalMsg → LBFT Unit
 processProposalMsg inst pm = do

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -34,15 +34,6 @@ module LibraBFT.ImplShared.Consensus.Types where
   open import LibraBFT.ImplShared.Consensus.Types.EpochIndep     public
   open import LibraBFT.ImplShared.Util.Crypto                    public
 
-  record EpochState : Set where
-    constructor EpochState∙new
-    field
-      _esEpoch    : Epoch
-      _esVerifier : ValidatorVerifier
-  open EpochState public
-  unquoteDecl esEpoch   esVerifier = mkLens (quote EpochState)
-             (esEpoch ∷ esVerifier ∷ [])
-
   data NewRoundReason : Set where
     QCReady : NewRoundReason
     TOReady : NewRoundReason

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -53,9 +53,70 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   Instant : Set
   Instant = ℕ   -- TODO-2: should eventually be a time stamp
 
+  -- LBFT-OBM-DIFF: We do not have world state.  We just count the Epoch/Round as the version.
+  record Version : Set where
+    constructor mkVersion
+    field
+      _vVE : Epoch
+      _vVR : Round
+  open Version public
+  postulate instance enc-Version : Encoder Version
+
+  _≤-Version_ : Version → Version → Set
+  v1 ≤-Version v2 = _vVE v1 < _vVE v2
+                  ⊎ _vVE v1 ≡ _vVE v2 × _vVR v1 ≤ _vVR v2
+
+  _≤?-Version_ : (v1 v2 : Version) → Dec (v1 ≤-Version v2)
+  v1 ≤?-Version v2
+     with _vVE v1 <? _vVE v2
+  ...| yes prf = yes (inj₁ prf)
+  ...| no  ege
+     with _vVE v1 ≟ _vVE v2
+  ...| no  rneq = no (⊥-elim ∘ λ { (inj₁ x) → ege x
+                                 ; (inj₂ (x , _)) → rneq x })
+  ...| yes refl
+     with _vVR v1 ≤? _vVR v2
+  ...| yes rleq = yes (inj₂ (refl , rleq))
+  ...| no  rgt  = no (⊥-elim ∘ λ { (inj₁ x) → ege x
+                                 ; (inj₂ (_ , x)) → rgt x })
+
   -----------------
   -- Information --
   -----------------
+
+  record ValidatorConsensusInfo : Set where
+    constructor ValidatorConsensusInfo∙new
+    field
+     _vciPublicKey   : PK
+     _vciVotingPower : U64
+  open ValidatorConsensusInfo public
+  unquoteDecl vciPublicKey   vciVotingPower = mkLens (quote ValidatorConsensusInfo)
+             (vciPublicKey ∷ vciVotingPower ∷ [])
+
+  record ValidatorVerifier : Set where
+    constructor ValidatorVerifier∙new
+    field
+      _vvAddressToValidatorInfo : (KVMap AccountAddress ValidatorConsensusInfo)
+      _vvQuorumVotingPower      : ℕ  -- TODO-2: see above; for now, this is QuorumSize
+      -- :vvTotalVotingPower    : ℕ  -- TODO-2: see above; for now, this is number of peers in EpochConfig
+  open ValidatorVerifier public
+  unquoteDecl vvAddressToValidatorInfo   vvQuorumVotingPower = mkLens  (quote ValidatorVerifier)
+             (vvAddressToValidatorInfo ∷ vvQuorumVotingPower ∷ [])
+
+
+  record EpochState : Set where
+    constructor EpochState∙new
+    field
+      _esEpoch    : Epoch
+      _esVerifier : ValidatorVerifier
+  open EpochState public
+  unquoteDecl esEpoch   esVerifier = mkLens (quote EpochState)
+             (esEpoch ∷ esVerifier ∷ [])
+
+  postulate -- one valid assumption, one that can be proved using it
+    instance
+      Enc-EpochState   : Encoder EpochState
+      Enc-EpochStateMB : Encoder (Maybe EpochState)  -- TODO-1: make combinator to build this
 
   record BlockInfo : Set where
     constructor BlockInfo∙new
@@ -63,15 +124,27 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
       _biEpoch : Epoch
       _biRound : Round
       _biId    : HashValue
-      -- This has more fields...
+      _biExecutedStateId : HashValue -- aka liTransactionAccumulatorHash
+      _biVersion         : Version
+      --, _biTimestamp       :: Instant
+      _biNextEpochState  : Maybe EpochState
   open BlockInfo public
-  unquoteDecl biEpoch   biRound   biId = mkLens (quote BlockInfo)
-             (biEpoch ∷ biRound ∷ biId ∷ [])
+  unquoteDecl biEpoch   biRound   biId   biExecutedState   biVersion   biNextEpochState = mkLens (quote BlockInfo)
+             (biEpoch ∷ biRound ∷ biId ∷ biExecutedState ∷ biVersion ∷ biNextEpochState ∷ [])
   postulate instance enc-BlockInfo : Encoder BlockInfo
 
-  BlockInfo-η : ∀{e1 e2 r1 r2 i1 i2} → e1 ≡ e2 → r1 ≡ r2 → i1 ≡ i2
-              → BlockInfo∙new e1 r1 i1 ≡ BlockInfo∙new e2 r2 i2
-  BlockInfo-η refl refl refl = refl
+  postulate
+    _≟-BlockInfo_ : (bi1 bi2 : BlockInfo) → Dec (bi1 ≡ bi2)
+
+  instance
+    Eq-BlockInfo : Eq BlockInfo
+    Eq._≟_ Eq-BlockInfo = _≟-BlockInfo_
+
+  BlockInfo-η : ∀{e1 e2 r1 r2 i1 i2 x1 x2 v1 v2 n1 n2}
+              → e1 ≡ e2 → r1 ≡ r2 → i1 ≡ i2 → x1 ≡ x2 → v1 ≡ v2 → n1 ≡ n2
+              → BlockInfo∙new e1 r1 i1 x1 v1 n1 ≡ BlockInfo∙new e2 r2 i2 x2 v2 n2
+  BlockInfo-η refl refl refl refl refl refl = refl
+
 
   record LedgerInfo : Set where
     constructor LedgerInfo∙new
@@ -167,6 +240,10 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl qcVoteData   qcSignedLedgerInfo = mkLens (quote QuorumCert)
              (qcVoteData ∷ qcSignedLedgerInfo ∷ [])
   postulate instance enc-QuorumCert : Encoder QuorumCert
+
+  -- For some reason the Haskell code has inconistent names.  This lets us stay consistent with it.
+  qcLedgerInfo : Lens QuorumCert LedgerInfoWithSignatures
+  qcLedgerInfo = qcSignedLedgerInfo
 
   -- Because QuorumCert has an injective encoding (postulated, for now),
   -- we can use it to determine equality of QuorumCerts.
@@ -309,15 +386,23 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl brDeadline   brPreferredPeer = mkLens (quote BlockRetriever)
              (brDeadline ∷ brPreferredPeer ∷ [])
 
+  record AccumulatorExtensionProof : Set where
+    constructor AccumulatorExtensionProof∙new
+    field
+      _aepObmNumLeaves : Version
+  open AccumulatorExtensionProof public
+  unquoteDecl aepObmNumLeaves = mkLens (quote AccumulatorExtensionProof)
+             (aepObmNumLeaves ∷ [])
+
   record VoteProposal : Set where
     constructor VoteProposal∙new
     field
-      -- _vpAccumulatorExtensionProof : AccumulatorExtensionProof
+      _vpAccumulatorExtensionProof : AccumulatorExtensionProof
       _vpBlock : Block
-      -- _vpNextEpochState : Maybe EpochState
+      _vpNextEpochState : Maybe EpochState
   open VoteProposal public
-  unquoteDecl  vpBlock = mkLens (quote VoteProposal)
-              (vpBlock ∷ [])
+  unquoteDecl  vpAccumulatorExtensionProof   vpBlock   vpNextEpochState = mkLens (quote VoteProposal)
+              (vpAccumulatorExtensionProof ∷ vpBlock ∷ vpNextEpochState ∷ [])
 
   record MaybeSignedVoteProposal : Set where
     constructor MaybeSignedVoteProposal∙new
@@ -453,20 +538,28 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl pvLiDigestToVotes   pvMaybePartialTC   pvAuthorToVote = mkLens (quote PendingVotes)
              (pvLiDigestToVotes ∷ pvMaybePartialTC ∷ pvAuthorToVote ∷ [])
 
+  record StateComputeResult : Set where
+    constructor StateComputeResult∙new
+    field
+      _scrObmNumLeaves : Version
+      _scrEpochState   : Maybe EpochState
+  open StateComputeResult public
+  unquoteDecl scrObmNumLeaves   scrEpochState = mkLens (quote StateComputeResult)
+             (scrObmNumLeaves ∷ scrEpochState ∷ [])
+
   -- Note: this is a placeholder.
   -- We are not concerned for now with executing transactions, just ordering/committing them.
-  -- This is outdated (see comment at top).
-  data StateComputeResult : Set where
+  postulate
     stateComputeResult : StateComputeResult
 
   record ExecutedBlock : Set where
     constructor ExecutedBlock∙new
     field
-      _ebBlock  : Block
-      _ebOutput : StateComputeResult
+      _ebBlock              : Block
+      _ebStateComputeResult : StateComputeResult
   open ExecutedBlock public
-  unquoteDecl ebBlock   ebOutput = mkLens (quote ExecutedBlock)
-             (ebBlock ∷ ebOutput ∷ [])
+  unquoteDecl ebBlock   ebStateComputeResult = mkLens (quote ExecutedBlock)
+             (ebBlock ∷ ebStateComputeResult ∷ [])
 
   ebId : Lens ExecutedBlock HashValue
   ebId = ebBlock ∙ bId
@@ -551,15 +644,6 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
       _viConfig : ValidatorConfig
   open ValidatorInfo public
 
-  record ValidatorConsensusInfo : Set where
-    constructor ValidatorConsensusInfo∙new
-    field
-     _vciPublicKey   : PK
-     _vciVotingPower : U64
-  open ValidatorConsensusInfo public
-  unquoteDecl vciPublicKey   vciVotingPower = mkLens (quote ValidatorConsensusInfo)
-             (vciPublicKey ∷ vciVotingPower ∷ [])
-
   data ObmNotValidProposerReason : Set where
     ProposalDoesNotHaveAnAuthor ProposerForBlockIsNotValidForThisRound NotValidProposer : ObmNotValidProposerReason
 
@@ -570,16 +654,6 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
       -- :peObmLeaderOfRound : LeaderOfRoundFn
       -- :peObmNodesInORder  : NodesInOrder
   open ProposerElection
-
-  record ValidatorVerifier : Set where
-    constructor ValidatorVerifier∙new
-    field
-      _vvAddressToValidatorInfo : (KVMap AccountAddress ValidatorConsensusInfo)
-      _vvQuorumVotingPower      : ℕ  -- TODO-2: see above; for now, this is QuorumSize
-      -- :vvTotalVotingPower    : ℕ  -- TODO-2: see above; for now, this is number of peers in EpochConfig
-  open ValidatorVerifier public
-  unquoteDecl vvAddressToValidatorInfo   vvQuorumVotingPower = mkLens  (quote ValidatorVerifier)
-             (vvAddressToValidatorInfo ∷ vvQuorumVotingPower ∷ [])
 
   record SafetyRules : Set where
     constructor SafetyRules∙new

--- a/LibraBFT/ImplShared/Util/Crypto.agda
+++ b/LibraBFT/ImplShared/Util/Crypto.agda
@@ -30,7 +30,8 @@ module LibraBFT.ImplShared.Util.Crypto where
   open WithCryptoHash sha256 sha256-cr
 
   blockInfoBSList : BlockInfo → List ByteString
-  blockInfoBSList (BlockInfo∙new epoch round id) = encode epoch ∷ encode round ∷ encode id ∷ []
+  blockInfoBSList (BlockInfo∙new epoch round id execStId ver mes) =
+    encode epoch ∷ encode round ∷ encode id ∷ encode execStId ∷ encode ver ∷ encode mes ∷ []
 
   hashBI : BlockInfo → HashValue
   hashBI = sha256 ∘ bs-concat ∘ blockInfoBSList
@@ -41,7 +42,10 @@ module LibraBFT.ImplShared.Util.Crypto where
   ...| inj₂ res with bs-concat-inj (blockInfoBSList bi1) (blockInfoBSList bi2) res
   ...| final = inj₂ (BlockInfo-η (encode-inj (proj₁ (∷-injective final)))
                                  (encode-inj (proj₁ (∷-injective (proj₂ (∷-injective final)))))
-                                 (encode-inj (proj₁ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective final))))))))
+                                 (encode-inj (proj₁ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective final)))))))
+                                 (encode-inj (proj₁ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective final)))))))))
+                                 (encode-inj (proj₁ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective final)))))))))))
+                                 (encode-inj (proj₁ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective (proj₂ (∷-injective final))))))))))))))
 
   voteDataHashList : VoteData → List Hash
   voteDataHashList (VoteData∙new proposed parent) =

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -312,6 +312,12 @@ module LibraBFT.Prelude where
     (Left  a) → fa a
     (Right b) → fb b
 
+  open import Data.String as String
+    hiding (_==_ ; _≟_)
+
+  check : Bool → List String → Either String Unit
+  check b t = if b then inj₂ unit else inj₁ (String.intersperse "; " t)
+
   -- TODO-1: Maybe this belongs somewhere else?  It's in a similar
   -- category as Optics, so maybe should similarly be in a module that
   -- is separate from the main project?


### PR DESCRIPTION
Restated the contract for `verifyQcM`  to something that actually holds, and prove it and some related properties it depends on.  This required fleshing out various pieces of implementation.  Restating the contract for `verifyQcM` broke the proof for `continue1.contract`; it is commented out in this PR and is already proved in another branch building on `chris-roundmanager-proofs`.

Implementation pieces fleshed out:

* `LibraBFT.Impl.Consensus.ConsensusTypes.Block`
* `LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock`
* `LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert`
* `LibraBFT.Impl.Consensus.ConsensusTypes.VoteData`
* `LibraBFT.Impl.Execution.ExecutorTypes.StateComputeResult`
* `LibraBFT.ImplShared.Consensus.Types`
* `LibraBFT.ImplShared.Consensus.Types.EpochIndep`

Properties added/updated/proved:

* `LibraBFT.Impl.Consensus.ConsensusTypes.Properties.QuorumCert`
* `LibraBFT.Impl.Consensus.ConsensusTypes.Properties.VoteData`
* `LibraBFT.Impl.Types.Properties.LedgerInfoWithSignatures`
