### PR TITLE
Reworking contracts for proving qcVoteSigsSentB4

### DIFF
--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -51,6 +51,7 @@ initRMSatisfiesInv =
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
 
 invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in an `Properties.Invariants` module
+                  -- TODO-2: This needs to be tightend so that the msgPool is of the previous system state (if there is one)
   : ∀ pid (pre : SystemState)
     → ReachableSystemState pre → RoundManagerInv (msgPool pre) (peerStates pre pid)
 invariantsCorrect pid pre@._ step-0 = initRMSatisfiesInv
@@ -69,10 +70,7 @@ invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest 
    = ++-RoundManagerInv _ initRMSatisfiesInv
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , P pm} m∈pool ini))))
    | yes refl
-  with handleProposalSpec.contract!-RoundManagerInv 0 pm (msgPool pre') (peerStates pre' pid) reqs
-  where
-  reqs : handleProposalSpec.Requirements 0 pm (msgPool pre') (peerStates pre' pid)
-  reqs = record { mSndr = sndr ; m∈pool = m∈pool }
+  with handleProposalSpec.Contract.rmInv $ handleProposalSpec.contract! 0 pm (msgPool pre') (peerStates pre' pid)
 ...| invPres
   rewrite override-target-≡{a = pid}{b = LBFT-post (handleProposal 0 pm) (peerStates pre' pid)}{f = peerStates pre'}
   = ++-RoundManagerInv _ (invPres (invariantsCorrect pid pre' preach))
@@ -90,16 +88,19 @@ invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest 
     TODO : RoundManagerInv (msgPool pre) (peerStates pre pid)
 
 qcVoteSigsSentB4
-  : ∀ pid (st : SystemState) {v qc vs pk}
-    → ReachableSystemState st
-    → qc QCProps.∈RoundManager (peerStates st pid)
-    → WithVerSig pk v
+  : ∀ pid (pre : SystemState) {ppost msgs}
+    → ReachableSystemState pre
+    → StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (ppost , msgs)
+    → ∀ {v qc vs pk}
+    → qc QCProps.∈RoundManager ppost
     → vs ∈ qcVotes qc → rebuildVote qc vs ≈Vote v
+    → WithVerSig pk v
     → ¬ (∈GenInfo-impl genesisInfo (proj₂ vs))
-    → MsgWithSig∈ pk (proj₂ vs) (msgPool st)
-qcVoteSigsSentB4 pid st rss qc∈rm sig vs∈qcvs ≈v ¬gen = qcsigsSentB4 qc∈rm sig vs∈qcvs ≈v ¬gen
+    → MsgWithSig∈ pk (proj₂ vs) (msgPool pre)
+qcVoteSigsSentB4 pid st rss sps qc∈rm vs∈qcvs ≈v sig ¬gen =
+  obm-dangerous-magic' "TODO: (waiting on: change to type signature of `invariantsCorrect`)"
   where
-  open RoundManagerInv (invariantsCorrect pid st rss)
+  open RoundManagerInv (invariantsCorrect pid _ (step-s rss (step-peer (step-honest sps))))
 
 lastVotedRound-mono
   : ∀ pid (pre : SystemState) {ppost} {msgs}
@@ -119,10 +120,7 @@ lastVotedRound-mono pid pre{ppost} preach ini (step-msg{_ , m} m∈pool ini₁) 
   hpPst  = LBFT-post (handleProposal 0 pm) hpPre
   hpOut  = LBFT-outs (handleProposal 0 pm) hpPre
 
-  hpReq : handleProposalSpec.Requirements 0 pm hpPool hpPre
-  hpReq = record { mSndr = _ ; m∈pool = m∈pool }
-
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre hpReq)
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
   open RoundManagerInvariants.RoundManagerInv (invariantsCorrect pid pre preach)
 
   module VoteOld (lv≡ : hpPre ≡L hpPst at pssSafetyData-rm ∙ sdLastVote) where

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -42,7 +42,7 @@ module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
   initRM-correct : RoundManager-correct initRM
-  initRM-qcs     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM -- TODO-1: This is not true (the definition of the predicate needs updating).
+  initRM-qcs     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM -- NOTE: all QCs in `initRM` come from the genesis info
   initRM-btInv   : BlockStoreInv initRM
 
 initRMSatisfiesInv : RoundManagerInvariants.RoundManagerInv [] initRM
@@ -154,10 +154,13 @@ lastVotedRound-mono pid pre{ppost} preach ini (step-msg{_ , m} m∈pool ini₁) 
   ...| Right (mkVoteNewGenerated lvr< lvr≡) = VoteNew.help lv≡v lvr< lvr≡
 
 -- Receiving a vote or commit message does not update the last vote
-...| V vm = ≡⇒≤ TODO
-  where
-  postulate -- TODO-2: prove (waiting on: `handle`)
-    TODO : Meta.getLastVoteRound (peerStates pre pid) ≡ Meta.getLastVoteRound (LBFT-post (handle pid (V vm) 0) (peerStates pre pid))
+...| V vm = ≡⇒≤ $ cong (maybe (_^∙ vRound) 0 ∘ (_^∙ sdLastVote)) noSDChange
+   where
+   hvPre = peerStates pre pid
+   hvPst = LBFT-post (handle pid (V vm) 0) hvPre
+
+   open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm (msgPool pre) hvPre)
+
 ...| C cm = ≡⇒≤ TODO
   where
   postulate -- TODO-2: prove (waiting on: `handle`)

--- a/LibraBFT/Impl/Properties/Common.agda
+++ b/LibraBFT/Impl/Properties/Common.agda
@@ -65,8 +65,8 @@ availEpochsConsistent :
    → pcs4𝓔 pkvpf ≡ pcs4𝓔 pkvpf'
 availEpochsConsistent (mkPCS4PK _ (inGenInfo refl) _) (mkPCS4PK _ (inGenInfo refl) _) refl = refl
 
-postulate
-  uninitQcs∈Gen -- TODO-1: Prove (waiting on: complete definition of `initRM`)
+postulate -- TODO-1: Prove (waiting on: complete definition of `initRM`)
+  uninitQcs∈Gen
     : ∀ {pid qc vs}{st : SystemState}
       → ReachableSystemState st
       → initialised st pid ≡ uninitd
@@ -208,10 +208,16 @@ module ReachableSystemStateProps where
     open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre hpReq)
     open ≡-Reasoning
 
