### PR TITLE
Fixes to `LibraBFT.Impl.Properties.Util.agda`

### DIFF
--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -166,7 +166,7 @@ module processProposalMSpec (proposal : Block) where
        -- General properties / invariants
       rmInv         : StateInvariants.Preserves StateInvariants.RoundManagerInv pre post
       noEpochChange : StateTransProps.NoEpochChange pre post
-      noBroadcasts  : OutputProps.NoBroadcasts outs
+      NoProposals  : OutputProps.NoProposals outs
       -- Voting
       voteAttemptCorrect : Voting.VoteAttemptCorrect pre post outs proposal
 
@@ -190,7 +190,7 @@ module processProposalMSpec (proposal : Block) where
     contractBail : ∀ {outs} → OutputProps.NoMsgs outs → Contract pre unit pre outs
     contractBail{outs} nmo =
       mkContract StateInvariants.reflPreservesRoundManagerInv (StateTransProps.reflNoEpochChange{pre})
-        (OutputProps.NoMsgs⇒NoBroadcasts outs nmo)
+        (OutputProps.NoMsgs⇒NoProposals outs nmo)
         (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs nmo))
 
     contract-step₂ : RWST-weakestPre (executeAndVoteM proposal >>= step₂) (Contract pre) unit pre
@@ -208,7 +208,7 @@ module processProposalMSpec (proposal : Block) where
           pf : (r : Either ErrLog Vote) (vrc : EAV.VoteResultCorrect pre st lvr≡? r) → RWST-weakestPre-bindPost unit step₂ (Contract pre) r st outs
           pf (Left _) vrc ._ refl =
             mkContract rmInv₂ noEpochChange
-              (OutputProps.++-NoBroadcasts outs _ (OutputProps.NoMsgs⇒NoBroadcasts outs noMsgOuts) refl)
+              (OutputProps.++-NoProposals outs _ (OutputProps.NoMsgs⇒NoProposals outs noMsgOuts) refl)
               (inj₁ (lvr≡? , Voting.mkVoteUnsentCorrect
                                (OutputProps.++-NoVotes outs _ (OutputProps.NoMsgs⇒NoVotes outs noMsgOuts) refl) vrc))
           pf (Right vote) vrc ._ refl ._ refl ._ refl =
@@ -229,7 +229,7 @@ module processProposalMSpec (proposal : Block) where
                   (StateInvariants.transPreservesRoundManagerInv rmInv₂
                     (StateInvariants.mkPreservesRoundManagerInv id btInv₂ id))
                   (StateTransProps.transNoEpochChange{i = pre}{j = st}{k = stUpdateRS} noEpochChange refl)
