### PR TITLE
impl RoundManager processSyncInfoMsgM; processLocalTimeoutM

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -169,7 +169,7 @@ insertSingleQuorumCertE bs qc =
 insertTimeoutCertificateM : TimeoutCertificate → LBFT (Either ErrLog Unit)
 insertTimeoutCertificateM tc = do
   curTcRound ← maybeHsk {-(Round-} 0 {-)-} (_^∙ tcRound) <$> use (lBlockStore ∙ bsHighestTimeoutCert)
-  ifM tc ^∙ tcRound ≤?ℕ curTcRound
+  if-RWST tc ^∙ tcRound ≤?ℕ curTcRound
     then ok unit
     else
       PersistentLivenessStorage.saveHighestTimeoutCertM tc ∙^∙ withErrCtx ("" ∷ []) ∙?∙ λ _ → do

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -193,3 +193,4 @@ syncInfoM : LBFT SyncInfo
 syncInfoM =
   SyncInfo∙new <$> use (lBlockStore ∙ bsHighestQuorumCert)
                <*> use (lBlockStore ∙ bsHighestCommitCert)
+               <*> use (lBlockStore ∙ bsHighestTimeoutCert)

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -47,6 +47,7 @@ module syncInfoMSpec where
   syncInfo pre =
     SyncInfo∙new (pre ^∙ lBlockStore ∙ bsHighestQuorumCert)
                  (pre ^∙ lBlockStore ∙ bsHighestCommitCert)
+                 (pre ^∙ lBlockStore ∙ bsHighestTimeoutCert)
 
   contract : ∀ pre Post → (Post (syncInfo pre) pre []) → LBFT-weakestPre syncInfoM Post pre
-  contract pre Post pf ._ refl ._ refl ._ refl ._ refl = pf
+  contract pre Post pf ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl = pf

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -48,11 +48,11 @@ insertQuorumCertM qc retriever = do
     (Right _) →
       ok unit
   maybeS (bs ^∙ bsRoot) (bail fakeErr) $ λ bsr →
-    ifM (bsr ^∙ ebRound) <?ℕ (qc ^∙ qcCommitInfo ∙ biRound)
+    if-RWST (bsr ^∙ ebRound) <?ℕ (qc ^∙ qcCommitInfo ∙ biRound)
       then (do
         let finalityProof = qc ^∙ qcLedgerInfo
         BlockStore.commitM finalityProof ∙?∙ λ xx →
-          ifM qc ^∙ qcEndsEpoch
+          if-RWST qc ^∙ qcEndsEpoch
             then ok unit -- TODO-1 EPOCH CHANGE
             else ok unit)
       else

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Vote.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Vote.agda
@@ -17,6 +17,7 @@ newWithSignature voteData author ledgerInfo signature =
 
 postulate
   verify : Vote → ValidatorVerifier → Either ErrLog Unit
+  addTimeoutSignature : Vote → Signature → Vote
 
 timeout : Vote → Timeout
 timeout v =

--- a/LibraBFT/Impl/Consensus/Liveness/ProposalGenerator.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposalGenerator.agda
@@ -18,6 +18,9 @@ module LibraBFT.Impl.Consensus.Liveness.ProposalGenerator where
 
 ensureHighestQuorumCertM : Round → LBFT (Either ErrLog QuorumCert)
 
+postulate
+  generateNilBlockM : Round → LBFT (Either ErrLog Block)
+
 generateProposalM : Instant → Round → LBFT (Either ErrLog BlockData)
 generateProposalM _now round = do
   lrg ← use (lProposalGenerator ∙ pgLastRoundGenerated)

--- a/LibraBFT/Impl/Consensus/Liveness/ProposalGenerator.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposalGenerator.agda
@@ -24,11 +24,11 @@ postulate
 generateProposalM : Instant → Round → LBFT (Either ErrLog BlockData)
 generateProposalM _now round = do
   lrg ← use (lProposalGenerator ∙ pgLastRoundGenerated)
