### PR TITLE
Progress on proving that round manager QC votes have had their signatures sent before

### DIFF
--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -46,41 +46,42 @@ module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
   initRM-correct : RoundManager-correct initRM
+  initRM-qcs     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM -- TODO-1: This is not true (the definition of the predicate needs updating).
   initRM-btInv   : BlockStoreInv initRM
 
-initRMSatisfiesInv : RoundManagerInvariants.RoundManagerInv initRM
+initRMSatisfiesInv : RoundManagerInvariants.RoundManagerInv [] initRM
 initRMSatisfiesInv =
-  RoundManagerInvariants.mkRoundManagerInv initRM-correct refl initRM-btInv
+  RoundManagerInvariants.mkRoundManagerInv initRM-correct initRM-qcs refl initRM-btInv
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
 
 invariantsCorrect
   : ∀ pid (pre : SystemState)
-    → ReachableSystemState pre → RoundManagerInv (peerStates pre pid)
+    → ReachableSystemState pre → RoundManagerInv (msgPool pre) (peerStates pre pid)
 invariantsCorrect pid pre@._ step-0 = initRMSatisfiesInv
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-cheat{pid'} cheatMsgConstraint)))
   rewrite cheatStepDNMPeerStates₁{pid'}{pid}{pre = pre'} step unit
-  = invariantsCorrect pid pre' preach
+  = {!!} -- invariantsCorrect pid pre' preach
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-honest{pid'} sps)))
   with pid ≟ pid'
 ...| no pid≢pid'
   rewrite sym (pids≢StepDNMPeerStates{pre = pre'} sps pid≢pid')
-  = invariantsCorrect pid pre' preach
+  = {!!} -- invariantsCorrect pid pre' preach
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-init ini)))) | yes refl
   rewrite override-target-≡{a = pid}{b = initRM}{f = peerStates pre'}
-  = initRMSatisfiesInv
+  = {!!} --initRMSatisfiesInv
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , P pm} m∈pool ini)))) | yes refl
   with handleProposalSpec.contract!-RoundManagerInv 0 pm (msgPool pre') (peerStates pre' pid) (handleProposalRequirements preach m∈pool ini)
 ... | invPres
   rewrite override-target-≡{a = pid}{b = LBFT-post (handleProposal 0 pm) (peerStates pre' pid)}{f = peerStates pre'}
-  = invPres (invariantsCorrect pid pre' preach)
+  = {!!} -- invPres (invariantsCorrect pid pre' preach)
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , V x} m∈pool ini)))) | yes refl = TODO
   where
   postulate -- TODO-3: prove (waiting on: `handle`)
-    TODO : RoundManagerInv (peerStates pre pid)
+    TODO : {!!} -- RoundManagerInv (peerStates pre pid)
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , C x} m∈pool ini)))) | yes refl = TODO
   where
   postulate -- TODO-3: prove (waiting on: `handle`)
-    TODO : RoundManagerInv (peerStates pre pid)
+    TODO : RoundManagerInv (msgPool pre) (peerStates pre pid)
 
 lastVotedRound-mono
   : ∀ pid (pre : SystemState) {ppost} {msgs}

--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -55,7 +55,11 @@ module handleVote (now : Instant) (vm : VoteMsg) where
       (Left (Right i)) → logInfo i
       (Right _)        → RoundManager.processVoteMsgM now vm
 
-handleVote = handleVote.step₀
+abstract
+  handleVote = handleVote.step₀
+
+  handleVote≡ : handleVote ≡ handleVote.step₀
+  handleVote≡ = refl
 
 handle : NodeId → NetworkMsg → Instant → LBFT Unit
 handle _self msg now =

--- a/LibraBFT/Impl/Properties/Common.agda
+++ b/LibraBFT/Impl/Properties/Common.agda
@@ -271,7 +271,7 @@ module ReachableSystemStateProps where
       → s' ^∙ rmEpoch ≡ v ^∙ vEpoch
       → peerStates st pid ^∙ rmEpoch ≡ v ^∙ vEpoch
   mws∈pool⇒epoch≡ rss (step-init uni) pcsfpk hpk sig ¬gen mws∈pool epoch≡ =
-    case uninitd ≡ initd ∋ trans (sym uni) ini of λ ()
+    absurd (uninitd ≡ initd) case (trans (sym uni) ini) of λ ()
     where
     ini = mws∈pool⇒initd rss pcsfpk hpk sig ¬gen mws∈pool
   mws∈pool⇒epoch≡{pid}{v}{st = st} rss (step-msg{_ , P pm} m∈pool ini) pcsfpk hpk sig ¬gen mws∈pool epoch≡ = begin

