### PR TITLE
Revert changes to RoundManager output contracts introduced in PR #94

### DIFF
--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -56,11 +56,14 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
       (RWST-weakestPre-bindPost unit (λ where (myEpoch , vv) → step₁ myEpoch vv) (Contract pre))
       contract-step₁
     where
-    contractBail : ∀ outs → OutputProps.NoMsgs outs → Contract pre unit pre outs
-    contractBail outs noMsgs =
+    contractBail : ∀ outs → OutputProps.NoVotes outs → Contract pre unit pre outs
+    contractBail outs noVotes =
       mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
-        (Voting.mkVoteAttemptCorrectWithEpochReq (Voting.voteAttemptBailed outs noMsgs) tt)
-        obm-dangerous-magic! -- TODO-2: prove it, ...
+        (Voting.mkVoteAttemptCorrectWithEpochReq (Voting.voteAttemptBailed outs noVotes) tt)
+        outqcs∈pre
+      where
+      postulate -- TODO-1: Prove this (waiting on: updates to RoundManager contracts)
+        outqcs∈pre : QC.OutputQc∈RoundManager outs pre
 
     contract-step₁ : _
     proj₁ (contract-step₁ (myEpoch@._ , vv@._) refl) (inj₁ e)  pp≡Left =


### PR DESCRIPTION
As I mentioned in PR #94, it will not be true of the final implementation that `ensureRoundAndSyncUpM` sends not output messages. I have reverted these contract changes, and many of the accompanying changes to lemmas in `LibraBFT.Impl.Properties.Util.agda` I have also repaired and simplified the case of `newVote⇒lv≡` in `LibraBFT.Impl.Properties.VotesOnce.agda` proved in PR #94 .