-  mws∈pool⇒epoch≡{pid}{v}{st = st} rss (step-msg{sndr , V vm} _ _) pcsfpk hpk sig ¬gen mws∈pool epoch≡ = TODO
+  mws∈pool⇒epoch≡{pid}{v}{st = st} rss (step-msg{sndr , V vm} _ _) pcsfpk hpk sig ¬gen mws∈pool epoch≡ = begin
+    hvPre ^∙ rmEpoch ≡⟨ noEpochChange ⟩
+    hvPos ^∙ rmEpoch ≡⟨ epoch≡ ⟩
+    v ^∙ vEpoch      ∎
     where
-    postulate -- TODO-3: prove (waiting on: epoch config changes)
-      TODO : peerStates st pid ^∙ rmEpoch ≡ v ^∙ vEpoch
+    hvPre = peerStates st pid
+    hvPos = LBFT-post (handleVote 0 vm) hvPre
+
+    open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm (msgPool st) hvPre)
+    open ≡-Reasoning
 
   mws∈pool⇒epoch≡{pid}{v}{st = st} rss (step-msg{sndr , C cm} _ _) pcsfpk hpk sig ¬gen mws∈pool epoch≡ = TODO
     where

--- a/LibraBFT/Impl/Properties/Common.agda
+++ b/LibraBFT/Impl/Properties/Common.agda
@@ -202,10 +202,7 @@ module ReachableSystemStateProps where
     hpPre  = peerStates st pid
     hpPos  = LBFT-post (handleProposal 0 pm) hpPre
 
-    hpReq : handleProposalSpec.Requirements 0 pm hpPool hpPre
-    hpReq = record { mSndr = _ ; m∈pool = m∈pool }
-
-    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre hpReq)
+    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
     open ≡-Reasoning
 
   mws∈pool⇒epoch≡{pid}{v}{st = st} rss (step-msg{sndr , V vm} _ _) pcsfpk hpk sig ¬gen mws∈pool epoch≡ = begin

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -50,13 +50,13 @@ module OutputProps where
 
     NoMsgs⇒× : NoMsgs → NoProposals × NoVotes × NoSyncInfos
     proj₁ (NoMsgs⇒× noMsgs) =