--- a/LibraBFT/Impl/Properties/Common.agda
+++ b/LibraBFT/Impl/Properties/Common.agda
@@ -75,7 +75,7 @@ postulate
     : ∀ {pid qc vs}{st : SystemState}
       → ReachableSystemState st
       → initialised st pid ≡ uninitd
-      → qc QC.∈RoundManager (peerStates st pid)
+      → qc QCProps.∈RoundManager (peerStates st pid)
       → vs ∈ qcVotes qc
       → ∈GenInfo-impl genesisInfo (proj₂ vs)
 
@@ -90,7 +90,7 @@ qcVoteSigsSentB4
   : ∀ {pid qc vs pk}{st : SystemState}
     → ReachableSystemState st
     → initialised st pid ≡ initd
-    → qc QC.∈RoundManager (peerStates st pid)
+    → qc QCProps.∈RoundManager (peerStates st pid)
     → vs ∈ qcVotes qc
     → ¬ (∈GenInfo-impl genesisInfo (proj₂ vs))
     → MsgWithSig∈ pk (proj₂ vs) (msgPool st)
@@ -100,8 +100,8 @@ qcVoteSigsSentB4{pid}{qc}{st = st} rss'@(step-s{pre = pre} rss (step-peer sp@(st
   pre≡ : peerStates (StepPeer-post{pre = pre} sp) pid ≡ peerStates pre pid
   pre≡ = cheatStepDNMPeerStates₁ sp unit
 
-  qc∈rmPre : qc QC.∈RoundManager peerStates pre pid
-  qc∈rmPre = subst (λ rm → qc QC.∈RoundManager rm) pre≡ qc∈rm
+  qc∈rmPre : qc QCProps.∈RoundManager peerStates pre pid
+  qc∈rmPre = subst (λ rm → qc QCProps.∈RoundManager rm) pre≡ qc∈rm
 
   iniPre : initialised pre pid ≡ initd
   iniPre = trans (sym (cheatStepDNMInitialised₁ sp unit)) ini
