### PR TITLE
Fully connect `handle` in `InputOutputHandlers` to `RoundManager`

### DIFF
--- a/LibraBFT/Impl/Consensus/ConsensusTypes/ProposalMsg.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/ProposalMsg.agda
@@ -1,0 +1,17 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+open import LibraBFT.Base.Types
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.ConsensusTypes.ProposalMsg where
+
+
+postulate
+  verify : ProposalMsg → ValidatorVerifier → Either ErrLog Unit

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Vote.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Vote.agda
@@ -4,7 +4,7 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.PKCS hiding (verify)
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 open import Optics.All
@@ -14,6 +14,9 @@ module LibraBFT.Impl.Consensus.ConsensusTypes.Vote where
 newWithSignature : VoteData → Author → LedgerInfo → Signature → Vote
 newWithSignature voteData author ledgerInfo signature =
   Vote∙new voteData author ledgerInfo signature nothing
+
+postulate
+  verify : Vote → ValidatorVerifier → Either ErrLog Unit
 
 timeout : Vote → Timeout
 timeout v =

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/VoteMsg.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/VoteMsg.agda
@@ -7,7 +7,14 @@ open import LibraBFT.Base.Types
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote as Vote
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.VoteMsg where
+
+verify : VoteMsg → ValidatorVerifier → Either ErrLog Unit
+verify self validator = do
+-- lcheck (self ^∙ vmVote ∙ vEpoch == self ^∙ vmSyncInfo ∙ siEpoch)
+--        (here $ "VoteMsg has different epoch" ∷ lsSI (self ^∙ vmSyncInfo) ∷ [])
+  Vote.verify (self ^∙ vmVote) validator

--- a/LibraBFT/Impl/Consensus/Network.agda
+++ b/LibraBFT/Impl/Consensus/Network.agda
@@ -22,7 +22,7 @@ processProposal {- peerId -} proposal myEpoch vv =
     (Left e) → Left (Left e)
     (Right unit) →
       grd‖ proposal ^∙ pmProposal ∙ bEpoch == myEpoch ≔
-           return unit
+           pure unit
          -- TODO : push this onto a queue if epoch is in future (is this still relevant?)
          ‖ proposal ^∙ pmProposal ∙ bEpoch == myEpoch + 1 ≔
            Left (Right fakeInfo) -- proposal in new epoch arrived before my epoch change

--- a/LibraBFT/Impl/Consensus/Network.agda
+++ b/LibraBFT/Impl/Consensus/Network.agda
@@ -9,11 +9,28 @@ open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.NetworkMsg
 open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Impl.Consensus.ConsensusTypes.ProposalMsg as ProposalMsg
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Consensus.Network where
 
 postulate  -- TODO-1: implement this
-  processProposal : {- NodeId → -} ProposalMsg → Epoch → ValidatorVerifier → Either (Either ErrLog InfoLog) Unit
   processVote     : {- NodeId → -} VoteMsg     → Epoch → ValidatorVerifier → Either (Either ErrLog InfoLog) Unit
+
+processProposal : {- NodeId → -} ProposalMsg → Epoch → ValidatorVerifier → Either (Either ErrLog InfoLog) Unit
+processProposal {- peerId -} proposal myEpoch vv =
+  case pProposal of λ where
+    (Left e) → Left (Left e)
+    (Right unit) →
+      grd‖ proposal ^∙ pmProposal ∙ bEpoch == myEpoch ≔
+           return unit
+         -- TODO : push this onto a queue if epoch is in future (is this still relevant?)
+         ‖ proposal ^∙ pmProposal ∙ bEpoch == myEpoch + 1 ≔
+           Left (Right fakeInfo) -- proposal in new epoch arrived before my epoch change
+         ‖ otherwise≔
+           Left (Left fakeErr)   -- proposal for wrong epoch
+  where
+  pProposal = do
+    ProposalMsg.verify proposal vv
+    {- lcheck (proposal ^∙ pmProposal ∙ bAuthor == just peerId) -}

--- a/LibraBFT/Impl/Consensus/Network.agda
+++ b/LibraBFT/Impl/Consensus/Network.agda
@@ -15,4 +15,5 @@ open import Optics.All
 module LibraBFT.Impl.Consensus.Network where
 
 postulate  -- TODO-1: implement this
-  processProposal : {- NodeId → -} ProposalMsg → Epoch → ValidatorVerifier → (Either ErrLog InfoLog) ⊎ Unit
+  processProposal : {- NodeId → -} ProposalMsg → Epoch → ValidatorVerifier → Either (Either ErrLog InfoLog) Unit
+  processVote     : {- NodeId → -} VoteMsg     → Epoch → ValidatorVerifier → Either (Either ErrLog InfoLog) Unit

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -537,6 +537,8 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   vmParent : Lens VoteMsg BlockInfo
   vmParent = vmVote ∙ vVoteData ∙ vdParent
 
+  vmEpoch : Lens VoteMsg Epoch
+  vmEpoch = vmVote ∙ vEpoch
 
   -- This is a notification of a commit.  It may not be explicitly included in an implementation,
   -- but we need something to be able to express correctness conditions.  It will

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -537,6 +537,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   vmParent : Lens VoteMsg BlockInfo
   vmParent = vmVote ∙ vVoteData ∙ vdParent
 
+  -- IMPL-DIFF: getter-only in Haskell
   vmEpoch : Lens VoteMsg Epoch
   vmEpoch = vmVote ∙ vEpoch
 


### PR DESCRIPTION
This PR implements `processProposal` and `processVote` in `LibraBFT.Impl.Consensus.Network.agda` and removes the remaining hole in `LibraBFT.Impl.IO.OBM.InputOutputHandlers.agda`.