### PR TITLE
Add `OutputQc∈RoundManager` to `handleProposalSpec.Contract`, use it to prove one of the `qcVoteSigsSentB4` cases

### DIFF
--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -194,7 +194,7 @@ module processProposalMSpec (proposal : Block) where
     contractBail{outs} nmo =
       mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
         (OutputProps.NoMsgs⇒NoProposals outs nmo)
-        (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs nmo))
+        (Voting.voteAttemptBailed outs nmo)
 
     contract-step₂ : RWST-weakestPre (executeAndVoteM proposal >>= step₂) (Contract pre) unit pre
     contract-step₂ =
@@ -213,7 +213,7 @@ module processProposalMSpec (proposal : Block) where
             mkContract rmInv₂ noEpochChange
               (OutputProps.++-NoProposals outs _ (OutputProps.NoMsgs⇒NoProposals outs noMsgOuts) refl)
               (inj₁ (lvr≡? , Voting.mkVoteUnsentCorrect
-                               (OutputProps.++-NoVotes outs _ (OutputProps.NoMsgs⇒NoVotes outs noMsgOuts) refl) vrc))
+                               (OutputProps.++-NoMsgs outs _ noMsgOuts refl) vrc))
           pf (Right vote) vrc ._ refl ._ refl ._ refl =
             syncInfoMSpec.contract (st & rsVoteSent-rm ?~ vote)
               (RWST-weakestPre-bindPost unit (step₃ vote) (RWST-Post++ (Contract pre) outs))
@@ -327,10 +327,10 @@ module processProposalMsgMSpec
   contract' : ∀ pre → LBFT-weakestPre (processProposalMsgM now pm) (Contract pre) pre
   contract' pre rewrite processProposalMsgM≡ = contract
     where
-    contractBail : ∀ outs → OutputProps.NoVotes outs → Contract pre unit pre outs
-    contractBail outs nvo =
+    contractBail : ∀ outs → OutputProps.NoMsgs outs → Contract pre unit pre outs
+    contractBail outs nmo =
       mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
-        (Voting.voteAttemptBailed outs nvo)
+        (Voting.voteAttemptBailed outs nmo)
 
     contract : LBFT-weakestPre step₀ (Contract pre) pre
     proj₁ contract ≡nothing = contractBail _ refl