@@ -113,8 +113,8 @@ qcVoteSigsSentB4{pid}{qc}{_ , sig}{pk} (step-s{pre = pre} rss (step-peer sp@(ste
   pre≡ : peerStates (StepPeer-post{pre = pre} sp) pid ≡ peerStates pre pid
   pre≡ = sym $ pids≢StepDNMPeerStates sps pid≢
 
-  qc∈rmPre : qc QC.∈RoundManager peerStates pre pid
-  qc∈rmPre = subst (λ rm → qc QC.∈RoundManager rm) pre≡ qc∈rm
+  qc∈rmPre : qc QCProps.∈RoundManager peerStates pre pid
+  qc∈rmPre = subst (λ rm → qc QCProps.∈RoundManager rm) pre≡ qc∈rm
 
   iniPre : initialised pre pid ≡ initd
   iniPre = trans (pids≢StepDNMInitialised{pre = pre} sps pid≢) ini
@@ -126,7 +126,7 @@ qcVoteSigsSentB4{pid}{qc}{_ , sig}{pk} (step-s{pre = pre} rss (step-peer sp@(ste
   pre≡ : peerStates (StepPeer-post{pre = pre} sp) pid ≡ peerStates pre pid
   pre≡ = sym $ trans (peerUninitState rss uni) (StepPeer-post-lemma sp)
 
-  qc∈rmPre : qc QC.∈RoundManager peerStates pre pid'
+  qc∈rmPre : qc QCProps.∈RoundManager peerStates pre pid'
   qc∈rmPre rewrite pre≡ = qc∈rm
 
 ...| step-msg{sndr , V pm} m∈pool ini' =  obm-dangerous-magic' "waiting on : handleVoteSpec"
@@ -302,6 +302,5 @@ open ReachableSystemStateProps
 handleProposalRequirements {st = st} {sndr} {pm} {pid} reach m∈pool ini =
   record { mSndr = sndr
          ; m∈pool = m∈pool
-         ; qcs∈RmSigsSentB4 = qcs∈RMSigSentB4 (systemInvariants reach) ini
          }
 

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -114,6 +114,12 @@ module QCProps where
   SigsForVotes∈Rm-SentB4 : SentMessages → RoundManager → Set
   SigsForVotes∈Rm-SentB4 pool rm = ∀ {qc v pk} → SigForVote∈Rm-SentB4 v pk qc rm pool
 
+  ++-SigsForVote∈Rm-SentB4
+    : ∀ {pool rm} → (msgs : SentMessages) → SigsForVotes∈Rm-SentB4 pool rm
+      → SigsForVotes∈Rm-SentB4 (msgs ++ pool) rm
+  ++-SigsForVote∈Rm-SentB4{pool} msgs sfvb4 qc∈rm sig vs∈qc rbld≈v =
+    MsgWithSig∈-++ʳ{ms = msgs} (sfvb4 qc∈rm sig vs∈qc rbld≈v)
+
 module RoundManagerInvariants where
   -- The property that a block tree `bt` has only valid QCs with respect to epoch config `𝓔`
   AllValidQCs : (𝓔 : EpochConfig) (bt : BlockTree) → Set
@@ -153,6 +159,10 @@ module RoundManagerInvariants where
       epochsMatch  : EpochsMatch rm
       btInv        : BlockStoreInv rm
       srInv        : SafetyRulesInv rm
+
+  ++-RoundManagerInv : ∀ {pool rm} → (msgs : SentMessages) → RoundManagerInv pool rm → RoundManagerInv (msgs ++ pool) rm
+  ++-RoundManagerInv msgs (mkRoundManagerInv rmCorrect qcsigsSentB4 epochsMatch btInv srInv) =
+    mkRoundManagerInv rmCorrect (QCProps.++-SigsForVote∈Rm-SentB4 msgs qcsigsSentB4) epochsMatch btInv srInv
 
   Preserves : ∀ {ℓ} → (P : RoundManager → Set ℓ) (pre post : RoundManager) → Set ℓ
   Preserves Pred pre post = Pred pre → Pred post

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -181,6 +181,15 @@ module RoundManagerTransProps where
   transNoEpochChange : Transitive NoEpochChange
   transNoEpochChange = trans
 
+  NoSafetyDataChange : (pre post : RoundManager) → Set
+  NoSafetyDataChange pre post = pre ≡L post at pssSafetyData-rm
+
+  reflNoSafetyDataChange : Reflexive NoSafetyDataChange
+  reflNoSafetyDataChange = refl
+
+  transNoSafetyDataChange : Transitive NoSafetyDataChange
+  transNoSafetyDataChange = trans
+
   -- - state changes from generating or not generating a vote
   LastVoteIs : RoundManager → Vote → Set
   LastVoteIs rm v = just v ≡ rm ^∙ pssSafetyData-rm ∙ sdLastVote

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -26,8 +26,7 @@ open import Optics.All
 
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open        ParamsWithInitAndHandlers InitAndHandlers
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers
-                               PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers PeerCanSignForPK PeerCanSignForPK-stable
 
 module LibraBFT.Impl.Properties.Util where
 
@@ -89,6 +88,32 @@ module OutputProps where
     |       nv
     |       ov = refl
 
+module QCProps where
+
+  data _∈RoundManager_ (qc : QuorumCert) (rm : RoundManager) : Set where
+    inHQC : qc ≡ rm ^∙ lBlockStore ∙ bsInner ∙ btHighestQuorumCert → qc ∈RoundManager rm
+    inHCC : qc ≡ rm ^∙ lBlockStore ∙ bsInner ∙ btHighestCommitCert → qc ∈RoundManager rm
+    -- NOTE: When `need/fetch` is implemented, we will need an additional
+    -- constructor for sent qcs taken from the blockstore.
+
+  OutputQc∈RoundManager : List Output → RoundManager → Set
+  OutputQc∈RoundManager outs rm =
+    All (λ out → ∀ qc nm → qc QC∈NM nm → nm Msg∈Out out → qc ∈RoundManager rm) outs
+
+
+  -- TODO-3: Should be either that the vote is represented in the genesis info,
+  -- *or* it isn't and is in the pool
+  SigForVote∈Rm-SentB4 : Vote → PK → QuorumCert → RoundManager → SentMessages → Set
+  SigForVote∈Rm-SentB4 v pk qc rm pool =
+    qc ∈RoundManager rm
+    → WithVerSig pk v →
+    ∀ {vs : Author × Signature} → let (pid , sig) = vs in
+      vs ∈ qcVotes qc → rebuildVote qc vs ≈Vote v
+    → MsgWithSig∈ pk sig pool
+
+  SigsForVotes∈Rm-SentB4 : SentMessages → RoundManager → Set
+  SigsForVotes∈Rm-SentB4 pool rm = ∀ {qc v pk} → SigForVote∈Rm-SentB4 v pk qc rm pool
+
 module RoundManagerInvariants where
   -- The property that a block tree `bt` has only valid QCs with respect to epoch config `𝓔`
   AllValidQCs : (𝓔 : EpochConfig) (bt : BlockTree) → Set
@@ -115,18 +140,19 @@ module RoundManagerInvariants where
       field
         sdInv : SafetyDataInv
 
-    -- NOTE: This will be proved by induction on reachable states using the
-    -- property that peer handlers preserve invariants. That is to say, many of
-    -- these cannot be proven as a post-condition of the peer handler: one can
-    -- only prove of the handler that if the invariant holds for the prestate,
-    -- then it holds for the poststate.
-    record RoundManagerInv : Set where
-      constructor mkRoundManagerInv
-      field
-        rmCorrect   : RoundManager-correct rm
-        epochsMatch : EpochsMatch
-        btInv       : BlockStoreInv
-        srInv       : SafetyRulesInv
+  -- NOTE: This will be proved by induction on reachable states using the
+  -- property that peer handlers preserve invariants. That is to say, many of
+  -- these cannot be proven as a post-condition of the peer handler: one can
+  -- only prove of the handler that if the invariant holds for the prestate,
+  -- then it holds for the poststate.
+  record RoundManagerInv (pool : SentMessages) (rm : RoundManager) : Set where
+    constructor mkRoundManagerInv
+    field
+      rmCorrect    : RoundManager-correct rm
+      qcsigsSentB4 : QCProps.SigsForVotes∈Rm-SentB4 pool rm
+      epochsMatch  : EpochsMatch rm
+      btInv        : BlockStoreInv rm
+      srInv        : SafetyRulesInv rm
 
   Preserves : ∀ {ℓ} → (P : RoundManager → Set ℓ) (pre post : RoundManager) → Set ℓ
   Preserves Pred pre post = Pred pre → Pred post
@@ -134,12 +160,29 @@ module RoundManagerInvariants where
   reflPreserves : ∀ {ℓ} (P : RoundManager → Set ℓ) → Reflexive (Preserves P)
   reflPreserves Pred = id
 
-  reflPreservesRoundManagerInv = reflPreserves RoundManagerInv
+  reflPreservesRoundManagerInv : ∀ {pool} → Reflexive (Preserves (RoundManagerInv pool))
+  reflPreservesRoundManagerInv{pool} = reflPreserves (RoundManagerInv pool)
 
   transPreserves : ∀ {ℓ} (P : RoundManager → Set ℓ) → Transitive (Preserves P)
   transPreserves Pred p₁ p₂ = p₂ ∘ p₁
 
-  transPreservesRoundManagerInv = transPreserves RoundManagerInv
+  transPreservesRoundManagerInv : ∀ {pool} → Transitive (Preserves (RoundManagerInv pool))
+  transPreservesRoundManagerInv{pool} = transPreserves (RoundManagerInv pool)
+
+
+  substSigsForVotes∈Rm-SentB4
+    : ∀ {pool pre post} → pre ≡L post at rmBlockStore
+      → Preserves (QCProps.SigsForVotes∈Rm-SentB4 pool) pre post
+  substSigsForVotes∈Rm-SentB4{pool}{pre}{post} bs≡ qcsB4 {qc} (QCProps.inHQC qc≡) sig vs∈qc rbld≈v =
+    qcsB4 (QCProps.inHQC qc≡') sig vs∈qc rbld≈v
+    where
+    qc≡' : qc ≡ pre ^∙ lBlockStore ∙ bsInner ∙ btHighestQuorumCert
+    qc≡' = trans qc≡ (cong (_^∙ bsInner ∙ btHighestQuorumCert) (sym bs≡))
+  substSigsForVotes∈Rm-SentB4{pool}{pre}{post} bs≡ qcsB4 {qc} (QCProps.inHCC qc≡) sig vs∈qc rbld≈v =
+    qcsB4 (QCProps.inHCC qc≡') sig vs∈qc rbld≈v
+    where
+    qc≡' : qc ≡ pre ^∙ lBlockStore ∙ bsInner ∙ btHighestCommitCert
+    qc≡' = trans qc≡ (cong (_^∙ bsInner ∙ btHighestCommitCert) (sym bs≡))
 
   substSafetyDataInv
     : ∀ {pre post} → pre ≡L post at pssSafetyData-rm → Preserves SafetyDataInv pre post
@@ -158,14 +201,15 @@ module RoundManagerInvariants where
   mkPreservesSafetyRulesInv lvP (mkSafetyRulesInv lv) = mkSafetyRulesInv (lvP lv)
 
   mkPreservesRoundManagerInv
-    : ∀ {pre post}
-      → Preserves RoundManager-correct pre post
-      → Preserves EpochsMatch          pre post
-      → Preserves BlockStoreInv        pre post
-      → Preserves SafetyRulesInv       pre post
-      → Preserves RoundManagerInv      pre post
-  mkPreservesRoundManagerInv rmP emP bsP srP (mkRoundManagerInv rmCorrect epochsMatch btInv srInv) =
-    mkRoundManagerInv (rmP rmCorrect) (emP epochsMatch) (bsP btInv) (srP srInv)
+    : ∀ {pre post pool}
+      → Preserves RoundManager-correct                  pre post
+      → Preserves (QCProps.SigsForVotes∈Rm-SentB4 pool) pre post
+      → Preserves EpochsMatch                           pre post
+      → Preserves BlockStoreInv                         pre post
+      → Preserves SafetyRulesInv                        pre post
+      → Preserves (RoundManagerInv pool)                pre post
+  mkPreservesRoundManagerInv rmP qcP emP bsP srP (mkRoundManagerInv rmCorrect qcsB4 epochsMatch btInv srInv) =
+    mkRoundManagerInv (rmP rmCorrect) (qcP qcsB4) (emP epochsMatch) (bsP btInv) (srP srInv)
 
 module RoundManagerTransProps where
   -- Relations between the pre/poststate which may or may not hold, depending on
@@ -430,33 +474,11 @@ module Voting where
     ⊥-elim (sendVote∉actions{outs}{st = pre} (sym noVoteMsgOuts) vm∈outs)
   voteAttemptCorrectAndSent⇒voteSentCorrect{pre}{outs = outs}{vm = vm} vm∈outs (mkVoteAttemptCorrectWithEpochReq (Right vsc) _) = vsc
 
-module QC where
-
-  data _∈RoundManager_ (qc : QuorumCert) (rm : RoundManager) : Set where
-    inHQC : qc ≡ rm ^∙ lBlockStore ∙ bsInner ∙ btHighestQuorumCert → qc ∈RoundManager rm
-    inHCC : qc ≡ rm ^∙ lBlockStore ∙ bsInner ∙ btHighestCommitCert → qc ∈RoundManager rm
-    -- NOTE: When `need/fetch` is implemented, we will need an additional
-    -- constructor for sent qcs taken from the blockstore.
-
-  OutputQc∈RoundManager : List Output → RoundManager → Set
-  OutputQc∈RoundManager outs rm =
-    All (λ out → ∀ qc nm → qc QC∈NM nm → nm Msg∈Out out → qc ∈RoundManager rm) outs
-
-  SigForVote∈Qc∈Rm-SentB4 : Vote → PK → QuorumCert → RoundManager → SentMessages → Set
-  SigForVote∈Qc∈Rm-SentB4 v pk qc rm pool =
-    qc ∈RoundManager rm
-    → WithVerSig pk v →
-    ∀ {vs : Author × Signature} → let (pid , sig) = vs in
-      vs ∈ qcVotes qc → rebuildVote qc vs ≈Vote v
-    → MsgWithSig∈ pk sig pool
-
-  SigsForVotes∈Qc∈Rm-SentB4 : RoundManager → SentMessages → Set
-  SigsForVotes∈Qc∈Rm-SentB4 rm pool = ∀ {qc v pk} → SigForVote∈Qc∈Rm-SentB4 v pk qc rm pool
 
 record SystemInv (st : SystemState) : Set where
   field
     qcs∈RMSigSentB4 : ∀ {pid}
                     → initialised st pid ≡ initd
-                    → QC.SigsForVotes∈Qc∈Rm-SentB4 (peerStates st pid) (msgPool st)
+                    → QCProps.SigsForVotes∈Rm-SentB4 (msgPool st) (peerStates st pid)
 open SystemInv public
 

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -60,14 +60,14 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach (step-msg{sndr , nm} m∈pool
   hpPre  = peerStates pre pid
   hpOut  = LBFT-outs (handle pid nm 0) hpPre
 
-  nmSentQcs∈RM : (nm1 : NetworkMsg) → nm1 ≡ nm → QC.OutputQc∈RoundManager hpOut hpPre
+  nmSentQcs∈RM : (nm1 : NetworkMsg) → nm1 ≡ nm → QCProps.OutputQc∈RoundManager hpOut hpPre
   nmSentQcs∈RM (P pm) refl = outQcs∈RM
     where open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre $ handleProposalRequirements preach m∈pool ini)
   nmSentQcs∈RM (V vm) refl = obm-dangerous-magic' "Waiting on handleVoteSpec"
   nmSentQcs∈RM (C cm) refl = obm-dangerous-magic' "Waiting on handleCommitSpec"
 
   module _ (nm1 : NetworkMsg) (nm≡ : nm1 ≡ nm) where
-    qc∈rm : qc QC.∈RoundManager hpPre
+    qc∈rm : qc QCProps.∈RoundManager hpPre
     qc∈rm
       with sendMsg∈actions{hpOut}{st = hpPre} m∈acts
     ...| out , out∈hpOut , m∈out = All-lookup (nmSentQcs∈RM nm1 nm≡) out∈hpOut qc m qc∈m m∈out
@@ -77,7 +77,7 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach (step-msg{sndr , nm} m∈pool
 
 newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vote∈vm m∈outs sig hpk ¬gen ¬msb4
   with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid) $ handleProposalRequirements preach m∈pool ini
-...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , voteUnsent)) sdEpoch≡?) _ _ =
+...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , voteUnsent)) sdEpoch≡?) _ =
   ⊥-elim (¬voteUnsent voteUnsent)
   where
   handleOuts = LBFT-outs (handle pid (P pm) 0) (peerStates pre pid)
@@ -86,7 +86,7 @@ newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vot
   ¬voteUnsent (Voting.mkVoteUnsentCorrect noVoteMsgOuts _) =
     sendVote∉actions{outs = handleOuts}{st = peerStates pre pid}
       (sym noVoteMsgOuts) m∈outs
-...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect (VoteMsg∙new v' _) rcvr voteMsgOuts vgCorrect)) sdEpoch≡?) _ _ =
+...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect (VoteMsg∙new v' _) rcvr voteMsgOuts vgCorrect)) sdEpoch≡?) _ =
   sentVoteIsPostLV
   where
   handlePost = LBFT-post (handle pid (P pm) 0) (peerStates pre pid)
@@ -104,7 +104,7 @@ newVote⇒lv≡{pre}{pid}{s' = s'}{v = v} preach (step-msg{sndr , V vm} m∈pool
   where
   hvPre = peerStates pre pid
   hvOut = LBFT-outs (handleVote 0 vm) hvPre
-  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre)
+  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre))
 
 oldVoteRound≤lvr
   : ∀ {pid pk v}{pre : SystemState}
@@ -299,7 +299,7 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s{pre = pre} preach step@(step-peer sp@
   hvPre = peerStates pre pid
   hvPos = LBFT-post (handleVote 0 vm) hvPre
   hvOut = LBFT-outs (handleVote 0 vm) hvPre
-  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre)
+  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre))
 
   m'∈poolPre : (pid' , V (VoteMsg∙new v' _)) ∈ msgPool pre
   m'∈poolPre = either (⊥-elim ∘ absurd) id (Any-++⁻ (actionsToSentMessages pid (outputsToActions{hvPre} hvOut)) m'∈pool)