-  ifM lrg <?ℕ round
+  if-RWST lrg <?ℕ round
     then (do
       lProposalGenerator ∙ pgLastRoundGenerated ∙= round
       ensureHighestQuorumCertM round ∙?∙ λ hqc -> do
-        payload ← ifM BlockInfo.hasReconfiguration (hqc ^∙ qcCertifiedBlock)
+        payload ← if-RWST BlockInfo.hasReconfiguration (hqc ^∙ qcCertifiedBlock)
                       -- IMPL-DIFF : create a fake TX
                       then pure (Encode.encode 0) -- (Payload [])
                       else pure (Encode.encode 0) -- use pgTxnManager <*> use (rmEpochState ∙ esEpoch) <*> pure round

--- a/LibraBFT/Impl/Consensus/Liveness/ProposalGenerator.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposalGenerator.agda
@@ -32,8 +32,7 @@ generateProposalM _now round = do
                       -- IMPL-DIFF : create a fake TX
                       then pure (Encode.encode 0) -- (Payload [])
                       else pure (Encode.encode 0) -- use pgTxnManager <*> use (rmEpochState ∙ esEpoch) <*> pure round
-        s ← get
-        caseMM rmPgAuthor s of λ where
+        use (lRoundManager ∙ pgAuthor) >>= λ where
           nothing       → bail fakeErr -- ErrL (here ["lRoundManager.pgAuthor", "Nothing"])
           (just author) →
             ok (BlockData.newProposal payload author round {-pure blockTimestamp <*>-} hqc))

--- a/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
@@ -24,7 +24,7 @@ isValidProposalM b =
   maybeS-RWST (b ^∙ bAuthor) (bail ProposalDoesNotHaveAnAuthor) $ λ a → do
     -- IMPL-DIFF: `ifM` in Haskell means something else
     vp ← isValidProposerM a (b ^∙ bRound)
-    ifM vp
+    if-RWST vp
       then ok unit
       else bail ProposerForBlockIsNotValidForThisRound
 

--- a/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
@@ -23,6 +23,11 @@ module LibraBFT.Impl.Consensus.Liveness.RoundState where
 
 ------------------------------------------------------------------------------
 
+postulate
+  processLocalTimeoutM : Instant → Epoch → Round → LBFT Bool
+
+------------------------------------------------------------------------------
+
 processCertificatesM : Instant → SyncInfo → LBFT (Maybe NewRoundEvent)
 processCertificatesM now syncInfo = do
   rshcr <- use (lRoundState ∙ rsHighestCommittedRound)
@@ -43,6 +48,6 @@ insertVoteM vote verifier = do
 ------------------------------------------------------------------------------
 -- TODO-1: Implement this.
 -- > recordVote v = rsVoteSent ∙= just v
-recordVote : Vote → LBFT Unit
-recordVote v = rsVoteSent-rm ∙= just v
+recordVoteM : Vote → LBFT Unit
+recordVoteM v = rsVoteSent-rm ∙= just v
 

--- a/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
@@ -31,7 +31,7 @@ postulate
 processCertificatesM : Instant → SyncInfo → LBFT (Maybe NewRoundEvent)
 processCertificatesM now syncInfo = do
   rshcr <- use (lRoundState ∙ rsHighestCommittedRound)
-  ifM (syncInfo ^∙ siHighestCommitRound <? rshcr) -- TODO : define and use 'when'
+  if-RWST (syncInfo ^∙ siHighestCommitRound <? rshcr) -- TODO : define and use 'when'
     then pure unit -- IMPL-TODO ((lRoundState ∙ rsHighestCommittedRound) :=  (syncInfo ^∙ siHighestCommitRound))
     else pure unit
   pure nothing
@@ -41,7 +41,7 @@ processCertificatesM now syncInfo = do
 insertVoteM : Vote → ValidatorVerifier → LBFT VoteReceptionResult
 insertVoteM vote verifier = do
   currentRound ← use (lRoundState ∙ rsCurrentRound)
-  ifM vote ^∙ vVoteData ∙ vdProposed ∙ biRound == currentRound
+  if-RWST vote ^∙ vVoteData ∙ vdProposed ∙ biRound == currentRound
     then PendingVotes.insertVoteM vote verifier
     else pure (UnexpectedRound (vote ^∙ vVoteData ∙ vdProposed ∙ biRound) currentRound)
 

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -222,7 +222,7 @@ module processProposalMSpec (proposal : Block) where
               btInv₂ : StateInvariants.Preserves StateInvariants.BlockTreeInv st stUpdateRS
            -- btInv₂ = id
 
-            module _ (si : SyncInfo) (si≡ : si ≡ SyncInfo∙new (st ^∙ lBlockStore ∙ bsHighestQuorumCert) (st ^∙ lBlockStore ∙ bsHighestCommitCert)) where
+            module _ (si : SyncInfo) (si≡ : si ≡ SyncInfo∙new (st ^∙ lBlockStore ∙ bsHighestQuorumCert) (st ^∙ lBlockStore ∙ bsHighestCommitCert) (st ^∙ lBlockStore ∙ bsHighestTimeoutCert)) where
               contract-step₃ : RWST-weakestPre (step₃ vote si) (RWST-Post++ (Contract pre) outs) unit stUpdateRS
               contract-step₃ ._ refl ._ refl ._ refl ._ refl recipient@._ refl =
                 mkContract

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -77,7 +77,7 @@ verifyAndUpdatePreferredRoundM quorumCert safetyData = do
       twoChainRound  = quorumCert ^∙ qcParentBlock ∙ biRound
   -- LBFT-ALGO v3:p6: "... votes in round k only if the QC inside the k proposal
   -- is at least" PreferredRound."