@@ -350,7 +350,7 @@ module processProposalMsgMSpec
           contractBailAfterSync outs' noMsgsOuts' =
             mkContract rmInv noEpochChange
               (inj₁ (true , Voting.mkVoteUnsentCorrect
-                              (OutputProps.++-NoVotes outs _ (OutputProps.NoMsgs⇒NoVotes outs noMsgOuts) (OutputProps.NoMsgs⇒NoVotes outs' noMsgsOuts'))
+                              (OutputProps.++-NoMsgs outs _ noMsgOuts noMsgsOuts')
                               (inj₁ noVote)))
 
           pf : (r : Either ErrLog Bool) → RWST-weakestPre-bindPost unit step₂ (Contract pre) r st outs

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -47,6 +47,8 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
       noEpochChange      : NoEpochChange pre post
       -- Voting
       voteAttemptCorrect : Voting.VoteAttemptCorrectWithEpochReq pre post outs (pm ^∙ pmProposal)
+      -- Signatures sent
+      outQcs∈RM          : QC.OutputQc∈RoundManager outs pre -- could also be post, see which is more convenient
 
   contract : ∀ pre → LBFT-weakestPre (handleProposal now pm) (Contract pre) pre
   contract pre =
@@ -58,6 +60,7 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
     contractBail outs noVotes =
       mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
         (Voting.mkVoteAttemptCorrectWithEpochReq (Voting.voteAttemptBailed outs noVotes) tt)
+        obm-dangerous-magic! -- TODO-2: prove it, ...
 
     contract-step₁ : _
     proj₁ (contract-step₁ (myEpoch@._ , vv@._) refl) (inj₁ e)  pp≡Left =
@@ -79,6 +82,7 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
         mkContract rmInv noEpochChange
           (Voting.mkVoteAttemptCorrectWithEpochReq voteAttemptCorrect
             (Voting.voteAttemptEpochReq! voteAttemptCorrect sdEpoch≡))
+          obm-dangerous-magic! -- TODO-2: prove it, ...
 
   contract! : ∀ pre → LBFT-Post-True (Contract pre) (handleProposal now pm) pre
   contract! pre = LBFT-contract (handleProposal now pm) (Contract pre) pre (contract pre)

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -56,10 +56,10 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
       (RWST-weakestPre-bindPost unit (λ where (myEpoch , vv) → step₁ myEpoch vv) (Contract pre))
       contract-step₁
     where
-    contractBail : ∀ outs → OutputProps.NoVotes outs → Contract pre unit pre outs
-    contractBail outs noVotes =
+    contractBail : ∀ outs → OutputProps.NoMsgs outs → Contract pre unit pre outs
+    contractBail outs noMsgs =
       mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
-        (Voting.mkVoteAttemptCorrectWithEpochReq (Voting.voteAttemptBailed outs noVotes) tt)
+        (Voting.mkVoteAttemptCorrectWithEpochReq (Voting.voteAttemptBailed outs noMsgs) tt)
         obm-dangerous-magic! -- TODO-2: prove it, ...
 
     contract-step₁ : _

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -420,6 +420,11 @@ module Voting where
       voteAttempt : VoteAttemptCorrect pre post outs block
       sdEpoch≡?   : VoteAttemptEpochReq voteAttempt
 
+  sentVote⇒VoteCorrect : ∀ {pre post outs block}
+                       → VoteAttemptCorrectWithEpochReq pre post outs block
+                       → VoteSentCorrect                pre post outs block
+  sentVote⇒VoteCorrect = obm-dangerous-magic! -- TODO - prove it
+
 module QC where
 
   data _∈RoundManager_ (qc : QuorumCert) (rm : RoundManager) : Set where

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -425,17 +425,16 @@ module QC where
   data _∈RoundManager_ (qc : QuorumCert) (rm : RoundManager) : Set where
     inHQC : qc ≡ rm ^∙ lBlockStore ∙ bsInner ∙ btHighestQuorumCert → qc ∈RoundManager rm
     inHCC : qc ≡ rm ^∙ lBlockStore ∙ bsInner ∙ btHighestCommitCert → qc ∈RoundManager rm
- -- NOTE: When `need/fetch` is implemented, we will need an additional
- -- constructor for sent qcs taken from the blockstore.
+    -- NOTE: When `need/fetch` is implemented, we will need an additional
+    -- constructor for sent qcs taken from the blockstore.
 
   data _NM∈Out_ : NetworkMsg → Output → Set where
     inBP : ∀ {pm pids} → P pm NM∈Out BroadcastProposal pm pids
     inSV : ∀ {vm pids} → V vm NM∈Out SendVote vm pids
 
-  OutputQcSi∈RoundManagerSi : List Output → RoundManager → Set
-  OutputQcSi∈RoundManagerSi outs rm =
+  OutputQc∈RoundManager : List Output → RoundManager → Set
+  OutputQc∈RoundManager outs rm =
     All (λ out → ∀ qc nm → qc QC∈NM nm → nm NM∈Out out → qc ∈RoundManager rm) outs
-
 
   SigForVote∈Qc∈Rm-SentB4 : Vote → PK → QuorumCert → RoundManager → SentMessages → Set
   SigForVote∈Qc∈Rm-SentB4 v pk qc rm pool =

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -424,7 +424,9 @@ module Voting where
                        → send m ∈ outputsToActions {pre} outs
                        → VoteAttemptCorrectWithEpochReq pre post outs block
                        → VoteSentCorrect                pre post outs block
-  sentVote⇒VoteCorrect = obm-dangerous-magic! -- TODO - prove it
+  sentVote⇒VoteCorrect {pre} {outs = outs} {m = m} m∈acts (mkVoteAttemptCorrectWithEpochReq (Left (_ , mkVoteUnsentCorrect noMsgOuts _)) _) =
+    ⊥-elim (sendMsg∉actions {outs} {m} {pre} (sym noMsgOuts) m∈acts)
+  sentVote⇒VoteCorrect m∈acts (mkVoteAttemptCorrectWithEpochReq (Right vsc) _) = vsc
 
 module QC where
 

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -420,7 +420,8 @@ module Voting where
       voteAttempt : VoteAttemptCorrect pre post outs block
       sdEpoch≡?   : VoteAttemptEpochReq voteAttempt
 
-  sentVote⇒VoteCorrect : ∀ {pre post outs block}
+  sentVote⇒VoteCorrect : ∀ {pre post outs block m}
+                       → send m ∈ outputsToActions {pre} outs
                        → VoteAttemptCorrectWithEpochReq pre post outs block
                        → VoteSentCorrect                pre post outs block
   sentVote⇒VoteCorrect = obm-dangerous-magic! -- TODO - prove it

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -54,7 +54,7 @@ newVote⇒lv≡
     → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
     → LastVoteIs s' v
 -- We are handling a proposal message, we may send a Vote message, containing
-newVote⇒lv≡ {pre} {pid} {s'} {v = v}{m}{pk} preach (step-msg{sndr , P pm} m∈pool ini) (vote∈qc {vs} {qc} vs∈qc v≈rbld qc∈m) m∈acts sig hpk ¬gen ¬msb4 =
+newVote⇒lv≡ {pre} {pid} {s'} {v = v}{m}{pk} preach (step-msg{sndr , P pm} _ ini) (vote∈qc {vs} {qc} vs∈qc v≈rbld qc∈m) m∈acts sig hpk ¬gen ¬msb4 =
     ⊥-elim (¬msb4 sigSentB4)
     where hpPre = peerStates pre pid
           handleOuts = LBFT-outs (handle pid (P pm) 0) (peerStates pre pid)
@@ -87,7 +87,7 @@ newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vot
 
   ¬voteUnsent : ¬ Voting.VoteUnsentCorrect (peerStates pre pid) _ _ _ _
   ¬voteUnsent (Voting.mkVoteUnsentCorrect noVoteMsgOuts _) =
-    sendVote∉actions{outs = handleOuts}{st = peerStates pre pid}
+    sendMsg∉actions{outs = handleOuts}{st = peerStates pre pid}
       (sym noVoteMsgOuts) m∈outs
 ...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect (VoteMsg∙new v' _) rcvr voteMsgOuts vgCorrect)) sdEpoch≡?) _ =
   sentVoteIsPostLV
@@ -276,7 +276,7 @@ sameERasLV⇒sameId{pid = .pid“}{pid'}{pk} (step-s{pre = pre} preach step@(ste
   ret
     with voteAttemptCorrect
   ...| Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts _)) _ =
-    ⊥-elim (sendVote∉actions{outs = hpOuts}{st = hpPre} (sym noVoteMsgOuts) m∈outs)
+    ⊥-elim (sendMsg∉actions{outs = hpOuts}{st = hpPre} (sym noVoteMsgOuts) m∈outs)
   ...| Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid voteMsgOuts vgCorrect)) _
     with vgCorrect
   ...| Voting.mkVoteGeneratedCorrect (StateTransProps.mkVoteGenerated lv≡v _) _ = cong (_^∙ vProposedId) v≡v'
@@ -456,7 +456,7 @@ votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr
 votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈outs sig ¬gen ¬msb pcspkv v'⊂m' m'∈pool sig' ¬gen' eid≡
   with handleProposalSpec.contract! 0 pm (peerStates pre pid)
 ...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?) _ =