@@ -470,7 +470,7 @@ sameERasLV⇒sameId{pid@.pid“}{pid'}{pk} (step-s{pre = pre} preach step@(step-
   hvPos = LBFT-post (handleVote 0 vm) hvPre
   hvOut = LBFT-outs (handleVote 0 vm) hvPre
 
-  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre)
+  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre))
 
   voteData≡ : v' ≡L msgPart mws∈pool at vVoteData
   voteData≡ = either (⊥-elim ∘ PerReachableState.meta-sha256-cr preach) id (sameSig⇒sameVoteData (msgSigned mws∈pool) sig' (msgSameSig mws∈pool))
@@ -540,9 +540,9 @@ votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr
     TODO : v' [ _<_ ]L v at vRound ⊎ Common.VoteForRound∈ InitAndHandlers 𝓔 pk (v ^∙ vRound) (v ^∙ vEpoch) (v ^∙ vProposedId) (msgPool pre)
 votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈outs sig ¬gen ¬msb pcspkv v'⊂m' m'∈pool sig' ¬gen' eid≡
   with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid) $ handleProposalRequirements preach m∈pool ini
-...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?) _ _ =
+...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?) _ =
   ⊥-elim (sendVote∉actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym noVoteMsgOuts) m∈outs)
-...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?) _ _
+...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?) _
   with sendVote∈actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym voteMsgOuts) m∈outs
 ...| refl = ret
   where
