### PR TITLE
make logging align with Haskell version

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -40,7 +40,7 @@ postulate
 replaceTimeoutCertM : TimeoutCertificate → LBFT Unit
 replaceTimeoutCertM tc = do
   lBlockStore ∙ bsInner ∙ btHighestTimeoutCert ?= tc
-  logInfo -- lTO (InfoUpdateHighestTimeoutCert (Just tc))
+  logInfo fakeInfo -- lTO (InfoUpdateHighestTimeoutCert (Just tc))
 
 ------------------------------------------------------------------------------
 
@@ -103,9 +103,9 @@ insertQuorumCertM : QuorumCert → LBFT Unit
 insertQuorumCertM qc = do
   bt ← use lBlockTree
   case insertQuorumCertE qc bt of λ where
-    (Left  e)   → logErr
+    (Left  e)   → logErr e
     (Right (bt' , info)) → do
-      forM_ info (const logInfo)
+      forM_ info logInfo
       lBlockTree ∙= bt'
 
 ------------------------------------------------------------------------------

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -43,10 +43,10 @@ insertQuorumCertM qc retriever = do
       bail e
     (Right NeedFetch) →
       fetchQuorumCertM qc retriever
-      ∙^∙ withErrCtxt
+      ∙^∙ withErrCtx ("" ∷ [])
     (Right QCBlockExist) →
-      BlockStore.insertSingleQuorumCertM qc ∙^∙ withErrCtxt ∙?∙ λ _ → do
-      use lBlockStore >>= const logInfo -- InfoBlockStoreShort (here [lsQC qc])
+      BlockStore.insertSingleQuorumCertM qc ∙^∙ withErrCtx ("" ∷ []) ∙?∙ λ _ → do
+      use lBlockStore >>= const (logInfo fakeInfo) -- InfoBlockStoreShort (here [lsQC qc])
       ok unit
     (Right _) →
       ok unit

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
@@ -37,8 +37,9 @@ verify self validator = do
              (here' ("Genesis QC should not carry signatures" ∷ []))
       )
     else do
-      -- TODO: withErrCtx'
-      (LedgerInfoWithSignatures.verifySignatures (self ^∙ qcLedgerInfo) validator)
+      withErrCtx'
+        ("fail to verify QuorumCert" ∷ [])
+        (LedgerInfoWithSignatures.verifySignatures (self ^∙ qcLedgerInfo) validator)
       VoteData.verify (self ^∙ qcVoteData)
  where
   here' : List String.String → List String.String

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -177,7 +177,7 @@ module processProposalMSpec (proposal : Block) where
          → executeAndVoteMSpec.Contract proposal pre r st outs
          → RWST-weakestPre-bindPost unit step₂ (Contract pre) r st outs
     pf (Left x) st outs (executeAndVoteMSpec.mkContract noOuts inv resultCorrect) .(Left x) refl =
-      mkContract (Left (mkNoOutsCorrect (++-NoMsgOuts outs (LogErr fakeErr ∷ []) noOuts refl) resultCorrect)) inv
+      mkContract (Left (mkNoOutsCorrect (++-NoMsgOuts outs (LogErr _ ∷ []) noOuts refl) resultCorrect)) inv
     pf (Right vote) st outs (executeAndVoteMSpec.mkContract noOuts inv resultCorrect) ._ refl ._ refl ._ refl =
       syncInfoMSpec.contract (st & rsVoteSent-rm ∙~ just vote)
         (RWST-weakestPre-bindPost unit (step₃ vote) (RWST-Post++ (Contract pre) outs))

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -266,7 +266,7 @@ module constructAndSignVoteMSpec where
                       let author = validatorSigner ^∙ vsAuthor
                           st₁    = pre & (lSafetyData ∙~ safetyData1) in
                       constructLedgerInfoMSpec.contract proposedBlock (hashVD voteData)
-                        (RWST-weakestPre-∙^∙Post unit withErrCtxt
+                        (RWST-weakestPre-∙^∙Post unit (withErrCtx ("" ∷ []))
                           (RWST-weakestPre-ebindPost unit (step₃ safetyData1 voteData author) (Contract pre epoch round)))
                         st₁
                         (λ where .(Left fakeErr) refl → bailAfterSetSafetyData r>lvr)
@@ -418,7 +418,7 @@ module constructAndSignVoteMSpec where
       Post : LBFT-Post (Either ErrLog Vote)
       Post x post outs =
         RWST-weakestPre-bindPost unit
-          (λ r → logInfo >> pure r) (Contract pre epoch round)
+          (λ r → logInfo fakeInfo >> pure r) (Contract pre epoch round)
           x post (LogInfo fakeInfo ∷ outs)
 
       pf : ∀ r st outs → Contract pre epoch round r st outs → Post r st outs

--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -29,8 +29,8 @@ handleProposal : Instant → ProposalMsg → LBFT Unit
 handleProposal now pm = do
   (myEpoch , vv) ← epvv
   caseM⊎ Network.processProposal {- {!!} -} pm myEpoch vv of λ where
-    (Left (Left _))  → logErr
-    (Left (Right _)) → logInfo
+    (Left (Left  e)) → logErr e
+    (Left (Right i)) → logInfo i
     (Right _)        → RoundManager.processProposalMsgM now pm
 
 handle : NodeId → NetworkMsg → Instant → LBFT Unit

--- a/LibraBFT/Impl/Types/LedgerInfoWithSignatures.agda
+++ b/LibraBFT/Impl/Types/LedgerInfoWithSignatures.agda
@@ -7,6 +7,7 @@
 open import LibraBFT.Base.KVMap                   as Map
 open import LibraBFT.Base.PKCS
 import      LibraBFT.Impl.OBM.Crypto              as Crypto
+open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.Impl.Types.ValidatorVerifier as ValidatorVerifier
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
@@ -23,8 +24,8 @@ addSignature validator sig liws =
       liws & liwsSignatures ∙~ Map.kvm-insert-Haskell validator sig (liws ^∙ liwsSignatures)
 
 verifySignatures : LedgerInfoWithSignatures → ValidatorVerifier → Either ErrLog Unit
-verifySignatures self validator = -- withErrCtx'
-  -- ["LedgerInfoWithSignatures", "verify"]
-  ValidatorVerifier.batchVerifyAggregatedSignatures
-     validator (self ^∙ liwsLedgerInfo) (self ^∙ liwsSignatures)
+verifySignatures self validator = withErrCtx'
+  ("LedgerInfoWithSignatures" ∷ "verify" ∷ [])
+  (ValidatorVerifier.batchVerifyAggregatedSignatures
+     validator (self ^∙ liwsLedgerInfo) (self ^∙ liwsSignatures))
 


### PR DESCRIPTION
- `logErr` and `logInfo`
  - take an arg (like Haskell)
- `withErrCtx`
  - renamed from `withErrCtxt` (to be like Haskell)
  - take an arg (like Haskell)
- `withErrCtx'`
  - implemented and used
- `logEE`
  - take an arg (like Haskell)

@cwjnkins please check the change in `RoundManager.Properties`