-  ⊥-elim (sendVote∉actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym noVoteMsgOuts) m∈outs)
+  ⊥-elim (sendMsg∉actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym noVoteMsgOuts) m∈outs)
 ...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?) _
   with sendVote∈actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym voteMsgOuts) m∈outs
 ...| refl = ret
@@ -559,8 +559,8 @@ votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v
   v≡v' : v ≡ v'
   v≡v'
     with voteAttemptCorrect
-  ...| Voting.mkVoteAttemptCorrectWithEpochReq (Left (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts _)) _ =
-    ⊥-elim (sendVote∉actions{outs = hpOut}{st = hpPre} (sym noVoteMsgOuts) m∈outs)
+  ...| Voting.mkVoteAttemptCorrectWithEpochReq (Left (_ , Voting.mkVoteUnsentCorrect noMsgOuts _)) _ =
+    ⊥-elim (sendMsg∉actions{outs = hpOut}{st = hpPre} (sym noMsgOuts) m∈outs)
   ...| Voting.mkVoteAttemptCorrectWithEpochReq (Right (Voting.mkVoteSentCorrect vm pid voteMsgOuts _)) _ = begin
     v            ≡⟨        cong (_^∙ vmVote) (sendVote∈actions{outs = hpOut}{st = hpPre} (sym voteMsgOuts) m∈outs) ⟩
     vm ^∙ vmVote ≡⟨ (sym $ cong (_^∙ vmVote) (sendVote∈actions{outs = hpOut}{st = hpPre} (sym voteMsgOuts) m'∈outs)) ⟩

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -62,7 +62,7 @@ newVote⇒lv≡ {s' = s'} {v = v}{m} preach (step-msg{sndr , m'} m∈pool ini) (
 
 newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vote∈vm m∈outs sig hpk ¬gen ¬msb4
   with handleProposalSpec.contract! 0 pm (peerStates pre pid)
-...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , voteUnsent)) sdEpoch≡?) =
+...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , voteUnsent)) sdEpoch≡?) _ =
   ⊥-elim (¬voteUnsent voteUnsent)
   where
   handleOuts = LBFT-outs (handle pid (P pm) 0) (peerStates pre pid)