-      filter-∪?-[]₁ outs isBroadcastProposal? _
-        (filter-∪?-[]₁ outs _ _ noMsgs)
+      filter-∪?-[]₁ outs isBroadcastProposal? _ noMsgs
     proj₁ (proj₂ (NoMsgs⇒× noMsgs)) =
-      filter-∪?-[]₂ outs _ isSendVote? noMsgs
+      filter-∪?-[]₂ outs _ isSendVote?
+        (filter-∪?-[]₂ outs _ _ noMsgs)
     proj₂ (proj₂ (NoMsgs⇒× noMsgs)) =
-      filter-∪?-[]₂ outs _ isBroadcastSyncInfo?
-        (filter-∪?-[]₁ outs _ _ noMsgs)
+      filter-∪?-[]₁ outs isBroadcastSyncInfo? _
+        (filter-∪?-[]₂ outs _ _ noMsgs)
 
     NoMsgs⇒NoProposals : NoMsgs → NoProposals
     NoMsgs⇒NoProposals = proj₁ ∘ NoMsgs⇒×
@@ -99,6 +99,14 @@ module QCProps where
   OutputQc∈RoundManager : List Output → RoundManager → Set
   OutputQc∈RoundManager outs rm =
     All (λ out → ∀ qc nm → qc QC∈NM nm → nm Msg∈Out out → qc ∈RoundManager rm) outs
+
+  NoMsgs⇒OutputQc∈RoundManager : ∀ outs rm → OutputProps.NoMsgs outs → OutputQc∈RoundManager outs rm
+  NoMsgs⇒OutputQc∈RoundManager outs rm noMsgs =
+    All-map help (noneOfKind⇒All¬ outs _ noMsgs)
+    where
+    help : ∀ {out : Output} → ¬ IsOutputMsg out → ∀ qc nm → qc QC∈NM nm → nm Msg∈Out out → qc ∈RoundManager rm
+    help ¬msg qc .(P _) qc∈m inBP = ⊥-elim (¬msg (Left tt))
+    help ¬msg qc .(V _) qc∈m inSV = ⊥-elim (¬msg (Right (Right tt)))
 
   SigForVote∈Rm-SentB4 : Vote → PK → QuorumCert → RoundManager → SentMessages → Set
   SigForVote∈Rm-SentB4 v pk qc rm pool =

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -37,7 +37,7 @@ open        ParamsWithInitAndHandlers InitAndHandlers
 open import LibraBFT.ImplShared.Util.HashCollisions InitAndHandlers
 
 open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers
-                               PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+                               PeerCanSignForPK PeerCanSignForPK-stable
 open        Structural impl-sps-avp
 
 -- This module proves the two "VotesOnce" proof obligations for our handler.

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -53,20 +53,21 @@ newVote⇒lv≡
     → Meta-Honest-PK pk → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
     → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
     → LastVoteIs s' v
-newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach (step-msg{sndr , nm} m∈pool ini) (vote∈qc{vs}{qc} vs∈qc v≈rbld qc∈m) m∈acts sig hpk ¬gen ¬msb4 =
+newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach sps@(step-msg{sndr , nm} m∈pool ini) (vote∈qc{vs}{qc} vs∈qc v≈rbld qc∈m) m∈acts sig hpk ¬gen ¬msb4 =
   ⊥-elim (¬msb4 $ sigSentB4 nm refl)
   where
   hpPool = msgPool pre
   hpPre  = peerStates pre pid
   hpOut  = LBFT-outs (handle pid nm 0) hpPre
+  hpPst  = LBFT-post (handle pid nm 0) hpPre
 
-  nmSentQcs∈RM : (nm1 : NetworkMsg) → nm1 ≡ nm → QCProps.OutputQc∈RoundManager hpOut hpPre
-  nmSentQcs∈RM (P pm) refl = outQcs∈RM
+  nmSentQcs∈RM : (nm1 : NetworkMsg) → nm1 ≡ nm → QCProps.OutputQc∈RoundManager hpOut hpPst
+  nmSentQcs∈RM (P pm) refl = outQcs∈RM outQcReq
     where
-    hpReq : handleProposalSpec.Requirements 0 pm hpPool hpPre
-    hpReq = record { mSndr = _ ; m∈pool = m∈pool }
+    outQcReq : handleProposalSpec.OutQcs.Requirements 0 pm hpPool hpPre
+    outQcReq = handleProposalSpec.OutQcs.mkRequirements _ m∈pool
 
