### PR TITLE
Modify `SyncInfo.Contract`, prove `ensureRoundAndSyncUpMSpec.contract`

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -50,7 +50,7 @@ commitM
   → LBFT (Either ErrLog Unit)
 commitM finalityProof = do
   bs ← use lBlockStore
-  maybeS (bs ^∙ bsRoot) (bail fakeErr) $ λ bsr → do
+  maybeS-RWST (bs ^∙ bsRoot) (bail fakeErr) $ λ bsr → do
     let blockIdToCommit = finalityProof ^∙ liwsLedgerInfo ∙ liConsensusBlockId
     case getBlock blockIdToCommit bs of λ where
       nothing →

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -42,7 +42,7 @@ addCertsM {-reason-} syncInfo retriever =
   syncToHighestCommitCertM     (syncInfo ^∙ siHighestCommitCert) retriever ∙?∙ \_ ->
   insertQuorumCertM {-reason-} (syncInfo ^∙ siHighestCommitCert) retriever ∙?∙ \_ ->
   insertQuorumCertM {-reason-} (syncInfo ^∙ siHighestQuorumCert) retriever ∙?∙ \_ ->
-  maybeS                       (syncInfo ^∙ siHighestTimeoutCert) (ok unit) $
+  maybeS-RWST                  (syncInfo ^∙ siHighestTimeoutCert) (ok unit) $
     \tc -> BlockStore.insertTimeoutCertificateM tc
 
 ------------------------------------------------------------------------------
@@ -61,7 +61,7 @@ insertQuorumCertM qc retriever = do
       ok unit
     (Right _) →
       ok unit