@@ -71,7 +71,7 @@ newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vot
   ¬voteUnsent (Voting.mkVoteUnsentCorrect noVoteMsgOuts _) =
     sendVote∉actions{outs = handleOuts}{st = peerStates pre pid}
       (sym noVoteMsgOuts) m∈outs
-...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect (VoteMsg∙new v' _) rcvr voteMsgOuts vgCorrect)) sdEpoch≡?) =
+...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect (VoteMsg∙new v' _) rcvr voteMsgOuts vgCorrect)) sdEpoch≡?) _ =
   sentVoteIsPostLV
   where
   handlePost = LBFT-post (handle pid (P pm) 0) (peerStates pre pid)
@@ -437,9 +437,9 @@ votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr
     TODO : v' [ _<_ ]L v at vRound ⊎ Common.VoteForRound∈ InitAndHandlers 𝓔 pk (v ^∙ vRound) (v ^∙ vEpoch) (v ^∙ vProposedId) (msgPool pre)
 votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈outs sig ¬gen ¬msb pcspkv v'⊂m' m'∈pool sig' ¬gen' eid≡
   with handleProposalSpec.contract! 0 pm (peerStates pre pid)
-...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?) =
+...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?) _ =
   ⊥-elim (sendVote∉actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym noVoteMsgOuts) m∈outs)