-  ifM oneChainRound <? preferredRound
+  if-RWST oneChainRound <? preferredRound
     then bail fakeErr -- error: incorrect preferred round, QC round does not match preferred round
     else do
       updated ← case (compare twoChainRound preferredRound) of λ where
@@ -101,7 +101,7 @@ verifyAuthorM author = do
       author
       (bail fakeErr) -- (ErrL (here' ["InvalidProposal", "No author found in the proposal"])))
       (\a ->
-        ifM validatorSigner ^∙ vsAuthor /= a
+        if-RWST validatorSigner ^∙ vsAuthor /= a
         then bail fakeErr -- (ErrL (here' ["InvalidProposal", "Proposal author is not validator signer"]))
         else ok unit)
  where
@@ -112,7 +112,7 @@ verifyAuthorM author = do
 
 verifyEpochM : Epoch → SafetyData → LBFT (Either ErrLog Unit)
 verifyEpochM epoch safetyData =
-  ifM epoch /= safetyData ^∙ sdEpoch
+  if-RWST epoch /= safetyData ^∙ sdEpoch
     then bail fakeErr -- incorrect epoch
     else ok unit
 
@@ -122,7 +122,7 @@ verifyEpochM epoch safetyData =
 verifyAndUpdateLastVoteRoundM : Round → SafetyData → LBFT (Either ErrLog SafetyData)
 verifyAndUpdateLastVoteRoundM round safetyData =
   -- LBFT-ALGO v3:p6 : "... votes in round k it if is higher than" LastVotedRound
-  ifM round >? (safetyData ^∙ sdLastVotedRound)
+  if-RWST round >? (safetyData ^∙ sdLastVotedRound)
     then ok (safetyData & sdLastVotedRound ∙~ round )
     else bail fakeErr -- incorrect last vote round
 
@@ -160,7 +160,7 @@ module constructAndSignVoteM-continue0 (voteProposal : VoteProposal) (validatorS
   step₁ safetyData0 = do
       caseMM (safetyData0 ^∙ sdLastVote) of λ where
         (just vote) →
-          ifM vote ^∙ vVoteData ∙ vdProposed ∙ biRound == proposedBlock ^∙ bRound
+          if-RWST vote ^∙ vVoteData ∙ vdProposed ∙ biRound == proposedBlock ^∙ bRound
             then ok vote
             else constructAndSignVoteM-continue1 voteProposal validatorSigner proposedBlock safetyData0
         nothing → constructAndSignVoteM-continue1 voteProposal validatorSigner proposedBlock safetyData0
@@ -230,7 +230,7 @@ signProposalM blockData = do
   safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
   verifyAuthorM (blockData ^∙ bdAuthor) ∙?∙ λ _ →
     verifyEpochM (blockData ^∙ bdEpoch) safetyData ∙?∙ λ _ →
-      ifM blockData ^∙ bdRound ≤?ℕ safetyData ^∙ sdLastVotedRound
+      if-RWST blockData ^∙ bdRound ≤?ℕ safetyData ^∙ sdLastVotedRound
       then bail fakeErr
       -- {-     ErrL (here' [ "InvalidProposal"
       --                    , "Proposed round is not higher than last voted round "

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -245,3 +245,7 @@ signProposalM blockData = do
   here' : List String.String → List String.String
   here' t = "SafetyRules" ∷ "signProposalM" ∷ t
 
+------------------------------------------------------------------------------
+
+postulate
+  signTimeoutM : Timeout → LBFT (Either ErrLog Signature)

--- a/LibraBFT/Impl/Consensus/Types/PendingVotes.agda
+++ b/LibraBFT/Impl/Consensus/Types/PendingVotes.agda
@@ -24,7 +24,7 @@ insertVoteM vote vv = do
   atv          ← use (lPendingVotes ∙ pvAuthorToVote)
   case Map.lookup (vote ^∙ vAuthor) atv of λ where
     (just previouslySeenVote) →
-      ifM liDigest ≟Hash (hashLI (previouslySeenVote ^∙ vLedgerInfo))
+      if-RWST liDigest ≟Hash (hashLI (previouslySeenVote ^∙ vLedgerInfo))
       then (do
         let newTimeoutVote = Vote.isTimeout vote ∧ not (Vote.isTimeout previouslySeenVote)
         if not newTimeoutVote

--- a/LibraBFT/ImplFake/Consensus/RoundManager.agda
+++ b/LibraBFT/ImplFake/Consensus/RoundManager.agda
@@ -59,7 +59,7 @@ processProposalMsg inst pm = do
                   nothing
       sv = record uv { _vSignature = sign ⦃ sig-Vote ⦄ uv fakeSK}
       bt = rm ^∙ lBlockTree
-      si = SyncInfo∙new (_btHighestQuorumCert bt) (_btHighestCommitCert bt)
+      si = SyncInfo∙new (_btHighestQuorumCert bt) (_btHighestCommitCert bt) (_btHighestTimeoutCert bt)
       rm' = rm & rmLastVotedRound ∙~ nr
   put rm'
   tell1 (SendVote (VoteMsg∙new sv si) (fakeAuthor ∷ []))

--- a/LibraBFT/ImplFake/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/ImplFake/Consensus/RoundManager/Properties.agda
@@ -33,11 +33,14 @@ module LibraBFT.ImplFake.Consensus.RoundManager.Properties where
   rmHighestCommitQC : Lens RoundManager QuorumCert
   rmHighestCommitQC = lBlockStore ∙ bsInner ∙ btHighestCommitCert
 
+  rmHighestTimeoutCert : Lens RoundManager (Maybe TimeoutCertificate)
+  rmHighestTimeoutCert = lBlockStore ∙ bsInner ∙ btHighestTimeoutCert
+
   -- The quorum certificates sent in SyncInfo with votes are those from the peer state.
   -- This is no longer used because matching m∈outs parameters to here refl eliminated the need for
   -- it, at least for our simple handler.  I'm keeping it, though, as it may be needed in future
   -- when the real handler will be much more complicated and this proof may no longer be trivial.
   procPMCerts≡ : ∀ {ts pm pre vm αs}
                → (SendVote vm αs) ∈ LBFT-outs (processProposalMsg ts pm) pre
-               → vm ^∙ vmSyncInfo ≡ SyncInfo∙new (pre ^∙ rmHighestQC) (pre ^∙ rmHighestCommitQC)
+               → vm ^∙ vmSyncInfo ≡ SyncInfo∙new (pre ^∙ rmHighestQC) (pre ^∙ rmHighestCommitQC) (pre ^∙ rmHighestTimeoutCert)
   procPMCerts≡ (here refl) = refl

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -80,13 +80,17 @@ module LibraBFT.ImplShared.Consensus.Types where
              (rmEpochState ∷ rmBlockStore ∷ rmRoundState ∷ rmProposerElection ∷
               rmProposalGenerator ∷ rmSafetyRules ∷ rmSyncOnly ∷ [])
 
-  rmObmAllAuthors : RoundManager → List Author
-  rmObmAllAuthors rm =
-    List-map proj₁ (kvm-toList (rm ^∙ rmEpochState ∙ esVerifier ∙ vvAddressToValidatorInfo))
+  -- IMPL-DIFF: this is RoundManager field/lens in Haskell; and it is implemented completely different
+  rmObmAllAuthors : Lens RoundManager (List Author)
+  rmObmAllAuthors = mkLens'
+    (λ rm → List-map proj₁ (kvm-toList (rm ^∙ rmEpochState ∙ esVerifier ∙ vvAddressToValidatorInfo)))
+    (λ rm _ → rm) -- TODO-1 cannot be written
 
+  -- getter only in Haskell
   rmEpoch : Lens RoundManager Epoch
   rmEpoch = rmEpochState ∙ esEpoch
 
+  -- not defined in Haskell
   rmLastVotedRound : Lens RoundManager Round
   rmLastVotedRound = rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdLastVotedRound
 
@@ -99,11 +103,9 @@ module LibraBFT.ImplShared.Consensus.Types where
   lRoundState : Lens RoundManager RoundState
   lRoundState = rmRoundState
 
+  -- not defined in Haskell
   rsVoteSent-rm : Lens RoundManager (Maybe Vote)
   rsVoteSent-rm = lRoundState ∙ rsVoteSent
-
-  lSyncOnly : Lens RoundManager Bool
-  lSyncOnly = rmSyncOnly
 
   lPendingVotes : Lens RoundManager PendingVotes
   lPendingVotes = rmRoundState ∙ rsPendingVotes
@@ -114,6 +116,7 @@ module LibraBFT.ImplShared.Consensus.Types where
   lPersistentSafetyStorage : Lens RoundManager PersistentSafetyStorage
   lPersistentSafetyStorage = lSafetyRules ∙ srPersistentStorage
 
+  -- TODO-1 : this is named/used pssSafetyData in Haskell in SET situations
   lSafetyData : Lens RoundManager SafetyData
   lSafetyData = lPersistentSafetyStorage ∙ pssSafetyData
 
@@ -123,25 +126,21 @@ module LibraBFT.ImplShared.Consensus.Types where
   lBlockTree : Lens RoundManager BlockTree
   lBlockTree = lBlockStore ∙ bsInner
 
-  -- This is a trivial lens, which is used in the Haskell code, so we keep it here for consistency.
   lRoundManager : Lens RoundManager RoundManager
   lRoundManager = lens (λ _ _ f rm → f rm)
 
+  -- getter only in Haskell
   srValidatorVerifier : Lens RoundManager ValidatorVerifier
   srValidatorVerifier = rmEpochState ∙ esVerifier
 
-
--- In some cases, the getting operation is not dependent but a lens still
-  -- cannot be defined because the *setting* operation would require dependent
-  -- types. Below, `rmGetValidatorVerifier` is an example of this situation, and
-  -- we would "use" it like this
-  --
-  --    vv ← gets rmGetValidatorVerifier
-
-  -- IMPL-DIFF : this is defined as a lens getter only (no setter) in Haskell.
-  rmPgAuthor : RoundManager → Maybe Author
-  rmPgAuthor rm =
-    maybeS (rm ^∙ rmSafetyRules ∙ srValidatorSigner) nothing (just ∘ (_^∙ vsAuthor))
+  -- getter only in Haskell
+  pgAuthor : Lens RoundManager (Maybe Author)
+  pgAuthor = mkLens' g s
+    where
+    g : RoundManager → Maybe Author
+    g rm = maybeS (rm ^∙ rmSafetyRules ∙ srValidatorSigner) nothing (just ∘ (_^∙ vsAuthor))
+    s : RoundManager → Maybe Author → RoundManager
+    s rm _ma = rm -- TODO-1 cannot be written
 
   record GenesisInfo : Set where
     constructor mkGenInfo

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -242,29 +242,33 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
              (vVoteData ∷ vAuthor ∷ vLedgerInfo ∷ vSignature ∷ vTimeoutSignature ∷ [])
   postulate instance enc-Vote     : Encoder Vote
 
+  -- not defined in Haskell
   vParent : Lens Vote BlockInfo
   vParent = vVoteData ∙ vdParent
 
+  -- not defined in Haskell
   vProposed : Lens Vote BlockInfo
   vProposed = vVoteData ∙ vdProposed
 
+  -- not defined in Haskell
   vParentId : Lens Vote Hash
   vParentId = vVoteData ∙ vdParent ∙ biId
 
+  -- not defined in Haskell
   vParentRound : Lens Vote Round
   vParentRound = vVoteData ∙ vdParent ∙ biRound
 
+  -- not defined in Haskell
   vProposedId : Lens Vote Hash
   vProposedId = vVoteData ∙ vdProposed ∙ biId
 
+  -- getter only in Haskell
   vEpoch : Lens Vote Epoch
   vEpoch = vVoteData ∙ vdProposed ∙ biEpoch
 
-  vdRound : Lens VoteData Round
-  vdRound = vdProposed ∙ biRound
-
+  -- getter only in Haskell
   vRound : Lens Vote Round
-  vRound = vVoteData ∙ vdRound
+  vRound = vVoteData ∙ vdProposed ∙ biRound
 
   record QuorumCert : Set where
     constructor QuorumCert∙new
@@ -284,20 +288,23 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   _QCBoolEq_ : QuorumCert → QuorumCert → Bool
   _QCBoolEq_ q1 q2 = does (q1 ≟QC q2)
 
+  -- getter only in Haskell
   qcCertifiedBlock : Lens QuorumCert BlockInfo
   qcCertifiedBlock = qcVoteData ∙ vdProposed
 
+  -- getter only in Haskell
   qcParentBlock : Lens QuorumCert BlockInfo
   qcParentBlock = qcVoteData ∙ vdParent
 
-  -- This is a GETTER only in Haskell
+  -- getter only in Haskell
   qcLedgerInfo : Lens QuorumCert LedgerInfoWithSignatures
   qcLedgerInfo = qcSignedLedgerInfo
 
+  -- getter only in Haskell
   qcCommitInfo : Lens QuorumCert BlockInfo
   qcCommitInfo = qcSignedLedgerInfo ∙ liwsLedgerInfo ∙ liCommitInfo
 
-  -- GETTER only in Haskell
+  -- getter only in Haskell
   qcEndsEpoch : Lens QuorumCert Bool
   qcEndsEpoch = mkLens' g s
    where
@@ -329,9 +336,11 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   qcVotes : QuorumCert → List (Author × Signature)
   qcVotes qc = kvm-toList (qcVotesKV qc)
 
+  -- not defined in Haskell
   qcCertifies : Lens QuorumCert  Hash
   qcCertifies = qcVoteData ∙ vdProposed ∙ biId
 
+  -- not defined in Haskell
   qcRound : Lens QuorumCert Round
   qcRound = qcVoteData ∙ vdProposed ∙ biRound
 
@@ -385,13 +394,16 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
              (bdEpoch ∷ bdRound ∷ bdQuorumCert ∷ bdBlockType ∷ [])
   postulate instance enc-BlockData : Encoder BlockData
 
+  -- not defined in Haskell
   bdParentId : Lens BlockData Hash
   bdParentId = bdQuorumCert ∙ qcVoteData ∙ vdParent ∙ biId
 
+  -- not defined in Haskell
   -- This is the id of a block
   bdBlockId : Lens BlockData Hash
   bdBlockId = bdQuorumCert ∙ qcVoteData ∙ vdProposed ∙ biId
 
+  -- getter only in Haskell
   bdAuthor : Lens BlockData (Maybe Author)
   bdAuthor = mkLens' g s
     where
@@ -426,20 +438,25 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
 
   postulate instance enc : Encoder Block
 
-  bQuorumCert : Lens Block QuorumCert
-  bQuorumCert  = bBlockData ∙ bdQuorumCert
-
-  bRound : Lens Block Round
-  bRound =  bBlockData ∙ bdRound
-
+  -- getter only in Haskell
   bAuthor : Lens Block (Maybe Author)
   bAuthor = bBlockData ∙ bdAuthor
 
+  -- getter only in Haskell
+  bEpoch : Lens Block Epoch
+  bEpoch = bBlockData ∙ bdEpoch
+
+  -- getter only in Haskell
+  bQuorumCert : Lens Block QuorumCert
+  bQuorumCert  = bBlockData ∙ bdQuorumCert
+
+  -- getter only in Haskell
   bParentId : Lens Block HashValue
   bParentId = bQuorumCert ∙ qcCertifiedBlock ∙ biId
 
-  bEpoch : Lens Block Epoch
-  bEpoch = bBlockData ∙ bdEpoch
+  -- getter only in Haskell
+  bRound : Lens Block Round
+  bRound =  bBlockData ∙ bdRound
 
   record BlockRetriever : Set where
     constructor BlockRetriever∙new
@@ -498,11 +515,11 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   TimeoutCertificate∙new : Timeout → TimeoutCertificate
   TimeoutCertificate∙new to = mkTimeoutCertificate to Map.empty
 
-  -- IMPL-DIFF : only a getter in haskell
+  -- getter only in haskell
   tcEpoch : Lens TimeoutCertificate Epoch
   tcEpoch = tcTimeout ∙ toEpoch
 
-  -- IMPL-DIFF : only a getter in haskell
+  -- getter only in haskell
   tcRound : Lens TimeoutCertificate Round
   tcRound = tcTimeout ∙ toRound
 
@@ -571,6 +588,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
              (pmProposal ∷ pmSyncInfo ∷ [])
   postulate instance enc-ProposalMsg : Encoder ProposalMsg
 
+  -- getter only in Haskell
   pmProposer : Lens ProposalMsg (Maybe Author)
   pmProposer = pmProposal ∙ bAuthor
 
@@ -584,13 +602,15 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
              (vmVote ∷ vmSyncInfo ∷ [])
   postulate instance enc-VoteMsg : Encoder VoteMsg
 
+  -- not defined in Haskell
   vmProposed : Lens VoteMsg BlockInfo
   vmProposed = vmVote ∙ vVoteData ∙ vdProposed
 
+  -- not defined in Haskell
   vmParent : Lens VoteMsg BlockInfo
   vmParent = vmVote ∙ vVoteData ∙ vdParent
 
-  -- IMPL-DIFF: getter-only in Haskell
+  -- getter-only in Haskell
   vmEpoch : Lens VoteMsg Epoch
   vmEpoch = vmVote ∙ vEpoch
 
@@ -651,15 +671,19 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl ebBlock   ebStateComputeResult = mkLens (quote ExecutedBlock)
              (ebBlock ∷ ebStateComputeResult ∷ [])
 
+  -- getter only in Haskell
   ebId : Lens ExecutedBlock HashValue
   ebId = ebBlock ∙ bId
 
+  -- getter only in Haskell
   ebQuorumCert : Lens ExecutedBlock QuorumCert
   ebQuorumCert = ebBlock ∙ bQuorumCert
 
+  -- getter only in Haskell
   ebParentId : Lens ExecutedBlock HashValue
   ebParentId = ebQuorumCert ∙ qcCertifiedBlock ∙ biId
 
+  -- getter only in Haskell
   ebRound : Lens ExecutedBlock Round
   ebRound = ebBlock ∙ bRound
 
@@ -674,6 +698,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl lbExecutedBlock = mkLens (quote LinkableBlock)
              (lbExecutedBlock ∷ [])
 
+  -- getter only in Haskell
   lbId : Lens LinkableBlock HashValue
   lbId = lbExecutedBlock ∙ ebId
 
@@ -810,7 +835,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   btGetBlock : HashValue → BlockTree → Maybe ExecutedBlock
   btGetBlock hv bt = (_^∙ lbExecutedBlock) <$> btGetLinkableBlock hv bt
 
-  -- IMPL-DIFF : this is a getter only in Haskell
+  -- getter only in Haskell
   btRoot : Lens BlockTree (Maybe ExecutedBlock)
   btRoot = mkLens' g s
     where
@@ -823,7 +848,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     s : BlockTree → Maybe ExecutedBlock → BlockTree
     s bt _ = bt -- TODO-1 : cannot be done: need a way to defined only getters
 
-  -- GETTER ONLY in haskell
+  -- getter only in haskell
   btHighestCertifiedBlock : Lens BlockTree (Maybe ExecutedBlock)
   btHighestCertifiedBlock = mkLens' g s
     where
@@ -843,19 +868,19 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl bsInner = mkLens (quote BlockStore)
              (bsInner ∷ [])
 
-  -- IMPL-DIFF : this is a getter only in Haskell
+  -- getter only in Haskell
   bsRoot : Lens BlockStore (Maybe ExecutedBlock)
   bsRoot = bsInner ∙ btRoot
 
-  -- IMPL-DIFF : this is a getter only in Haskell
-  bsHighestCommitCert : Lens BlockStore QuorumCert
-  bsHighestCommitCert = bsInner ∙ btHighestCommitCert
-
-  -- IMPL-DIFF : this is a getter only in Haskell
+  -- getter only in Haskell
   bsHighestQuorumCert : Lens BlockStore QuorumCert
   bsHighestQuorumCert = bsInner ∙ btHighestQuorumCert
 
-  -- IMPL-DIFF : this is a getter only in Haskell
+  -- getter only in Haskell
+  bsHighestCommitCert : Lens BlockStore QuorumCert
+  bsHighestCommitCert = bsInner ∙ btHighestCommitCert
+
+  -- getter only in Haskell
   bsHighestTimeoutCert : Lens BlockStore (Maybe TimeoutCertificate)
   bsHighestTimeoutCert = bsInner ∙ btHighestTimeoutCert
 

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -535,9 +535,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
 
   -- getter only in Haskell
   siHighestCertifiedRound : Lens SyncInfo Round
-  siHighestCertifiedRound =
-    mkLens' (_^∙ siHighestQuorumCert ∙ qcCertifiedBlock ∙ biRound)
-            (λ x _r → x) -- TODO-1
+  siHighestCertifiedRound = siHighestQuorumCert ∙ qcCertifiedBlock ∙ biRound
 
   -- getter only in Haskell
   siHighestTimeoutRound : Lens SyncInfo Round

--- a/LibraBFT/ImplShared/Util/Crypto.agda
+++ b/LibraBFT/ImplShared/Util/Crypto.agda
@@ -30,8 +30,11 @@ module LibraBFT.ImplShared.Util.Crypto where
   open WithCryptoHash sha256 sha256-cr
 
   -- IMPL-DIFF
-  -- 1. cannot do "qcParts" because bs-concat does returns BitString
-  -- 2. no need to deal with a 'Proposal' for stable test hashes
+  -- 1. Cannot do equivalent of Haskell "qcParts"
+  --    because bs-concat here cannot be used because it returns BitString.
+  --    TODO-2 : Hashing in Haskell includes adding tags.
+  --             Need to model those tags and to postulate injectivity properties.
+  -- 2. No need to deal with a 'Proposal' for stable test hashes.
   hashBD : BlockData → HashValue
   hashBD = sha256 ∘ bs-concat ∘ blockDataBSList
    where

--- a/LibraBFT/ImplShared/Util/RWST/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/RWST/Syntax.agda
@@ -54,16 +54,17 @@ infix 1 ifM‖_
 ifM‖_ : Guards (RWST Ev Wr St A) → RWST Ev Wr St A
 ifM‖_ = RWST-if
 
-infix 0 ifM_then_else_
-ifM_then_else_ : ⦃ _ : ToBool B ⦄ → B → (c₁ c₂ : RWST Ev Wr St A) → RWST Ev Wr St A
-ifM b then c₁ else c₂ =
+infix 0 if-RWST_then_else_
+if-RWST_then_else_ : ⦃ _ : ToBool B ⦄ → B → (c₁ c₂ : RWST Ev Wr St A) → RWST Ev Wr St A
+if-RWST b then c₁ else c₂ =
   ifM‖ b ≔ c₁
      ‖ otherwise≔ c₂
 
-ifMHask : ⦃ _ : ToBool B ⦄ → RWST Ev Wr St B → (c₁ c₂ : RWST Ev Wr St A) → RWST Ev Wr St A
-ifMHask mb c₁ c₂ = do
+-- This is like the Haskell version, except Haskell's works for any monad (not just RWST).
+ifM : ⦃ _ : ToBool B ⦄ → RWST Ev Wr St B → (c₁ c₂ : RWST Ev Wr St A) → RWST Ev Wr St A
+ifM mb c₁ c₂ = do
   x ← mb
-  ifM x then c₁ else c₂
+  if-RWST x then c₁ else c₂
 
 infix 0 caseM⊎_of_ caseMM_of_
 caseM⊎_of_ : Either B C → (Either B C → RWST Ev Wr St A) → RWST Ev Wr St A
@@ -73,7 +74,7 @@ caseMM_of_ : Maybe B → (Maybe B → RWST Ev Wr St A) → RWST Ev Wr St A
 caseMM m of f = RWST-maybe m (f nothing) (f ∘ just)
 
 when : ∀ {ℓ} {B : Set ℓ} ⦃ _ : ToBool B ⦄ → B → RWST Ev Wr St Unit → RWST Ev Wr St Unit
-when b f = ifM toBool b then f else pure unit
+when b f = if-RWST toBool b then f else pure unit
 
 -- Composition with error monad
 ok : A → RWST Ev Wr St (B ⊎ A)

--- a/LibraBFT/ImplShared/Util/RWST/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/RWST/Syntax.agda
@@ -60,6 +60,12 @@ ifM b then c₁ else c₂ =
   ifM‖ b ≔ c₁
      ‖ otherwise≔ c₂
 
+ifMHask : ⦃ _ : ToBool B ⦄ → RWST Ev Wr St B → (c₁ c₂ : RWST Ev Wr St A) → RWST Ev Wr St A
+ifMHask mb c₁ c₂ =
+  mb >>= λ x → case toBool x of λ where
+                                   true  → c₁
+                                   false → c₂
+
 infix 0 caseM⊎_of_ caseMM_of_
 caseM⊎_of_ : Either B C → (Either B C → RWST Ev Wr St A) → RWST Ev Wr St A
 caseM⊎ e of f = RWST-either e (f ∘ Left) (f ∘ Right)

--- a/LibraBFT/ImplShared/Util/RWST/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/RWST/Syntax.agda
@@ -61,10 +61,9 @@ ifM b then c₁ else c₂ =
      ‖ otherwise≔ c₂
 
 ifMHask : ⦃ _ : ToBool B ⦄ → RWST Ev Wr St B → (c₁ c₂ : RWST Ev Wr St A) → RWST Ev Wr St A
-ifMHask mb c₁ c₂ =
-  mb >>= λ x → case toBool x of λ where
-                                   true  → c₁
-                                   false → c₂
+ifMHask mb c₁ c₂ = do
+  x ← mb
+  ifM x then c₁ else c₂
 
 infix 0 caseM⊎_of_ caseMM_of_
 caseM⊎_of_ : Either B C → (Either B C → RWST Ev Wr St A) → RWST Ev Wr St A


### PR DESCRIPTION
main work:

- RoundManager
  - implement processSyncInfoMsgM
  - implement processLocalTimeoutM

required for above:

- EpochIndep
  - rearrange Timeout/TimeoutCertificate so defined before used
  - add SyncInfo._siHighestTimeoutCert field
  - add various lens related to that field
- BlockStore.syncInfoM
  - add bsHighestTimeoutCert to SyncInfo.new
- Properties/BlockStore
  - add bsHighestTimeoutCert to SyncInfo.new
  - update contract *****
- Vote
  postulate addTimeoutSignature
- ProposalGenerator
  - postulate generateNilBlockM
- RoundState
  - postulate processLocalTimeoutM
  - rename recordVote to recordVoteM
- RoundManager/Properties.agda
  - add bsHighestTimeoutCert
- SafetyRules
  - postulate signTimeoutM
- ImplFake/Consensus/RoundManager
  - deal with btHighestTimeoutCert
- ImplFake/Consensus/RoundManager/Properties
  - deal with btHighestTimeoutCert