@@ -626,7 +626,7 @@ votesOnce₁{pid = pid}{pid'}{pk = pk}{pre = pre} preach sps@(step-msg{sndr , V 
   where
   hvPre = peerStates pre pid
   hvOut = LBFT-outs (handleVote 0 vm) hvPre
-  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre)
+  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre))
 
 votesOnce₂ : VO.ImplObligation₂ InitAndHandlers 𝓔
 votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v' = v'} hpk v⊂m m∈outs sig ¬gen ¬msb4 pcsfpk v'⊂m' m'∈outs sig' ¬gen' ¬msb4' pcsfpk' ≡epoch ≡round
@@ -665,4 +665,4 @@ votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v
   where
   hvPre = peerStates pre pid
   hvOut = LBFT-outs (handle pid (V vm) 0) hvPre
-  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre)
+  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre))

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -62,7 +62,11 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach (step-msg{sndr , nm} m∈pool
 
   nmSentQcs∈RM : (nm1 : NetworkMsg) → nm1 ≡ nm → QCProps.OutputQc∈RoundManager hpOut hpPre
   nmSentQcs∈RM (P pm) refl = outQcs∈RM
-    where open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre $ handleProposalRequirements preach m∈pool ini)
+    where
+    hpReq : handleProposalSpec.Requirements 0 pm hpPool hpPre
+    hpReq = record { mSndr = _ ; m∈pool = m∈pool }
+
+    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre hpReq)
   nmSentQcs∈RM (V vm) refl = obm-dangerous-magic' "Waiting on handleVoteSpec"
   nmSentQcs∈RM (C cm) refl = obm-dangerous-magic' "Waiting on handleCommitSpec"
 