-    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre hpReq)
+    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
   nmSentQcs∈RM (V vm) refl = outQcs∈RM outQcReq
     where
     outQcReq : handleVoteSpec.OutQcs.Requirements 0 vm hpPool
@@ -76,17 +77,18 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach (step-msg{sndr , nm} m∈pool
   nmSentQcs∈RM (C cm) refl = obm-dangerous-magic' "Waiting on handleCommitSpec"
 
   module _ (nm1 : NetworkMsg) (nm≡ : nm1 ≡ nm) where
-    qc∈rm : qc QCProps.∈RoundManager hpPre
+    qc∈rm : qc QCProps.∈RoundManager hpPst
     qc∈rm
       with sendMsg∈actions{hpOut}{st = hpPre} m∈acts
     ...| out , out∈hpOut , m∈out = All-lookup (nmSentQcs∈RM nm1 nm≡) out∈hpOut qc m qc∈m m∈out
 
     sigSentB4 : MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
     sigSentB4 rewrite cong _vSignature v≈rbld =
-      qcVoteSigsSentB4 pid pre{v}{qc = qc}{vs}{pk} preach qc∈rm sig vs∈qc v≈rbld ¬gen
+      qcVoteSigsSentB4 pid pre preach sps qc∈rm vs∈qc v≈rbld sig ¬gen
+      -- qcVoteSigsSentB4 pid pre{v}{qc = qc}{vs}{pk} preach qc∈rm sig vs∈qc v≈rbld ¬gen
 
 newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vote∈vm m∈outs sig hpk ¬gen ¬msb4
-  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid) (handleProposalSpec.mkRequirements sndr m∈pool)
+  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid)
 ...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , voteUnsent)) sdEpoch≡?) _ =
   ⊥-elim (¬voteUnsent voteUnsent)
   where
@@ -276,7 +278,7 @@ sameERasLV⇒sameId{pid = .pid“}{pid'}{pk} (step-s{pre = pre} preach step@(ste
   -- Definitions
   hpPool = msgPool pre
   hpPre  = peerStates pre pid“
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre (handleProposalSpec.mkRequirements _ pm∈pool))
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
   hpPos  = LBFT-post (handleProposal 0 pm) hpPre
   hpOuts = LBFT-outs (handleProposal 0 pm) hpPre
 
@@ -369,7 +371,7 @@ sameERasLV⇒sameId{.pid“}{pid'}{pk} (step-s{pre = pre} preach step@(step-peer
   hpPre  = peerStates pre pid“
   rmInv  = invariantsCorrect pid“ pre preach
   open RoundManagerInvariants.RoundManagerInv (invariantsCorrect pid“ pre preach)
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre (handleProposalSpec.mkRequirements sndr m∈pool))
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
     renaming (rmInv to rmInvP)
   hpPos  = LBFT-post (handleProposal 0 pm) hpPre
   hpOuts = LBFT-outs (handleProposal 0 pm) hpPre
@@ -549,7 +551,7 @@ votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr
   postulate -- TODO-2: prove (waiting on: lemma that QC votes have been sent before)
     TODO : v' [ _<_ ]L v at vRound ⊎ Common.VoteForRound∈ InitAndHandlers 𝓔 pk (v ^∙ vRound) (v ^∙ vEpoch) (v ^∙ vProposedId) (msgPool pre)
 votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈outs sig ¬gen ¬msb pcspkv v'⊂m' m'∈pool sig' ¬gen' eid≡
-  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid) (handleProposalSpec.mkRequirements sndr m∈pool)
+  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid)
 ...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?) _ =
   ⊥-elim (sendVote∉actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym noVoteMsgOuts) m∈outs)
 ...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?) _
@@ -658,7 +660,7 @@ votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v
   hpPool = msgPool pre
   hpPre  = peerStates pre pid
   hpOut  = LBFT-outs (handleProposal 0 pm) hpPre
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre (handleProposalSpec.mkRequirements sndr m“∈pool))
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
 
   v≡v' : v ≡ v'
   v≡v'

--- a/LibraBFT/ImplShared/Interface/Output.agda
+++ b/LibraBFT/ImplShared/Interface/Output.agda
@@ -89,7 +89,7 @@ module LibraBFT.ImplShared.Interface.Output where
   IsOutputMsg : Output → Set
   IsOutputMsg = IsBroadcastProposal ∪ IsBroadcastSyncInfo ∪ IsSendVote
 
