### PR TITLE
use maybe-RWST

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -50,7 +50,7 @@ commitM
   → LBFT (Either ErrLog Unit)
 commitM finalityProof = do
   bs ← use lBlockStore
-  maybeS (bs ^∙ bsRoot) (bail fakeErr) $ λ bsr → do
+  maybeS-RWST (bs ^∙ bsRoot) (bail fakeErr) $ λ bsr → do
     let blockIdToCommit = finalityProof ^∙ liwsLedgerInfo ∙ liConsensusBlockId
     case getBlock blockIdToCommit bs of λ where
       nothing →

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -42,7 +42,7 @@ addCertsM {-reason-} syncInfo retriever =
   syncToHighestCommitCertM     (syncInfo ^∙ siHighestCommitCert) retriever ∙?∙ \_ ->
   insertQuorumCertM {-reason-} (syncInfo ^∙ siHighestCommitCert) retriever ∙?∙ \_ ->
   insertQuorumCertM {-reason-} (syncInfo ^∙ siHighestQuorumCert) retriever ∙?∙ \_ ->
-  maybeS                       (syncInfo ^∙ siHighestTimeoutCert) (ok unit) $
+  maybeS-RWST                  (syncInfo ^∙ siHighestTimeoutCert) (ok unit) $
     \tc -> BlockStore.insertTimeoutCertificateM tc
 
 ------------------------------------------------------------------------------
@@ -61,7 +61,7 @@ insertQuorumCertM qc retriever = do
       ok unit
     (Right _) →
       ok unit