@@ -76,7 +80,7 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach (step-msg{sndr , nm} m∈pool
     sigSentB4 rewrite cong _vSignature v≈rbld = qcVoteSigsSentB4 preach ini qc∈rm vs∈qc ¬gen
 
 newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vote∈vm m∈outs sig hpk ¬gen ¬msb4
-  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid) $ handleProposalRequirements preach m∈pool ini
+  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid) (handleProposalSpec.mkRequirements sndr m∈pool)
 ...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , voteUnsent)) sdEpoch≡?) _ =
   ⊥-elim (¬voteUnsent voteUnsent)
   where
@@ -104,7 +108,7 @@ newVote⇒lv≡{pre}{pid}{s' = s'}{v = v} preach (step-msg{sndr , V vm} m∈pool
   where
   hvPre = peerStates pre pid
   hvOut = LBFT-outs (handleVote 0 vm) hvPre
-  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre))
+  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre) (handleVoteSpec.mkRequirements _ m∈pool))
 
 oldVoteRound≤lvr
   : ∀ {pid pk v}{pre : SystemState}
@@ -266,7 +270,7 @@ sameERasLV⇒sameId{pid = .pid“}{pid'}{pk} (step-s{pre = pre} preach step@(ste
   -- Definitions
   hpPool = msgPool pre
   hpPre  = peerStates pre pid“
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre $ handleProposalRequirements preach pm∈pool ini)
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre (handleProposalSpec.mkRequirements _ pm∈pool))
   hpPos  = LBFT-post (handleProposal 0 pm) hpPre
   hpOuts = LBFT-outs (handleProposal 0 pm) hpPre
 