-  isOutputMsg? = (isBroadcastProposal? ∪? isBroadcastSyncInfo?) ∪? isSendVote?
+  isOutputMsg? = isBroadcastProposal? ∪? (isBroadcastSyncInfo? ∪? isSendVote?)
 
   data _Msg∈Out_ : NetworkMsg → Output → Set where
     inBP : ∀ {pm pids} → P pm Msg∈Out BroadcastProposal pm pids

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -75,6 +75,24 @@ module LibraBFT.Lemmas where
  filter-∪?-[]₂ (x ∷ xs) p q () | no proof₁ | yes proof₂
  filter-∪?-[]₂ (x ∷ xs) p q () | yes proof
 
+ noneOfKind⇒¬Any
+   : ∀ {a p} {A : Set a} {P : A → Set p}
+       xs (p : (a : A) → Dec (P a))
+     → NoneOfKind xs p
+     → ¬ Any P xs
+ noneOfKind⇒¬Any (x ∷ xs) p none ∈xs
+    with p x
+ noneOfKind⇒¬Any (x ∷ xs) p none (here   px) | no ¬px = ¬px px
+ noneOfKind⇒¬Any (x ∷ xs) p none (there ∈xs) | no ¬px =
+   noneOfKind⇒¬Any xs p none ∈xs
+
+ noneOfKind⇒All¬
+   : ∀ {a p} {A : Set a} {P : A → Set p}
+       xs (p : (a : A) → Dec (P a))
+     → NoneOfKind xs p
+     → All (¬_ ∘ P) xs
+ noneOfKind⇒All¬ xs p none = ¬Any⇒All¬ xs (noneOfKind⇒¬Any xs p none)
+
  data All-vec {ℓ} {A : Set ℓ} (P : A → Set ℓ) : ∀ {n} → Vec {ℓ} A n → Set (Level.suc ℓ) where
    []  : All-vec P []
    _∷_ : ∀ {x n} {xs : Vec A n} (px : P x) (pxs : All-vec P xs) → All-vec P (x ∷ xs)

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -86,12 +86,13 @@ module LibraBFT.Prelude where
 
   open import Data.List.Relation.Unary.All
     using (All; []; _∷_)
-    renaming (head to All-head; tail to All-tail;
-              lookup to All-lookup; tabulate to All-tabulate;
-              reduce to All-reduce)
+    renaming (head     to All-head;   tail     to All-tail;
+              lookup   to All-lookup; tabulate to All-tabulate;
+              reduce   to All-reduce; map      to All-map)
     public
 
   open import Data.List.Relation.Unary.All.Properties
+    hiding   (All-map)
     renaming ( tabulate⁻ to All-tabulate⁻
              ; tabulate⁺ to All-tabulate⁺
              ; map⁺      to All-map⁺
@@ -241,12 +242,12 @@ module LibraBFT.Prelude where
     public
 
 
-  module _ {ℓ : Level} {A : Set} where
-    NoneOfKind : ∀ {P : A → Set ℓ} → List A → (p : (a : A) → Dec (P a)) → Set
+  module _ {ℓA} {A : Set ℓA} where
+    NoneOfKind : ∀ {ℓ} {P : A → Set ℓ} → List A → (p : (a : A) → Dec (P a)) → Set ℓA
     NoneOfKind xs p = List-filter p xs ≡ []
 
     postulate -- TODO-1: Replace with or prove using library properties?  Move to Lemmas?
-      NoneOfKind⇒ : ∀ {P : A → Set ℓ} {Q : A → Set ℓ} {xs : List A}
+      NoneOfKind⇒ : ∀ {ℓ} {P : A → Set ℓ} {Q : A → Set ℓ} {xs : List A}
                   → (p : (a : A) → Dec (P a))
                   → {q : (a : A) → Dec (Q a)}
                   → (∀ {a} → P a → Q a)  -- TODO-1: Use proper notation (Relation.Unary?)


### PR DESCRIPTION
I did not finish this, but just FYI: I think `invariantsCorrect` in `LibraBFT/Impl/Handle/Properties.agda` needs to be restated so that the votes in QCs in a peer round manager have come from the pool of the _preceding_ system state (I have updated the peer contracts to guarantee that QCs in output messages are in the post state).

There's also a useful lemma in here for relating `OutputProps.NoMsgs` to `QCProps.OutputQc∈RoundManager`