-                  (OutputProps.++-NoBroadcasts outs _ (OutputProps.NoMsgs⇒NoBroadcasts outs noMsgOuts) refl)
+                  (OutputProps.++-NoProposals outs _ (OutputProps.NoMsgs⇒NoProposals outs noMsgOuts) refl)
                   (inj₂ (Voting.mkVoteSentCorrect vm recipient
                           (OutputProps.++-NoVotes-OneVote outs _ (OutputProps.NoMsgs⇒NoVotes outs noMsgOuts) refl)
                           (Voting.step-VoteGeneratedCorrect-VoteNotGenerated{s₂ = st}
@@ -346,7 +346,7 @@ module processProposalMsgMSpec
             processProposalMSpec.contract (pm ^∙ pmProposal) st (RWST-Post++ (Contract pre) outs) pf-step₃
             where
             pf-step₃ : RWST-Post-⇒ _ (RWST-Post++ (Contract pre) outs)
-            pf-step₃ unit st' outs' (processProposalMSpec.mkContract rmInv' noEpochChange' noBroadcasts' voteAttemptCorrect') =
+            pf-step₃ unit st' outs' (processProposalMSpec.mkContract rmInv' noEpochChange' NoProposals' voteAttemptCorrect') =
               mkContract
                 (StateInvariants.transPreservesRoundManagerInv rmInv rmInv')
                 (StateTransProps.transNoEpochChange{i = pre}{j = st}{k = st'} noEpochChange noEpochChange')

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -33,13 +33,13 @@ module OutputProps where
     NoneOfKind : ∀ {ℓ} {P : Output → Set ℓ} (p : (out : Output) → Dec (P out)) → Set
     NoneOfKind p = List-filter p outs ≡ []
 
-    NoVotes      = NoneOfKind isSendVote?
-    NoBroadcasts = NoneOfKind isBroadcastProposal?
-    NoSyncInfo   = NoneOfKind isBroadcastSyncInfo?
-    NoMsgs       = NoneOfKind isOutputMsg?
-    NoErrors     = NoneOfKind isLogErr?
+    NoVotes     = NoneOfKind isSendVote?
+    NoProposals = NoneOfKind isBroadcastProposal?
+    NoSyncInfos = NoneOfKind isBroadcastSyncInfo?
+    NoMsgs      = NoneOfKind isOutputMsg?
+    NoErrors    = NoneOfKind isLogErr?
 
-    NoMsgs⇒× : NoMsgs → NoBroadcasts × NoVotes × NoSyncInfo
+    NoMsgs⇒× : NoMsgs → NoProposals × NoVotes × NoSyncInfos
     proj₁ (NoMsgs⇒× noMsgs) =
       filter-∪?-[]₁ outs isBroadcastProposal? _
         (filter-∪?-[]₁ outs _ _ noMsgs)
@@ -49,8 +49,8 @@ module OutputProps where
       filter-∪?-[]₂ outs _ isBroadcastSyncInfo?
         (filter-∪?-[]₁ outs _ _ noMsgs)
 
-    NoMsgs⇒NoBroadcasts : NoMsgs → NoBroadcasts
-    NoMsgs⇒NoBroadcasts = proj₁ ∘ NoMsgs⇒×
+    NoMsgs⇒NoProposals : NoMsgs → NoProposals
+    NoMsgs⇒NoProposals = proj₁ ∘ NoMsgs⇒×
 
     NoMsgs⇒NoVotes : NoMsgs → NoVotes
     NoMsgs⇒NoVotes = proj₁ ∘ proj₂ ∘ NoMsgs⇒×
@@ -62,9 +62,9 @@ module OutputProps where
                   → NoneOfKind xs p → NoneOfKind ys p → NoneOfKind (xs ++ ys) p
   ++-NoneOfKind xs ys p nok₁ nok₂ = filter-++-[] xs ys p nok₁ nok₂
 
-  ++-NoMsgs       = λ xs ys → ++-NoneOfKind xs ys isOutputMsg?
-  ++-NoVotes      = λ xs ys → ++-NoneOfKind xs ys isSendVote?
-  ++-NoBroadcasts = λ xs ys → ++-NoneOfKind xs ys isBroadcastProposal?
+  ++-NoMsgs      = λ xs ys → ++-NoneOfKind xs ys isOutputMsg?
+  ++-NoVotes     = λ xs ys → ++-NoneOfKind xs ys isSendVote?
+  ++-NoProposals = λ xs ys → ++-NoneOfKind xs ys isBroadcastProposal?
 
   ++-NoVotes-OneVote : ∀ xs ys {vm} {pids} → NoVotes xs → OneVote ys vm pids
                        → OneVote (xs ++ ys) vm pids

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -35,17 +35,25 @@ module OutputProps where
 
     NoVotes      = NoneOfKind isSendVote?
     NoBroadcasts = NoneOfKind isBroadcastProposal?
+    NoSyncInfo   = NoneOfKind isBroadcastSyncInfo?
     NoMsgs       = NoneOfKind isOutputMsg?
     NoErrors     = NoneOfKind isLogErr?
 
-    NoMsgs⇒× : NoMsgs → NoBroadcasts × NoVotes
-    NoMsgs⇒× noMsgs
-      rewrite filter-∪?-[]₁ outs isBroadcastProposal? isSendVote? noMsgs
-      |       filter-∪?-[]₂ outs isBroadcastProposal? isSendVote? noMsgs
-      = refl , refl
+    NoMsgs⇒× : NoMsgs → NoBroadcasts × NoVotes × NoSyncInfo
+    proj₁ (NoMsgs⇒× noMsgs) =
+      filter-∪?-[]₁ outs isBroadcastProposal? _
+        (filter-∪?-[]₁ outs _ _ noMsgs)
+    proj₁ (proj₂ (NoMsgs⇒× noMsgs)) =
+      filter-∪?-[]₂ outs _ isSendVote? noMsgs
+    proj₂ (proj₂ (NoMsgs⇒× noMsgs)) =
+      filter-∪?-[]₂ outs _ isBroadcastSyncInfo?
+        (filter-∪?-[]₁ outs _ _ noMsgs)
 
+    NoMsgs⇒NoBroadcasts : NoMsgs → NoBroadcasts
     NoMsgs⇒NoBroadcasts = proj₁ ∘ NoMsgs⇒×
-    NoMsgs⇒NoVotes      = proj₂ ∘ NoMsgs⇒×
+
+    NoMsgs⇒NoVotes : NoMsgs → NoVotes
+    NoMsgs⇒NoVotes = proj₁ ∘ proj₂ ∘ NoMsgs⇒×
 
     OneVote : VoteMsg → List Author → Set
     OneVote vm pids = List-filter isSendVote? outs ≡ (SendVote vm pids ∷ [])


### PR DESCRIPTION
The PR fixes a few definitions and lemmas concerning properties of peer handler outputs that arose when adding sync info messages.