@@ -299,7 +303,7 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s{pre = pre} preach step@(step-peer sp@
   hvPre = peerStates pre pid
   hvPos = LBFT-post (handleVote 0 vm) hvPre
   hvOut = LBFT-outs (handleVote 0 vm) hvPre
-  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre))
+  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre) (handleVoteSpec.mkRequirements _ m∈pool))
 
   m'∈poolPre : (pid' , V (VoteMsg∙new v' _)) ∈ msgPool pre
   m'∈poolPre = either (⊥-elim ∘ absurd) id (Any-++⁻ (actionsToSentMessages pid (outputsToActions{hvPre} hvOut)) m'∈pool)
@@ -359,7 +363,7 @@ sameERasLV⇒sameId{.pid“}{pid'}{pk} (step-s{pre = pre} preach step@(step-peer
   hpPre  = peerStates pre pid“
   rmInv  = invariantsCorrect pid“ pre preach
   open RoundManagerInvariants.RoundManagerInv (invariantsCorrect pid“ pre preach)
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre $ handleProposalRequirements preach m∈pool ini)
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre (handleProposalSpec.mkRequirements sndr m∈pool))
     renaming (rmInv to rmInvP)
   hpPos  = LBFT-post (handleProposal 0 pm) hpPre
   hpOuts = LBFT-outs (handleProposal 0 pm) hpPre