-  maybeS (bs ^∙ bsRoot) (bail fakeErr) $ λ bsr →
+  maybeS-RWST (bs ^∙ bsRoot) (bail fakeErr) $ λ bsr →
     if-RWST (bsr ^∙ ebRound) <?ℕ (qc ^∙ qcCommitInfo ∙ biRound)
       then (do
         let finalityProof = qc ^∙ qcLedgerInfo

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -96,7 +96,7 @@ verifyAndUpdatePreferredRoundM quorumCert safetyData = do
 verifyAuthorM : Maybe Author → LBFT (Either ErrLog Unit)
 verifyAuthorM author = do
   vs ← use (lSafetyRules ∙ srValidatorSigner)
-  maybeS-RWST vs (bail fakeErr) {-(ErrL (here' ["srValidatorSigner", "Nothing"]))-} $ λ validatorSigner →
+  maybeS vs (bail fakeErr) {-(ErrL (here' ["srValidatorSigner", "Nothing"]))-} $ λ validatorSigner →
     maybeS-RWST
       author
       (bail fakeErr) -- (ErrL (here' ["InvalidProposal", "No author found in the proposal"])))
@@ -224,7 +224,7 @@ constructAndSignVoteM-continue2 = constructAndSignVoteM-continue2.step₀
 signProposalM : BlockData → LBFT (Either ErrLog Block)
 signProposalM blockData = do
  vs ← use (lSafetyRules ∙ srValidatorSigner)
- maybeS-RWST vs (bail fakeErr) {-ErrL (here' ["srValidatorSigner", "Nothing"])-} $ λ validatorSigner -> do
+ maybeS vs (bail fakeErr) {-ErrL (here' ["srValidatorSigner", "Nothing"])-} $ λ validatorSigner -> do
   safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
   verifyAuthorM (blockData ^∙ bdAuthor) ∙?∙ λ _ →
     verifyEpochM (blockData ^∙ bdEpoch) safetyData ∙?∙ λ _ →
@@ -248,7 +248,7 @@ signProposalM blockData = do
 signTimeoutM : Timeout → LBFT (Either ErrLog Signature)
 signTimeoutM timeout = do
  vs ← use (lSafetyRules ∙ srValidatorSigner)
- maybeS-RWST vs (bail fakeErr) {-"srValidatorSigner", "Nothing"-} $ λ validatorSigner → do
+ maybeS vs (bail fakeErr) {-"srValidatorSigner", "Nothing"-} $ λ validatorSigner → do
    safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
    verifyEpochM (timeout ^∙ toEpoch) safetyData ∙^∙ withErrCtx (here' []) ∙?∙ λ _ -> do
      ifM‖ timeout ^∙ toRound ≤? safetyData ^∙ sdPreferredRound ≔

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -96,8 +96,8 @@ verifyAndUpdatePreferredRoundM quorumCert safetyData = do
 verifyAuthorM : Maybe Author → LBFT (Either ErrLog Unit)
 verifyAuthorM author = do
   vs ← use (lSafetyRules ∙ srValidatorSigner)
-  maybeS vs (bail fakeErr) {-(ErrL (here' ["srValidatorSigner", "Nothing"]))-} $ λ validatorSigner →
-    maybeS
+  maybeS-RWST vs (bail fakeErr) {-(ErrL (here' ["srValidatorSigner", "Nothing"]))-} $ λ validatorSigner →
+    maybeS-RWST
       author
       (bail fakeErr) -- (ErrL (here' ["InvalidProposal", "No author found in the proposal"])))
       (\a ->
@@ -224,7 +224,7 @@ constructAndSignVoteM-continue2 = constructAndSignVoteM-continue2.step₀
 signProposalM : BlockData → LBFT (Either ErrLog Block)
 signProposalM blockData = do
  vs ← use (lSafetyRules ∙ srValidatorSigner)
- maybeS vs (bail fakeErr) {-ErrL (here' ["srValidatorSigner", "Nothing"])-} $ λ validatorSigner -> do
+ maybeS-RWST vs (bail fakeErr) {-ErrL (here' ["srValidatorSigner", "Nothing"])-} $ λ validatorSigner -> do
   safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
   verifyAuthorM (blockData ^∙ bdAuthor) ∙?∙ λ _ →
     verifyEpochM (blockData ^∙ bdEpoch) safetyData ∙?∙ λ _ →
@@ -248,7 +248,7 @@ signProposalM blockData = do
 signTimeoutM : Timeout → LBFT (Either ErrLog Signature)
 signTimeoutM timeout = do
  vs ← use (lSafetyRules ∙ srValidatorSigner)
- maybeS vs (bail fakeErr) {-"srValidatorSigner", "Nothing"-} $ λ validatorSigner → do
+ maybeS-RWST vs (bail fakeErr) {-"srValidatorSigner", "Nothing"-} $ λ validatorSigner → do
    safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
    verifyEpochM (timeout ^∙ toEpoch) safetyData ∙^∙ withErrCtx (here' []) ∙?∙ λ _ -> do
      ifM‖ timeout ^∙ toRound ≤? safetyData ^∙ sdPreferredRound ≔

--- a/LibraBFT/ImplShared/Util/RWST/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/RWST/Syntax.agda
@@ -54,6 +54,22 @@ void m = do
   _ ← m
   pure unit
 
+{-
+Within the RWST monad, if and if-RWST are semantically interchangeable.
+Similarly for maybeS and maybe-RWST.
+
+The difference is in how proof obligations are generated
+- with the *-RWST variants generating new weakestPre obligations for each case.
+
+In some cases, this is helpful for structuring proofs, while in other cases it is
+unnecessary and introduces more structure to the proof without adding any benefit.
+
+A rule of thumb is that, if the "scrutinee" (whatever we are doing case analysis on,
+i.e., the first argument) is the value provided via >>= (RWST-bind) by a previous code block,
+then we already have a weakestPre proof obligation, so introducing additional ones via the
+*-RWST variants only creates more work and provides no additional benefit.
+-}
+
 -- Conditionals
 infix 1 ifM‖_
 ifM‖_ : Guards (RWST Ev Wr St A) → RWST Ev Wr St A


### PR DESCRIPTION
PR 
https://github.com/oracle/bft-consensus-agda/pull/103 
renamed `maybeS` to `maybeS-RWST`
and defined a new general "monadic" `maybeS`

This PR replaces some existing uses of `maybeS` in the `LBFT` monad with `maybeS-RWST`

IMPORTANT: See the comment in `Syntax.agda` on when to use the `-RWST` variant.