-  maybeS (bs ^∙ bsRoot) (bail fakeErr) $ λ bsr →
+  maybeS-RWST (bs ^∙ bsRoot) (bail fakeErr) $ λ bsr →
     if-RWST (bsr ^∙ ebRound) <?ℕ (qc ^∙ qcCommitInfo ∙ biRound)
       then (do
         let finalityProof = qc ^∙ qcLedgerInfo

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Properties/SyncInfo.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Properties/SyncInfo.agda
@@ -23,7 +23,7 @@ open import Optics.All
 open RoundManagerInvariants
 open RoundManagerTransProps
 
-module LibraBFT.Impl.Consensus.ConsensusTypes.SyncInfo.Properties where
+module LibraBFT.Impl.Consensus.ConsensusTypes.Properties.SyncInfo where
 
 module verifyMSpec (self : SyncInfo) (validator : ValidatorVerifier) where
 

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo.agda
@@ -28,7 +28,7 @@ verifyM : SyncInfo → ValidatorVerifier → LBFT (Either ErrLog Unit)
 verifyM self validator = pure (verify self validator)
 
 module verify (self : SyncInfo) (validator : ValidatorVerifier) where
-  step₀ step₁ step₂ step₃ step₄ : Either ErrLog Unit
+  step₀ step₁ step₂ step₃ step₄ step₅ : Either ErrLog Unit
   here' : List String.String → List String.String
 
   epoch = self ^∙ siHighestQuorumCert ∙ qcCertifiedBlock ∙ biEpoch
@@ -56,7 +56,9 @@ module verify (self : SyncInfo) (validator : ValidatorVerifier) where
 
   step₄ = do
     QuorumCert.verify (self ^∙ siHighestQuorumCert) validator
+    step₅
 
+  step₅ = do
     -- Note: do not use (self ^∙ siHighestCommitCert) because it might be
     -- same as siHighestQuorumCert -- so no need to check again
     maybeS (self ^∙ sixxxHighestCommitCert) (pure unit) (` QuorumCert.verify ` validator)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo.agda
@@ -27,32 +27,45 @@ verify : SyncInfo → ValidatorVerifier → Either ErrLog Unit
 verifyM : SyncInfo → ValidatorVerifier → LBFT (Either ErrLog Unit)
 verifyM self validator = pure (verify self validator)
 
-verify self validator = do
-  let epoch      = self ^∙ siHighestQuorumCert ∙ qcCertifiedBlock ∙ biEpoch
-
-  lcheck (epoch == self ^∙ siHighestCommitCert ∙ qcCertifiedBlock ∙ biEpoch)
-         (here' ("Multi epoch in SyncInfo - HCC and HQC" ∷ []))
-
-  lcheck (maybeS (self ^∙ siHighestTimeoutCert) true (λ tc -> epoch == tc ^∙ tcEpoch))
-         (here' ("Multi epoch in SyncInfo - TC and HQC" ∷ []))
-
-  lcheck (   self ^∙ siHighestQuorumCert ∙ qcCertifiedBlock ∙ biRound
-          ≥? self ^∙ siHighestCommitCert ∙ qcCertifiedBlock ∙ biRound)
-         (here' ("HQC has lower round than HCC" ∷ []))
-
-  lcheck (self ^∙ siHighestCommitCert ∙ qcCommitInfo /= BlockInfo.empty)
-         (here' ("HCC has no committed block" ∷ []))
-
-  QuorumCert.verify (self ^∙ siHighestQuorumCert) validator
-
-  -- Note: do not use (self ^∙ siHighestCommitCert) because it might be
-  -- same as siHighestQuorumCert -- so no need to check again
-  maybeS (self ^∙ sixxxHighestCommitCert) (pure unit) (` QuorumCert.verify ` validator)
-
-  maybeS (self ^∙ siHighestTimeoutCert)   (pure unit) (` TimeoutCertificate.verify ` validator)
- where
+module verify (self : SyncInfo) (validator : ValidatorVerifier) where
+  step₀ step₁ step₂ step₃ step₄ : Either ErrLog Unit
   here' : List String.String → List String.String
+
+  epoch = self ^∙ siHighestQuorumCert ∙ qcCertifiedBlock ∙ biEpoch
+
+  step₀ = do
+    lcheck (epoch == self ^∙ siHighestCommitCert ∙ qcCertifiedBlock ∙ biEpoch)
+           (here' ("Multi epoch in SyncInfo - HCC and HQC" ∷ []))
+    step₁
+
+  step₁ = do
+    lcheck (maybeS (self ^∙ siHighestTimeoutCert) true (λ tc -> epoch == tc ^∙ tcEpoch))
+           (here' ("Multi epoch in SyncInfo - TC and HQC" ∷ []))
+    step₂
+
+  step₂ = do
+    lcheck (   self ^∙ siHighestQuorumCert ∙ qcCertifiedBlock ∙ biRound
+           ≥? self ^∙ siHighestCommitCert ∙ qcCertifiedBlock ∙ biRound)
+           (here' ("HQC has lower round than HCC" ∷ []))
+    step₃
+
+  step₃ = do
+    lcheck (self ^∙ siHighestCommitCert ∙ qcCommitInfo /= BlockInfo.empty)
+           (here' ("HCC has no committed block" ∷ []))
+    step₄
+
+  step₄ = do
+    QuorumCert.verify (self ^∙ siHighestQuorumCert) validator
+
+    -- Note: do not use (self ^∙ siHighestCommitCert) because it might be
+    -- same as siHighestQuorumCert -- so no need to check again
+    maybeS (self ^∙ sixxxHighestCommitCert) (pure unit) (` QuorumCert.verify ` validator)
+
+    maybeS (self ^∙ siHighestTimeoutCert)   (pure unit) (` TimeoutCertificate.verify ` validator)
+
   here' t = "SyncInfo" ∷ "verify" ∷ t
+
+verify = verify.step₀
 
 hasNewerCertificates : SyncInfo → SyncInfo → Bool
 hasNewerCertificates self other

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo.agda
@@ -28,7 +28,7 @@ verifyM : SyncInfo → ValidatorVerifier → LBFT (Either ErrLog Unit)
 verifyM self validator = pure (verify self validator)
 
 module verify (self : SyncInfo) (validator : ValidatorVerifier) where
-  step₀ step₁ step₂ step₃ step₄ step₅ : Either ErrLog Unit
+  step₀ step₁ step₂ step₃ step₄ step₅ step₆ : Either ErrLog Unit
   here' : List String.String → List String.String
 
   epoch = self ^∙ siHighestQuorumCert ∙ qcCertifiedBlock ∙ biEpoch
@@ -62,7 +62,9 @@ module verify (self : SyncInfo) (validator : ValidatorVerifier) where
     -- Note: do not use (self ^∙ siHighestCommitCert) because it might be
     -- same as siHighestQuorumCert -- so no need to check again
     maybeS (self ^∙ sixxxHighestCommitCert) (pure unit) (` QuorumCert.verify ` validator)
+    step₆
 
+  step₆ = do
     maybeS (self ^∙ siHighestTimeoutCert)   (pure unit) (` TimeoutCertificate.verify ` validator)
 
   here' t = "SyncInfo" ∷ "verify" ∷ t

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo/Properties.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo/Properties.agda
@@ -105,7 +105,21 @@ module verifyMSpec (self : SyncInfo) (validator : ValidatorVerifier) where
       ...| Right unit | [ R ]
          with QC.contract (self ^∙ siHighestQuorumCert) validator (Right unit) refl R
       ...| qcCon = qcCon , verify≡₄
-   ...| sivpHqcVer , verify≡₅ =
+   ...| sivpHqcVer , verify≡₅
+      with sivpHccVer verify≡₅
+      where
+      sivpHccVer : (SI.verify.step₅ self validator ≡ Right unit)
+                   → (maybeS (self ^∙ sixxxHighestCommitCert) Unit $ λ qc → QC.Contract qc validator)
+                     × SI.verify.step₆ self validator ≡ Right unit
+      sivpHccVer verify≡₅
+         with self ^∙ sixxxHighestCommitCert
+      ...| nothing = unit , verify≡₅
+      ...| just qc
+         with QuorumCert.verify  qc  validator | inspect
+              (QuorumCert.verify qc) validator
+      ...| Left _ | _ = absurd Left _ ≡ Right _ case verify≡₅ of λ ()
+      ...| Right unit | [ R ] = QC.contract qc validator (Right unit) refl R , verify≡₅
+   ...| sivpHccVer , verify≡₆ =
    -- TODO: continue case analysis for remaining fields
      record
      { sivpEp≡       = sivpEp≡
@@ -113,8 +127,8 @@ module verifyMSpec (self : SyncInfo) (validator : ValidatorVerifier) where
      ; sivpHqc≥Hcc   = sivpHqc≥Hcc
      ; sivpHqc≢empty = sivpHqc≢empty
      ; sivpHqcVer    = sivpHqcVer
-     ; sivpHccVer    = obm-dangerous-magic' "TODO"
-     -- ; sivpHtcVer = 
+     ; sivpHccVer    = sivpHccVer
+     -- ; sivpHtcVer =
      }
 
    contract : LBFT-weakestPre (SI.verifyM self validator) Contract pre

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo/Properties.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo/Properties.agda
@@ -7,6 +7,8 @@
 open import LibraBFT.Base.Types
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Properties.QuorumCert as QC
+import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert            as QuorumCert
 open import LibraBFT.Impl.Consensus.ConsensusTypes.SyncInfo as SI
 open import LibraBFT.Impl.Properties.Util
 open import LibraBFT.Impl.Types.BlockInfo as BI
@@ -27,15 +29,15 @@ module verifyMSpec (self : SyncInfo) (validator : ValidatorVerifier) where
 
   epoch = self ^∙ siHighestQuorumCert ∙ qcCertifiedBlock ∙ biEpoch
 
-  record SIVerifyProps (pre : RoundManager) (rmc : RoundManager-correct pre) : Set where
+  record SIVerifyProps (pre : RoundManager) : Set where
     field
       sivpEp≡       : epoch ≡ self ^∙ siHighestCommitCert ∙ qcCertifiedBlock ∙ biEpoch
-      sivpTcEp≡     : maybeS (self ^∙ siHighestTimeoutCert) Unit (\tc -> epoch ≡ tc ^∙ tcEpoch)
+      sivpTcEp≡     : maybeS (self ^∙ siHighestTimeoutCert) Unit $ λ tc -> epoch ≡ tc ^∙ tcEpoch
       sivpHqc≥Hcc   : (self ^∙ siHighestQuorumCert) [ _≥_ ]L self ^∙ siHighestCommitCert at qcCertifiedBlock ∙ biRound
       sivpHqc≢empty : self ^∙ siHighestCommitCert ∙ qcCommitInfo ≢ BI.empty
-      sivpHqcVer    : WithEC.MetaIsValidQC (α-EC (pre , rmc)) (self ^∙ siHighestQuorumCert)
-      sivpHccVer    : maybeS (self ^∙ sixxxHighestCommitCert) Unit (WithEC.MetaIsValidQC          (α-EC (pre , rmc)))
-      sivpHtcVer    : maybeS (self ^∙ siHighestTimeoutCert  ) Unit (WithEC.MetaIsValidTimeoutCert (α-EC (pre , rmc)))
+      sivpHqcVer    : QC.Contract (self ^∙ siHighestQuorumCert) validator
+      sivpHccVer    : maybeS (self ^∙ sixxxHighestCommitCert) Unit $ λ qc → QC.Contract qc validator
+      -- Waiting on TimeoutCertificate Contract : sivpHtcVer    : maybeS (self ^∙ siHighestTimeoutCert  ) Unit $ λ tc → {!!}
 
   module _ (pool : SentMessages) (pre : RoundManager) where
 
@@ -48,12 +50,12 @@ module verifyMSpec (self : SyncInfo) (validator : ValidatorVerifier) where
        -- Output
        noMsgOuts     : OutputProps.NoMsgs outs
        -- Syncing
-       syncResCorr   : r ≡ Right unit → ∀ rmc → SIVerifyProps pre rmc
+       syncResCorr   : r ≡ Right unit → SIVerifyProps pre
        -- Signatures
        -- TODO-2: What requirements on `self` are needed to show `QCProps.OutputQc∈RoundManager outs pre`
 
-   verifyCorrect : SI.verify self validator ≡ Right unit → (rmc : RoundManager-correct pre) → SIVerifyProps pre rmc
-   verifyCorrect verify≡ rmc
+   verifyCorrect : SI.verify self validator ≡ Right unit → SIVerifyProps pre
+   verifyCorrect verify≡
       with epoch ≟ self ^∙ siHighestCommitCert ∙ qcCertifiedBlock ∙ biEpoch
    ...| no  ep≢ = absurd (Left _ ≡ Right _) case verify≡ of λ ()
    ...| yes sivpEp≡
@@ -90,16 +92,29 @@ module verifyMSpec (self : SyncInfo) (validator : ValidatorVerifier) where
          with self ^∙ siHighestCommitCert ∙ qcCommitInfo ≟ BI.empty
       ...| no  ≢empty = ≢empty , verify≡₃
       ...| yes ≡empty = absurd Left _ ≡ Right _ case verify≡₃ of λ ()
-   ...| sivpHqc≢empty , verify≡₄ =
+   ...| sivpHqc≢empty , verify≡₄
+      with sivpHqcVer verify≡₄
+      where
+      sivpHqcVer : (SI.verify.step₄ self validator ≡ Right unit)
+                   → QC.Contract (self ^∙ siHighestQuorumCert) validator
+                     × SI.verify.step₅ self validator ≡ Right unit
+      sivpHqcVer verify≡₄
+         with  QuorumCert.verify (self ^∙ siHighestQuorumCert)  validator | inspect
+              (QuorumCert.verify (self ^∙ siHighestQuorumCert)) validator
+      ...| Left  _    | _ = absurd Left _ ≡ Right _ case verify≡₄ of λ ()
+      ...| Right unit | [ R ]
+         with QC.contract (self ^∙ siHighestQuorumCert) validator (Right unit) refl R
+      ...| qcCon = qcCon , verify≡₄
+   ...| sivpHqcVer , verify≡₅ =
    -- TODO: continue case analysis for remaining fields
      record
      { sivpEp≡       = sivpEp≡
      ; sivpTcEp≡     = sivpTcEp≡
      ; sivpHqc≥Hcc   = sivpHqc≥Hcc
      ; sivpHqc≢empty = sivpHqc≢empty
-     ; sivpHqcVer    = obm-dangerous-magic' "TODO"
+     ; sivpHqcVer    = sivpHqcVer
      ; sivpHccVer    = obm-dangerous-magic' "TODO"
-     ; sivpHtcVer    = obm-dangerous-magic' "TODO"
+     -- ; sivpHtcVer = 
      }
 
    contract : LBFT-weakestPre (SI.verifyM self validator) Contract pre

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -97,7 +97,7 @@ verifyAuthorM : Maybe Author → LBFT (Either ErrLog Unit)
 verifyAuthorM author = do
   vs ← use (lSafetyRules ∙ srValidatorSigner)
   maybeS vs (bail fakeErr) {-(ErrL (here' ["srValidatorSigner", "Nothing"]))-} $ λ validatorSigner →
-    maybeS
+    maybeS-RWST
       author
       (bail fakeErr) -- (ErrL (here' ["InvalidProposal", "No author found in the proposal"])))
       (\a ->

--- a/LibraBFT/ImplShared/Util/RWST/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/RWST/Syntax.agda
@@ -54,6 +54,22 @@ void m = do
   _ ← m
   pure unit
 
+{-
+Within the RWST monad, if and if-RWST are semantically interchangeable.
+Similarly for maybeS and maybe-RWST.
+
+The difference is in how proof obligations are generated
+- with the *-RWST variants generating new weakestPre obligations for each case.
+
+In some cases, this is helpful for structuring proofs, while in other cases it is
+unnecessary and introduces more structure to the proof without adding any benefit.
+
+A rule of thumb is that, if the "scrutinee" (whatever we are doing case analysis on,
+i.e., the first argument) is the value provided via >>= (RWST-bind) by a previous code block,
+then we already have a weakestPre proof obligation, so introducing additional ones via the
+*-RWST variants only creates more work and provides no additional benefit.
+-}
+
 -- Conditionals
 infix 1 ifM‖_
 ifM‖_ : Guards (RWST Ev Wr St A) → RWST Ev Wr St A


### PR DESCRIPTION
* Merge in `main`
* Change `SyncInfo.Contract` to propagate `QC.Contract` up, don't try to convert to abstract `IsValidQC` yet; we need to do that in context of `Preserves RoundManagerInv` because we need the `RoundManager-correct` to construct an abstract `EpochConfig`
* Similarly for `highestCommitCert` (except deal with `Maybe QuorumCert`)
* Move `SyncInfo.Properties` to `Properties.SyncInfo`, consistent with others
* Prove `ensureRoundAndSyncUpMSpec.contract`