-...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?)
+...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?) _
   with sendVote∈actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym voteMsgOuts) m∈outs
 ...| refl = ret
   where

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -74,8 +74,8 @@ newVote⇒lv≡ {pre} {pid} {s'} {v = v}{m}{pk} preach (step-msg{sndr , P pm} m�
           sigSentB4 : MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
           sigSentB4 rewrite cong _vSignature v≈rbld = qcVoteSigsSentB4 preach ini qc∈rm vs∈qc ¬gen
 
-newVote⇒lv≡ {s' = s'} {v = v}{m} preach (step-msg{sndr , V vm} m∈pool ini) (vote∈qc vs∈qc v≈rbld qc∈m) m∈outs sig hpk ¬gen ¬msb4 = {!!}
-newVote⇒lv≡ {s' = s'} {v = v}{m} preach (step-msg{sndr , C cm} m∈pool ini) (vote∈qc vs∈qc v≈rbld qc∈m) m∈outs sig hpk ¬gen ¬msb4 = {!!}
+newVote⇒lv≡ {s' = s'} {v = v}{m} preach (step-msg{sndr , V vm} m∈pool ini) (vote∈qc vs∈qc v≈rbld qc∈m) m∈outs sig hpk ¬gen ¬msb4 = obm-dangerous-magic! -- Should be similar to above case
+newVote⇒lv≡ {s' = s'} {v = v}{m} preach (step-msg{sndr , C cm} m∈pool ini) (vote∈qc vs∈qc v≈rbld qc∈m) m∈outs sig hpk ¬gen ¬msb4 = obm-dangerous-magic! -- Should be similar to above case
 
 
 newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vote∈vm m∈outs sig hpk ¬gen ¬msb4

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -63,7 +63,7 @@ newVote⇒lv≡ {pre} {pid} {s'} {v = v}{m}{pk} preach (step-msg{sndr , P pm} m�
           qc∈rm
              with handleProposalSpec.contract! 0 pm (peerStates pre pid)
           ...| handleProposalSpec.mkContract _ _ vsc qc∈rmProp
-             with Voting.sentVote⇒VoteCorrect vsc
+             with Voting.sentVote⇒VoteCorrect m∈acts vsc
           ... | Voting.mkVoteSentCorrect vm pid voteMsgOuts vgCorrect
              with List-∈-filter⁻ isOutputMsg? {v = SendVote vm (pid ∷ [])} {xs = handleOuts}
                                  (subst (SendVote vm (pid ∷ []) ∈_) (sym voteMsgOuts) (here refl))

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -93,6 +93,10 @@ module LibraBFT.Prelude where
     using (_∈_; _∉_)
     public
 
+  open import Data.List.Membership.Propositional.Properties
+    renaming (∈-filter⁻ to List-∈-filter⁻)
+    public
+
   open import Data.Vec
     using (Vec; []; _∷_)
     renaming (replicate to Vec-replicate; lookup to Vec-lookup

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -226,6 +226,19 @@ module LibraBFT.Prelude where
   open import Data.Product.Properties
     public
 
+
+  module _ {ℓ : Level} {A : Set} where
+    NoneOfKind : ∀ {P : A → Set ℓ} → List A → (p : (a : A) → Dec (P a)) → Set
+    NoneOfKind xs p = List-filter p xs ≡ []
+
+    postulate -- TODO-1: Replace with or prove using library properties?  Move to Lemmas?
+      NoneOfKind⇒ : ∀ {P : A → Set ℓ} {Q : A → Set ℓ} {xs : List A}
+                  → (p : (a : A) → Dec (P a))
+                  → {q : (a : A) → Dec (Q a)}
+                  → (∀ {a} → P a → Q a)  -- TODO-1: Use proper notation (Relation.Unary?)
+                  → NoneOfKind xs q
+                  → NoneOfKind xs p
+
   infix 4 _<?ℕ_
   _<?ℕ_ : Decidable _<_
   m <?ℕ n = suc m ≤?ℕ n


### PR DESCRIPTION
Here is some progress on extending the `handleProposalSpec.Contract` to ensure `OutputQc∈RoundManager`, and then use it together with `qcVoteSigsSentB4` to prove one of the `TODO`s in `VotesOnce`.  It required generalising various properties.  I've left some postulates, `obm-dangerous-magic!`, etc., but I think they should all be provable.