@@ -470,7 +474,7 @@ sameERasLV⇒sameId{pid@.pid“}{pid'}{pk} (step-s{pre = pre} preach step@(step-
   hvPos = LBFT-post (handleVote 0 vm) hvPre
   hvOut = LBFT-outs (handleVote 0 vm) hvPre
 
-  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre))
+  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre) (handleVoteSpec.mkRequirements _ m∈pool))
 
   voteData≡ : v' ≡L msgPart mws∈pool at vVoteData
   voteData≡ = either (⊥-elim ∘ PerReachableState.meta-sha256-cr preach) id (sameSig⇒sameVoteData (msgSigned mws∈pool) sig' (msgSameSig mws∈pool))
@@ -539,7 +543,7 @@ votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr
   postulate -- TODO-2: prove (waiting on: lemma that QC votes have been sent before)
     TODO : v' [ _<_ ]L v at vRound ⊎ Common.VoteForRound∈ InitAndHandlers 𝓔 pk (v ^∙ vRound) (v ^∙ vEpoch) (v ^∙ vProposedId) (msgPool pre)
 votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈outs sig ¬gen ¬msb pcspkv v'⊂m' m'∈pool sig' ¬gen' eid≡
-  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid) $ handleProposalRequirements preach m∈pool ini
+  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid) (handleProposalSpec.mkRequirements sndr m∈pool)
 ...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?) _ =
   ⊥-elim (sendVote∉actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym noVoteMsgOuts) m∈outs)
 ...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?) _
@@ -626,7 +630,7 @@ votesOnce₁{pid = pid}{pid'}{pk = pk}{pre = pre} preach sps@(step-msg{sndr , V 
   where
   hvPre = peerStates pre pid
   hvOut = LBFT-outs (handleVote 0 vm) hvPre
-  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre))
+  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre) (handleVoteSpec.mkRequirements sndr m∈pool))
 
 votesOnce₂ : VO.ImplObligation₂ InitAndHandlers 𝓔
 votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v' = v'} hpk v⊂m m∈outs sig ¬gen ¬msb4 pcsfpk v'⊂m' m'∈outs sig' ¬gen' ¬msb4' pcsfpk' ≡epoch ≡round
@@ -648,7 +652,7 @@ votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v
   hpPool = msgPool pre
   hpPre  = peerStates pre pid
   hpOut  = LBFT-outs (handleProposal 0 pm) hpPre
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre $ handleProposalRequirements rss m“∈pool ini)
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre (handleProposalSpec.mkRequirements sndr m“∈pool))
 
   v≡v' : v ≡ v'
   v≡v'
@@ -665,4 +669,4 @@ votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v
   where
   hvPre = peerStates pre pid
   hvOut = LBFT-outs (handle pid (V vm) 0) hvPre
-  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre))
+  open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hvPre (msgPool pre) (handleVoteSpec.mkRequirements sndr m“∈pool))

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -30,6 +30,14 @@ module LibraBFT.Prelude where
   open import Data.Empty
     public
 
+  -- NOTE: This function is defined to give extra documentation when discharging
+  -- absurd cases where Agda can tell by pattern matching that `A` is not
+  -- inhabited. For example:
+  -- > absurd (just v ≡ nothing) case impossibleProof of λ ()
+  infix 0 absurd_case_of_
+  absurd_case_of_ : ∀ {ℓ₁ ℓ₂} (A : Set ℓ₁) {B : Set ℓ₂} → A → (A → ⊥) → B
+  absurd A case x of f = ⊥-elim (f x)
+
   open import Data.Nat
     renaming (_≟_ to _≟ℕ_; _≤?_ to _≤?ℕ_; _≥?_ to _≥?ℕ_; compare to compareℕ; Ordering to Orderingℕ)
     public


### PR DESCRIPTION
Updated the proof of `invariantsCorrect` now that "round manager QC votes have had their signatures sent before" is tracked as a property preserved by peer handler steps.

Also merged in `chris-handle-vote-spec` (which postulates the contract for `handleVote`, so that more progress can be made on the other cases for the `VotesOnce` property)