### PR TITLE
Reworked `qcVoteSigsSentB4` proof, progress on contract for `ensureRoundAndSyncUpM`

### DIFF
--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -3,7 +3,7 @@
    Copyright (c) 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
-
+{-# OPTIONS --allow-unsolved-metas #-}
 open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.Types
 open import LibraBFT.Concrete.System
@@ -58,7 +58,7 @@ module executeAndVoteMSpec (b : Block) where
       constructor mkContract
       field
         -- General properties / invariants
-        rmInv         : Preserves (RoundManagerInv pool) pre post
+        rmInv         : Preserves RoundManagerInv pre post
         noEpochChange : NoEpochChange pre post
         noMsgOuts     : OutputProps.NoMsgs outs
         -- Voting
@@ -104,8 +104,8 @@ module executeAndVoteMSpec (b : Block) where
           srP : Preserves SafetyRulesInv pre preUpdateBS
           srP = mkPreservesSafetyRulesInv (substSafetyDataInv refl)
 
-          invP₁ : Preserves (RoundManagerInv pool) pre preUpdateBS
-          invP₁ = mkPreservesRoundManagerInv id qcP id bsP srP
+          invP₁ : Preserves RoundManagerInv pre preUpdateBS
+          invP₁ = mkPreservesRoundManagerInv id id bsP srP
 
         contractBailSetBS : ∀ {e} outs → OutputProps.NoMsgs outs → Contract (Left e) preUpdateBS outs
         contractBailSetBS outs noMsgOuts =
@@ -183,7 +183,7 @@ module processProposalMSpec (proposal : Block) where
       constructor mkContract
       field
          -- General properties / invariants
-        rmInv         : Preserves (RoundManagerInv pool) pre post
+        rmInv         : Preserves RoundManagerInv pre post
         noEpochChange : NoEpochChange pre post
         noProposals   : OutputProps.NoProposals outs
         -- Voting
@@ -268,9 +268,9 @@ module processProposalMSpec (proposal : Block) where
                     srP : Preserves SafetyRulesInv st stUpdateRS
                     srP = mkPreservesSafetyRulesInv (substSafetyDataInv refl)
 
-                    rmInv₃ : Preserves (RoundManagerInv pool) pre stUpdateRS
+                    rmInv₃ : Preserves RoundManagerInv pre stUpdateRS
                     rmInv₃ = transPreservesRoundManagerInv rmInv₂
-                             (mkPreservesRoundManagerInv id qcP id bsP srP)
+                             (mkPreservesRoundManagerInv id id bsP srP)
 
     contract : ∀ Post → RWST-Post-⇒ Contract Post → LBFT-weakestPre (processProposalM proposal) Post pre
     contract Post pf = LBFT-⇒ Contract Post pf (processProposalM proposal) pre contract'
@@ -284,7 +284,7 @@ module syncUpMSpec
       constructor mkContract
       field
         -- General invariants / properties
-        rmInv         : Preserves (RoundManagerInv pool) pre post
+        rmInv         : Preserves RoundManagerInv pre post
         noEpochChange : NoEpochChange pre post
         noVoteOuts    : OutputProps.NoVotes outs
         -- Voting
@@ -315,19 +315,19 @@ module ensureRoundAndSyncUpMSpec
       constructor mkContract
       field
         -- General invariants / properties
-        rmInv         : Preserves (RoundManagerInv pool) pre post
+        rmInv         : Preserves RoundManagerInv pre post
         noEpochChange : NoEpochChange pre post
         noVoteOuts    : OutputProps.NoVotes outs
         -- Voting
         noVote        : VoteNotGenerated pre post true
         -- Signatures
-        outQcs∈RM     : QCProps.SyncInfoRequirements pool syncInfo → QCProps.OutputQc∈RoundManager outs post
+        outQcs∈RM     : QCProps.OutputQc∈RmOrMsg outs post {!!}
 
     contract'
       : LBFT-weakestPre (ensureRoundAndSyncUpM now messageRound syncInfo author helpRemote) Contract pre
     proj₁ (contract' ._ refl) _         =
-      mkContract (++-RoundManagerInv []) refl refl
-        (mkVoteNotGenerated refl refl) (const $ QCProps.NoMsgs⇒OutputQc∈RoundManager [] pre refl)
+      mkContract id refl refl
+        (mkVoteNotGenerated refl refl) {!!}
     proj₂ (contract' ._ refl) mrnd≥crnd = contract-step₁
       where
       contract-step₁
@@ -371,21 +371,22 @@ module processProposalMsgMSpec
       constructor mkContract
       field
         -- General invariants / properties
-        rmInv         : Preserves (RoundManagerInv pool) pre post
+        rmInv         : Preserves RoundManagerInv pre post
         noEpochChange : NoEpochChange pre post
         -- Voting
         voteAttemptCorrect : Voting.VoteAttemptCorrect pre post outs proposal
         -- Signatures
-        outQcs∈RM          : QCProps.MsgRequirements pool (P pm) → QCProps.OutputQc∈RoundManager outs post
+        outQcs∈RM : QCProps.OutputQc∈RmOrMsg outs pre (P pm)
+        qcSigsB4  : QCProps.MsgRequirements pool (P pm) → Preserves (QCProps.SigsForVotes∈Rm-SentB4 pool) pre post
 
     contract' : LBFT-weakestPre (processProposalMsgM now pm) Contract pre
     contract' rewrite processProposalMsgM≡ = contract
       where
       contractBail : ∀ outs → OutputProps.NoMsgs outs → Contract unit pre outs
-      contractBail outs nmo =
-        mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
-          (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs nmo))
-          (const $ QCProps.NoMsgs⇒OutputQc∈RoundManager outs pre nmo)
+      contractBail outs nmo = {!!}
+        -- mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
+        --   (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs nmo))
+        --   (const $ QCProps.NoMsgs⇒OutputQc∈RmOrMsg outs pre nmo)
 
       contract : LBFT-weakestPre step₀ Contract pre
       proj₁ contract ≡nothing = contractBail _ refl
@@ -403,18 +404,18 @@ module processProposalMsgMSpec
             where
             contractBailAfterSync : ∀ outs' → OutputProps.NoMsgs outs' → RWST-Post++ Contract outs unit st outs'
             contractBailAfterSync outs' noMsgs' =
-              mkContract rmInv noEpochChange vac outQcs∈RM'
+              mkContract rmInv noEpochChange vac {!!} {!!} -- outQcs∈RM'
               where
               vac : Voting.VoteAttemptCorrect pre st (outs ++ outs') proposal
               vac = Left (true , (Voting.mkVoteUnsentCorrect
                                    (OutputProps.++-NoVotes outs _ noVoteOuts (OutputProps.NoMsgs⇒NoVotes outs' noMsgs'))
                                    (Left noVote)))
 
-              outQcs∈RM' : QCProps.MsgRequirements pool (P pm) → QCProps.OutputQc∈RoundManager (outs ++ outs') st
-              outQcs∈RM' msgReq =
-                QCProps.++-OutputQc∈RoundManager
-                  (outQcs∈RM (QCProps.mkSyncInfoRequirements (P pm) msgReq inP))
-                  (QCProps.NoMsgs⇒OutputQc∈RoundManager outs' st noMsgs')
+              outQcs∈RM' : QCProps.MsgRequirements pool (P pm) → QCProps.OutputQc∈RmOrMsg (outs ++ outs') st (P pm)
+              outQcs∈RM' msgReq = {!!}
+                -- QCProps.++-OutputQc∈RmOrMsg
+                --   (outQcs∈RM (QCProps.mkSyncInfoRequirements (P pm) msgReq inP))
+                --   (QCProps.NoMsgs⇒OutputQc∈RmOrMsg outs' st noMsgs')
 
             pf-step₂' : (r : Either ErrLog Bool) → RWST-weakestPre-bindPost unit step₂ Contract r st outs
             pf-step₂' (Left e) ._ refl =
@@ -432,6 +433,7 @@ module processProposalMsgMSpec
                   (Voting.glue-VoteNotGenerated-VoteAttemptCorrect{outs₁ = outs}
                     noVote noVoteOuts voteAttemptCorrect')
                   (obm-dangerous-magic' "TODO")
+                  {!!}
 
     contract : ∀ Post → RWST-Post-⇒ Contract Post → LBFT-weakestPre (processProposalMsgM now pm) Post pre
     contract Post pf =

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -267,7 +267,7 @@ module constructAndSignVoteMSpec where
     constructor mkContract
     field
       -- General properties / invariants
-      rmInv          : Preserves (RoundManagerInv pool) pre post
+      rmInv          : Preserves RoundManagerInv pre post
       noEpochChange  : NoEpochChange pre post
       noMsgOuts      : OutputProps.NoMsgs outs
       -- Voting
@@ -346,8 +346,8 @@ module constructAndSignVoteMSpec where
             ...| just x  | [ lv≡ ] rewrite (trans (sym (Requirements.lv≡ reqs)) lv≡) =
               ≤-trans round≤ (≤-trans (≡⇒≤ (Requirements.lvr≡ reqs)) (<⇒≤ r>lvr))
 
-          invP₁ : Preserves (RoundManagerInv pool) pre preUpdatedSD
-          invP₁ = mkPreservesRoundManagerInv id qcP emP btip₁ srP
+          invP₁ : Preserves RoundManagerInv pre preUpdatedSD
+          invP₁ = mkPreservesRoundManagerInv id emP btip₁ srP
 
         -- Some lemmas
         module _ where
@@ -411,8 +411,8 @@ module constructAndSignVoteMSpec where
               srP₂ = mkPreservesSafetyRulesInv
                        (const $ mkSafetyDataInv (Requirements.es≡₂ reqs) (≡⇒≤ (cong (_^∙ bRound) pb≡vpb)))
 
-              invP₂ : Preserves (RoundManagerInv pool) pre preUpdatedSD₂
-              invP₂ = mkPreservesRoundManagerInv id qcP₂ emP btiP₂ srP₂
+              invP₂ : Preserves RoundManagerInv pre preUpdatedSD₂
+              invP₂ = mkPreservesRoundManagerInv id emP btiP₂ srP₂
 
     contract
       : ∀ pre pool Post

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -51,6 +51,7 @@ initRMSatisfiesInv =
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
 
 invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in an `Properties.Invariants` module
+                  -- TODO-2: This needs to be tightend so that the msgPool is of the previous system state (if there is one)
   : ∀ pid (pre : SystemState)
     → ReachableSystemState pre → RoundManagerInv (msgPool pre) (peerStates pre pid)
 invariantsCorrect pid pre@._ step-0 = initRMSatisfiesInv
@@ -69,10 +70,7 @@ invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest 
    = ++-RoundManagerInv _ initRMSatisfiesInv
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , P pm} m∈pool ini))))
    | yes refl
-  with handleProposalSpec.contract!-RoundManagerInv 0 pm (msgPool pre') (peerStates pre' pid) reqs
-  where
-  reqs : handleProposalSpec.Requirements 0 pm (msgPool pre') (peerStates pre' pid)
-  reqs = record { mSndr = sndr ; m∈pool = m∈pool }
+  with handleProposalSpec.Contract.rmInv $ handleProposalSpec.contract! 0 pm (msgPool pre') (peerStates pre' pid)
 ...| invPres
   rewrite override-target-≡{a = pid}{b = LBFT-post (handleProposal 0 pm) (peerStates pre' pid)}{f = peerStates pre'}
   = ++-RoundManagerInv _ (invPres (invariantsCorrect pid pre' preach))
@@ -90,16 +88,19 @@ invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest 
     TODO : RoundManagerInv (msgPool pre) (peerStates pre pid)
 
 qcVoteSigsSentB4
-  : ∀ pid (st : SystemState) {v qc vs pk}
-    → ReachableSystemState st
-    → qc QCProps.∈RoundManager (peerStates st pid)
-    → WithVerSig pk v
+  : ∀ pid (pre : SystemState) {ppost msgs}
+    → ReachableSystemState pre
+    → StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (ppost , msgs)
+    → ∀ {v qc vs pk}
+    → qc QCProps.∈RoundManager ppost
     → vs ∈ qcVotes qc → rebuildVote qc vs ≈Vote v
+    → WithVerSig pk v
     → ¬ (∈GenInfo-impl genesisInfo (proj₂ vs))
-    → MsgWithSig∈ pk (proj₂ vs) (msgPool st)
-qcVoteSigsSentB4 pid st rss qc∈rm sig vs∈qcvs ≈v ¬gen = qcsigsSentB4 qc∈rm sig vs∈qcvs ≈v ¬gen
+    → MsgWithSig∈ pk (proj₂ vs) (msgPool pre)
+qcVoteSigsSentB4 pid st rss sps qc∈rm vs∈qcvs ≈v sig ¬gen =
+  obm-dangerous-magic' "TODO: (waiting on: change to type signature of `invariantsCorrect`)"
   where
-  open RoundManagerInv (invariantsCorrect pid st rss)
+  open RoundManagerInv (invariantsCorrect pid _ (step-s rss (step-peer (step-honest sps))))
 
 lastVotedRound-mono
   : ∀ pid (pre : SystemState) {ppost} {msgs}
@@ -119,10 +120,7 @@ lastVotedRound-mono pid pre{ppost} preach ini (step-msg{_ , m} m∈pool ini₁) 
   hpPst  = LBFT-post (handleProposal 0 pm) hpPre
   hpOut  = LBFT-outs (handleProposal 0 pm) hpPre
 
-  hpReq : handleProposalSpec.Requirements 0 pm hpPool hpPre
-  hpReq = record { mSndr = _ ; m∈pool = m∈pool }
-
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre hpReq)
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
   open RoundManagerInvariants.RoundManagerInv (invariantsCorrect pid pre preach)
 
   module VoteOld (lv≡ : hpPre ≡L hpPst at pssSafetyData-rm ∙ sdLastVote) where

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -50,7 +50,7 @@ initRMSatisfiesInv =
   RoundManagerInvariants.mkRoundManagerInv initRM-correct initRM-qcs refl initRM-btInv
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
 
-invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in an `Properties.Invariants` module
+invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in a `Properties.Invariants` module
   : ∀ pid (pre : SystemState)
     → (preach : ReachableSystemState pre) → RoundManagerInv (Step*-prev-msgPool preach) (peerStates pre pid)
 invariantsCorrect pid pre@._ step-0 = initRMSatisfiesInv

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -45,47 +45,53 @@ postulate -- TODO-2: prove (waiting on: `initRM`)
   initRM-qcs     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM -- NOTE: all QCs in `initRM` come from the genesis info
   initRM-btInv   : BlockStoreInv initRM
 
-initRMSatisfiesInv : RoundManagerInvariants.RoundManagerInv [] initRM
+initRMSatisfiesInv : RoundManagerInv [] initRM
 initRMSatisfiesInv =
   RoundManagerInvariants.mkRoundManagerInv initRM-correct initRM-qcs refl initRM-btInv
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
 
 invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in an `Properties.Invariants` module
-                  -- TODO-2: This needs to be tightend so that the msgPool is of the previous system state (if there is one)
   : ∀ pid (pre : SystemState)
-    → ReachableSystemState pre → RoundManagerInv (msgPool pre) (peerStates pre pid)
+    → (preach : ReachableSystemState pre) → RoundManagerInv (Step*-prev-msgPool preach) (peerStates pre pid)
 invariantsCorrect pid pre@._ step-0 = initRMSatisfiesInv
-invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-cheat{pid'} cheatMsgConstraint)))
-  rewrite cheatStepDNMPeerStates₁{pid'}{pid}{pre = pre'} step unit
-  = ++-RoundManagerInv _ (invariantsCorrect pid pre' preach)
-invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-honest{pid'} sps)))
+
+invariantsCorrect pid _ (step-s{pre = pre'} preach' (step-peer (step-cheat{pid = pid'} cmc)))
+  rewrite cheatStepDNMPeerStates₁{pid'}{pid}{pre = pre'} (step-cheat{pre'} cmc) unit
+  |       Step*-prev-msgPool-lemma₁{st₂ = pre'} preach'
+  = ++-RoundManagerInv _ (invariantsCorrect pid pre' preach')
+
+invariantsCorrect pid _ (step-s{pre = pre'} preach' (step-peer (step-honest{pid'} sps)))
   with pid ≟ pid'
 ...| no pid≢pid'
   rewrite sym (pids≢StepDNMPeerStates{pre = pre'} sps pid≢pid')
-  = ++-RoundManagerInv _ (invariantsCorrect pid pre' preach)
-invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-init ini))))
+  |       Step*-prev-msgPool-lemma₁{st₂ = pre'} preach'
+  = ++-RoundManagerInv _ (invariantsCorrect pid pre' preach')
+invariantsCorrect pid _ (step-s{pre = pre'} preach (step-peer (step-honest (step-init ini))))
    | yes refl
   rewrite override-target-≡{a = pid}{b = initRM}{f = peerStates pre'}
-   |       sym $ ++-identityʳ (msgPool pre')
+   |      sym $ ++-identityʳ (msgPool pre')
+   |      Step*-prev-msgPool-lemma₁{st₂ = pre'} preach
    = ++-RoundManagerInv _ initRMSatisfiesInv
-invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , P pm} m∈pool ini))))
+invariantsCorrect pid _ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , P pm} m∈pool ini))))
    | yes refl
   with handleProposalSpec.Contract.rmInv $ handleProposalSpec.contract! 0 pm (msgPool pre') (peerStates pre' pid)
 ...| invPres
   rewrite override-target-≡{a = pid}{b = LBFT-post (handleProposal 0 pm) (peerStates pre' pid)}{f = peerStates pre'}
-  = ++-RoundManagerInv _ (invPres (invariantsCorrect pid pre' preach))
-invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , V vm} m∈pool ini))))
+  |       Step*-prev-msgPool-lemma₁{st₂ = pre'} preach
+  = invPres (++-RoundManagerInv _ (invariantsCorrect pid pre' preach))
+invariantsCorrect pid _ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , V vm} m∈pool ini))))
    | yes refl
   with handleVoteSpec.Contract.rmInv $ handleVoteSpec.contract! 0 vm (msgPool pre') (peerStates pre' pid)
 ...| invPres
   rewrite override-target-≡{a = pid}{b = LBFT-post (handleVote 0 vm) (peerStates pre' pid)}{f = peerStates pre'}
-  = ++-RoundManagerInv{pool = msgPool pre'} _ (invPres (invariantsCorrect pid pre' preach))
+  |       Step*-prev-msgPool-lemma₁{st₂ = pre'} preach
+  = invPres (++-RoundManagerInv _ (invariantsCorrect pid pre' preach))
 
-invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , C x} m∈pool ini))))
+invariantsCorrect pid pre@._ preach'@(step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , C x} m∈pool ini))))
    | yes refl = TODO
   where
   postulate -- TODO-3: prove (waiting on: `handle`)
-    TODO : RoundManagerInv (msgPool pre) (peerStates pre pid)
+    TODO : RoundManagerInv (Step*-prev-msgPool preach') (peerStates pre pid)
 
 qcVoteSigsSentB4
   : ∀ pid (pre : SystemState) {ppost msgs}
@@ -97,10 +103,13 @@ qcVoteSigsSentB4
     → WithVerSig pk v
     → ¬ (∈GenInfo-impl genesisInfo (proj₂ vs))
     → MsgWithSig∈ pk (proj₂ vs) (msgPool pre)
-qcVoteSigsSentB4 pid st rss sps qc∈rm vs∈qcvs ≈v sig ¬gen =
-  obm-dangerous-magic' "TODO: (waiting on: change to type signature of `invariantsCorrect`)"
+qcVoteSigsSentB4 pid st {ppost} rss sps{qc = qc} qc∈rm vs∈qcvs ≈v sig ¬gen
+  = qcsigsSentB4 qc∈rm' sig vs∈qcvs ≈v ¬gen
   where
   open RoundManagerInv (invariantsCorrect pid _ (step-s rss (step-peer (step-honest sps))))
+
+  qc∈rm' : qc QCProps.∈RoundManager (peerStates (StepPeer-post{pre = st} (step-honest sps)) pid)
+  qc∈rm' rewrite override-target-≡{a = pid}{b = ppost}{f = peerStates st} = qc∈rm
 
 lastVotedRound-mono
   : ∀ pid (pre : SystemState) {ppost} {msgs}

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -42,7 +42,7 @@ module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
   initRM-correct : RoundManager-correct initRM
-  initRM-qcs     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM -- TODO-1: This is not true (the definition of the predicate needs updating).
+  initRM-qcs     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM -- NOTE: all QCs in `initRM` come from the genesis info
   initRM-btInv   : BlockStoreInv initRM
 
 initRMSatisfiesInv : RoundManagerInvariants.RoundManagerInv [] initRM
@@ -154,10 +154,13 @@ lastVotedRound-mono pid pre{ppost} preach ini (step-msg{_ , m} m∈pool ini₁) 
   ...| Right (mkVoteNewGenerated lvr< lvr≡) = VoteNew.help lv≡v lvr< lvr≡
 
 -- Receiving a vote or commit message does not update the last vote
-...| V vm = ≡⇒≤ TODO
-  where
-  postulate -- TODO-2: prove (waiting on: `handle`)
-    TODO : Meta.getLastVoteRound (peerStates pre pid) ≡ Meta.getLastVoteRound (LBFT-post (handle pid (V vm) 0) (peerStates pre pid))
+...| V vm = ≡⇒≤ $ cong (maybe (_^∙ vRound) 0 ∘ (_^∙ sdLastVote)) noSDChange
+   where
+   hvPre = peerStates pre pid
+   hvPst = LBFT-post (handle pid (V vm) 0) hvPre
+
+   open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm (msgPool pre) hvPre)
+
 ...| C cm = ≡⇒≤ TODO
   where
   postulate -- TODO-2: prove (waiting on: `handle`)

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -48,12 +48,14 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
       constructor mkContract
       field
         -- General properties / invariants
-        rmInv              : Preserves (RoundManagerInv pool) pre post
+        rmInv              : Preserves RoundManagerInv pre post
         noEpochChange      : NoEpochChange pre post
         -- Voting
         voteAttemptCorrect : Voting.VoteAttemptCorrectWithEpochReq pre post outs (pm ^∙ pmProposal)
         -- Signatures
-        outQcs∈RM          : QCProps.MsgRequirements pool (P pm) → QCProps.OutputQc∈RoundManager outs post
+        outQcs∈RM : QCProps.OutputQc∈RmOrMsg outs pre (P pm)
+        qcSigsB4  : QCProps.MsgRequirements pool (P pm) → Preserves (QCProps.SigsForVotes∈Rm-SentB4 pool) pre post
+        -- QCProps.MsgRequirements pool (P pm)
 
     contract : LBFT-weakestPre (handleProposal now pm) Contract pre
     contract =
@@ -68,14 +70,17 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
       contractBail : ∀ outs → OutputProps.NoMsgs outs → Contract unit pre outs
       contractBail outs noMsgs =
         mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
-          vac outQcs∈RM
+          vac outQcs∈RM qcSigsB4
         where
         vac : Voting.VoteAttemptCorrectWithEpochReq pre pre outs (pm ^∙ pmProposal)
         vac = Voting.mkVoteAttemptCorrectWithEpochReq
                 (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs noMsgs)) tt
 
-        outQcs∈RM : QCProps.MsgRequirements pool (P pm) → QCProps.OutputQc∈RoundManager outs pre
-        outQcs∈RM _ = QCProps.NoMsgs⇒OutputQc∈RoundManager outs pre noMsgs
+        outQcs∈RM : QCProps.OutputQc∈RmOrMsg outs pre (P pm)
+        outQcs∈RM = QCProps.NoMsgs⇒OutputQc∈RmOrMsg outs pre (P pm) noMsgs
+
+        qcSigsB4 : QCProps.MsgRequirements pool (P pm) → Preserves (QCProps.SigsForVotes∈Rm-SentB4 pool) pre pre
+        qcSigsB4 _ = reflPreserves (QCProps.SigsForVotes∈Rm-SentB4 pool)
 
       contract-step₁ : Post-epvv (myEpoch , vv) pre []
       proj₁ (contract-step₁ (myEpoch@._ , vv@._) refl) (inj₁ e) pp≡Left =
@@ -93,8 +98,9 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
         ...| con rewrite pp≡Right = sym con
 
         pf : RWST-Post-⇒ (PPM.Contract pool pre) Contract
-        pf unit st outs (processProposalMsgMSpec.mkContract rmInv noEpochChange voteAttemptCorrect outQcs∈RM) =
-          mkContract rmInv noEpochChange vac outQcs∈RM
+        pf unit st outs (processProposalMsgMSpec.mkContract rmInv noEpochChange voteAttemptCorrect outQcs∈RM qcSigsB4) =
+          mkContract rmInv noEpochChange
+            vac outQcs∈RM qcSigsB4
           where
           vac : Voting.VoteAttemptCorrectWithEpochReq pre st outs (pm ^∙ pmProposal)
           vac = Voting.mkVoteAttemptCorrectWithEpochReq voteAttemptCorrect
@@ -103,7 +109,7 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
     contract! : LBFT-Post-True Contract (handleProposal now pm) pre
     contract! = LBFT-contract (handleProposal now pm) Contract pre contract
 
-    contract!-RoundManagerInv : LBFT-Post-True (λ r st outs → Preserves (RoundManagerInv pool) pre st) (handleProposal now pm) pre
+    contract!-RoundManagerInv : LBFT-Post-True (λ r st outs → Preserves RoundManagerInv pre st) (handleProposal now pm) pre
     contract!-RoundManagerInv rmInv = Contract.rmInv contract! rmInv
 
 module handleVoteSpec (now : Instant) (vm : VoteMsg) where
@@ -115,12 +121,14 @@ module handleVoteSpec (now : Instant) (vm : VoteMsg) where
       constructor mkContract
       field
         -- General properties / invariants
-        rmInv         : Preserves (RoundManagerInv pool) pre post
+        rmInv         : Preserves RoundManagerInv pre post
         noEpochChange : NoEpochChange pre post
         noSDChange    : NoSafetyDataChange pre post
         -- Output
         noVotes       : OutputProps.NoVotes outs
-        outQcs∈RM     : QCProps.MsgRequirements pool (V vm) → QCProps.OutputQc∈RoundManager outs post
+        -- Signatures
+        outQcs∈RM : QCProps.OutputQc∈RmOrMsg outs pre (V vm)
+        qcSigsB4  : QCProps.MsgRequirements pool (V vm) → Preserves (QCProps.SigsForVotes∈Rm-SentB4 pool) pre post
 
     postulate -- TODO-2: prove (waiting on: refinement of `Contract`)
       contract : LBFT-weakestPre (handleVote now vm) Contract pre

--- a/LibraBFT/Impl/Properties/Common.agda
+++ b/LibraBFT/Impl/Properties/Common.agda
@@ -65,8 +65,8 @@ availEpochsConsistent :
    → pcs4𝓔 pkvpf ≡ pcs4𝓔 pkvpf'
 availEpochsConsistent (mkPCS4PK _ (inGenInfo refl) _) (mkPCS4PK _ (inGenInfo refl) _) refl = refl
 
-postulate
-  uninitQcs∈Gen -- TODO-1: Prove (waiting on: complete definition of `initRM`)
+postulate -- TODO-1: Prove (waiting on: complete definition of `initRM`)
+  uninitQcs∈Gen
     : ∀ {pid qc vs}{st : SystemState}
       → ReachableSystemState st
       → initialised st pid ≡ uninitd
@@ -208,10 +208,16 @@ module ReachableSystemStateProps where
     open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre hpReq)
     open ≡-Reasoning
 
-  mws∈pool⇒epoch≡{pid}{v}{st = st} rss (step-msg{sndr , V vm} _ _) pcsfpk hpk sig ¬gen mws∈pool epoch≡ = TODO
+  mws∈pool⇒epoch≡{pid}{v}{st = st} rss (step-msg{sndr , V vm} _ _) pcsfpk hpk sig ¬gen mws∈pool epoch≡ = begin
+    hvPre ^∙ rmEpoch ≡⟨ noEpochChange ⟩
+    hvPos ^∙ rmEpoch ≡⟨ epoch≡ ⟩
+    v ^∙ vEpoch      ∎
     where
-    postulate -- TODO-3: prove (waiting on: epoch config changes)
-      TODO : peerStates st pid ^∙ rmEpoch ≡ v ^∙ vEpoch
+    hvPre = peerStates st pid
+    hvPos = LBFT-post (handleVote 0 vm) hvPre
+
+    open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm (msgPool st) hvPre)
+    open ≡-Reasoning
 
   mws∈pool⇒epoch≡{pid}{v}{st = st} rss (step-msg{sndr , C cm} _ _) pcsfpk hpk sig ¬gen mws∈pool epoch≡ = TODO
     where

--- a/LibraBFT/Impl/Properties/Common.agda
+++ b/LibraBFT/Impl/Properties/Common.agda
@@ -202,10 +202,7 @@ module ReachableSystemStateProps where
     hpPre  = peerStates st pid
     hpPos  = LBFT-post (handleProposal 0 pm) hpPre
 
-    hpReq : handleProposalSpec.Requirements 0 pm hpPool hpPre
-    hpReq = record { mSndr = _ ; m∈pool = m∈pool }
-
-    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre hpReq)
+    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
     open ≡-Reasoning
 
   mws∈pool⇒epoch≡{pid}{v}{st = st} rss (step-msg{sndr , V vm} _ _) pcsfpk hpk sig ¬gen mws∈pool epoch≡ = begin

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -50,13 +50,13 @@ module OutputProps where
 
     NoMsgs⇒× : NoMsgs → NoProposals × NoVotes × NoSyncInfos
     proj₁ (NoMsgs⇒× noMsgs) =
-      filter-∪?-[]₁ outs isBroadcastProposal? _
-        (filter-∪?-[]₁ outs _ _ noMsgs)
+      filter-∪?-[]₁ outs isBroadcastProposal? _ noMsgs
     proj₁ (proj₂ (NoMsgs⇒× noMsgs)) =
-      filter-∪?-[]₂ outs _ isSendVote? noMsgs
+      filter-∪?-[]₂ outs _ isSendVote?
+        (filter-∪?-[]₂ outs _ _ noMsgs)
     proj₂ (proj₂ (NoMsgs⇒× noMsgs)) =
-      filter-∪?-[]₂ outs _ isBroadcastSyncInfo?
-        (filter-∪?-[]₁ outs _ _ noMsgs)
+      filter-∪?-[]₁ outs isBroadcastSyncInfo? _
+        (filter-∪?-[]₂ outs _ _ noMsgs)
 
     NoMsgs⇒NoProposals : NoMsgs → NoProposals
     NoMsgs⇒NoProposals = proj₁ ∘ NoMsgs⇒×
@@ -99,6 +99,14 @@ module QCProps where
   OutputQc∈RoundManager : List Output → RoundManager → Set
   OutputQc∈RoundManager outs rm =
     All (λ out → ∀ qc nm → qc QC∈NM nm → nm Msg∈Out out → qc ∈RoundManager rm) outs
+
+  NoMsgs⇒OutputQc∈RoundManager : ∀ outs rm → OutputProps.NoMsgs outs → OutputQc∈RoundManager outs rm
+  NoMsgs⇒OutputQc∈RoundManager outs rm noMsgs =
+    All-map help (noneOfKind⇒All¬ outs _ noMsgs)
+    where
+    help : ∀ {out : Output} → ¬ IsOutputMsg out → ∀ qc nm → qc QC∈NM nm → nm Msg∈Out out → qc ∈RoundManager rm
+    help ¬msg qc .(P _) qc∈m inBP = ⊥-elim (¬msg (Left tt))
+    help ¬msg qc .(V _) qc∈m inSV = ⊥-elim (¬msg (Right (Right tt)))
 
   SigForVote∈Rm-SentB4 : Vote → PK → QuorumCert → RoundManager → SentMessages → Set
   SigForVote∈Rm-SentB4 v pk qc rm pool =

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -64,14 +64,14 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach sps@(step-msg{sndr , nm} m∈
   nmSentQcs∈RM : (nm1 : NetworkMsg) → nm1 ≡ nm → QCProps.OutputQc∈RoundManager hpOut hpPst
   nmSentQcs∈RM (P pm) refl = outQcs∈RM outQcReq
     where
-    outQcReq : handleProposalSpec.OutQcs.Requirements 0 pm hpPool hpPre
-    outQcReq = handleProposalSpec.OutQcs.mkRequirements _ m∈pool
+    outQcReq : QCProps.MsgRequirements hpPool (P pm)
+    outQcReq = QCProps.mkMsgRequirements _ m∈pool
 
     open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
   nmSentQcs∈RM (V vm) refl = outQcs∈RM outQcReq
     where
-    outQcReq : handleVoteSpec.OutQcs.Requirements 0 vm hpPool
-    outQcReq = handleVoteSpec.OutQcs.mkRequirements _ m∈pool
+    outQcReq : QCProps.MsgRequirements hpPool (V vm)
+    outQcReq = QCProps.mkMsgRequirements _ m∈pool
 
     open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hpPool hpPre)
   nmSentQcs∈RM (C cm) refl = obm-dangerous-magic' "Waiting on handleCommitSpec"
@@ -85,7 +85,6 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach sps@(step-msg{sndr , nm} m∈
     sigSentB4 : MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
     sigSentB4 rewrite cong _vSignature v≈rbld =
       qcVoteSigsSentB4 pid pre preach sps qc∈rm vs∈qc v≈rbld sig ¬gen
-      -- qcVoteSigsSentB4 pid pre{v}{qc = qc}{vs}{pk} preach qc∈rm sig vs∈qc v≈rbld ¬gen
 
 newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vote∈vm m∈outs sig hpk ¬gen ¬msb4
   with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid)

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -37,7 +37,7 @@ open        ParamsWithInitAndHandlers InitAndHandlers
 open import LibraBFT.ImplShared.Util.HashCollisions InitAndHandlers
 
 open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers
-                               PeerCanSignForPK (λ {st} {part} {pk} → PeerCanSignForPK-stable {st} {part} {pk})
+                               PeerCanSignForPK PeerCanSignForPK-stable
 open        Structural impl-sps-avp
 
 -- This module proves the two "VotesOnce" proof obligations for our handler.

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -53,20 +53,21 @@ newVote⇒lv≡
     → Meta-Honest-PK pk → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
     → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
     → LastVoteIs s' v
-newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach (step-msg{sndr , nm} m∈pool ini) (vote∈qc{vs}{qc} vs∈qc v≈rbld qc∈m) m∈acts sig hpk ¬gen ¬msb4 =
+newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach sps@(step-msg{sndr , nm} m∈pool ini) (vote∈qc{vs}{qc} vs∈qc v≈rbld qc∈m) m∈acts sig hpk ¬gen ¬msb4 =
   ⊥-elim (¬msb4 $ sigSentB4 nm refl)
   where
   hpPool = msgPool pre
   hpPre  = peerStates pre pid
   hpOut  = LBFT-outs (handle pid nm 0) hpPre
+  hpPst  = LBFT-post (handle pid nm 0) hpPre
 
-  nmSentQcs∈RM : (nm1 : NetworkMsg) → nm1 ≡ nm → QCProps.OutputQc∈RoundManager hpOut hpPre
-  nmSentQcs∈RM (P pm) refl = outQcs∈RM
+  nmSentQcs∈RM : (nm1 : NetworkMsg) → nm1 ≡ nm → QCProps.OutputQc∈RoundManager hpOut hpPst
+  nmSentQcs∈RM (P pm) refl = outQcs∈RM outQcReq
     where
-    hpReq : handleProposalSpec.Requirements 0 pm hpPool hpPre
-    hpReq = record { mSndr = _ ; m∈pool = m∈pool }
+    outQcReq : handleProposalSpec.OutQcs.Requirements 0 pm hpPool hpPre
+    outQcReq = handleProposalSpec.OutQcs.mkRequirements _ m∈pool
 
-    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre hpReq)
+    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
   nmSentQcs∈RM (V vm) refl = outQcs∈RM outQcReq
     where
     outQcReq : handleVoteSpec.OutQcs.Requirements 0 vm hpPool
@@ -76,17 +77,18 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach (step-msg{sndr , nm} m∈pool
   nmSentQcs∈RM (C cm) refl = obm-dangerous-magic' "Waiting on handleCommitSpec"
 
   module _ (nm1 : NetworkMsg) (nm≡ : nm1 ≡ nm) where
-    qc∈rm : qc QCProps.∈RoundManager hpPre
+    qc∈rm : qc QCProps.∈RoundManager hpPst
     qc∈rm
       with sendMsg∈actions{hpOut}{st = hpPre} m∈acts
     ...| out , out∈hpOut , m∈out = All-lookup (nmSentQcs∈RM nm1 nm≡) out∈hpOut qc m qc∈m m∈out
 
     sigSentB4 : MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
     sigSentB4 rewrite cong _vSignature v≈rbld =
-      qcVoteSigsSentB4 pid pre{v}{qc = qc}{vs}{pk} preach qc∈rm sig vs∈qc v≈rbld ¬gen
+      qcVoteSigsSentB4 pid pre preach sps qc∈rm vs∈qc v≈rbld sig ¬gen
+      -- qcVoteSigsSentB4 pid pre{v}{qc = qc}{vs}{pk} preach qc∈rm sig vs∈qc v≈rbld ¬gen
 
 newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vote∈vm m∈outs sig hpk ¬gen ¬msb4
-  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid) (handleProposalSpec.mkRequirements sndr m∈pool)
+  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid)
 ...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , voteUnsent)) sdEpoch≡?) _ =
   ⊥-elim (¬voteUnsent voteUnsent)
   where
@@ -276,7 +278,7 @@ sameERasLV⇒sameId{pid = .pid“}{pid'}{pk} (step-s{pre = pre} preach step@(ste
   -- Definitions
   hpPool = msgPool pre
   hpPre  = peerStates pre pid“
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre (handleProposalSpec.mkRequirements _ pm∈pool))
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
   hpPos  = LBFT-post (handleProposal 0 pm) hpPre
   hpOuts = LBFT-outs (handleProposal 0 pm) hpPre
 
@@ -369,7 +371,7 @@ sameERasLV⇒sameId{.pid“}{pid'}{pk} (step-s{pre = pre} preach step@(step-peer
   hpPre  = peerStates pre pid“
   rmInv  = invariantsCorrect pid“ pre preach
   open RoundManagerInvariants.RoundManagerInv (invariantsCorrect pid“ pre preach)
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre (handleProposalSpec.mkRequirements sndr m∈pool))
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
     renaming (rmInv to rmInvP)
   hpPos  = LBFT-post (handleProposal 0 pm) hpPre
   hpOuts = LBFT-outs (handleProposal 0 pm) hpPre
@@ -549,7 +551,7 @@ votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr
   postulate -- TODO-2: prove (waiting on: lemma that QC votes have been sent before)
     TODO : v' [ _<_ ]L v at vRound ⊎ Common.VoteForRound∈ InitAndHandlers 𝓔 pk (v ^∙ vRound) (v ^∙ vEpoch) (v ^∙ vProposedId) (msgPool pre)
 votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈outs sig ¬gen ¬msb pcspkv v'⊂m' m'∈pool sig' ¬gen' eid≡
-  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid) (handleProposalSpec.mkRequirements sndr m∈pool)
+  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid)
 ...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?) _ =
   ⊥-elim (sendVote∉actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym noVoteMsgOuts) m∈outs)
 ...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?) _
@@ -658,7 +660,7 @@ votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v
   hpPool = msgPool pre
   hpPre  = peerStates pre pid
   hpOut  = LBFT-outs (handleProposal 0 pm) hpPre
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre (handleProposalSpec.mkRequirements sndr m“∈pool))
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
 
   v≡v' : v ≡ v'
   v≡v'

--- a/LibraBFT/ImplShared/Interface/Output.agda
+++ b/LibraBFT/ImplShared/Interface/Output.agda
@@ -89,7 +89,7 @@ module LibraBFT.ImplShared.Interface.Output where
   IsOutputMsg : Output → Set
   IsOutputMsg = IsBroadcastProposal ∪ IsBroadcastSyncInfo ∪ IsSendVote
 
-  isOutputMsg? = (isBroadcastProposal? ∪? isBroadcastSyncInfo?) ∪? isSendVote?
+  isOutputMsg? = isBroadcastProposal? ∪? (isBroadcastSyncInfo? ∪? isSendVote?)
 
   data _Msg∈Out_ : NetworkMsg → Output → Set where
     inBP : ∀ {pm pids} → P pm Msg∈Out BroadcastProposal pm pids

--- a/LibraBFT/Lemmas.agda
+++ b/LibraBFT/Lemmas.agda
@@ -75,6 +75,24 @@ module LibraBFT.Lemmas where
  filter-∪?-[]₂ (x ∷ xs) p q () | no proof₁ | yes proof₂
  filter-∪?-[]₂ (x ∷ xs) p q () | yes proof
 
+ noneOfKind⇒¬Any
+   : ∀ {a p} {A : Set a} {P : A → Set p}
+       xs (p : (a : A) → Dec (P a))
+     → NoneOfKind xs p
+     → ¬ Any P xs
+ noneOfKind⇒¬Any (x ∷ xs) p none ∈xs
+    with p x
+ noneOfKind⇒¬Any (x ∷ xs) p none (here   px) | no ¬px = ¬px px
+ noneOfKind⇒¬Any (x ∷ xs) p none (there ∈xs) | no ¬px =
+   noneOfKind⇒¬Any xs p none ∈xs
+
+ noneOfKind⇒All¬
+   : ∀ {a p} {A : Set a} {P : A → Set p}
+       xs (p : (a : A) → Dec (P a))
+     → NoneOfKind xs p
+     → All (¬_ ∘ P) xs
+ noneOfKind⇒All¬ xs p none = ¬Any⇒All¬ xs (noneOfKind⇒¬Any xs p none)
+
  data All-vec {ℓ} {A : Set ℓ} (P : A → Set ℓ) : ∀ {n} → Vec {ℓ} A n → Set (Level.suc ℓ) where
    []  : All-vec P []
    _∷_ : ∀ {x n} {xs : Vec A n} (px : P x) (pxs : All-vec P xs) → All-vec P (x ∷ xs)

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -86,12 +86,13 @@ module LibraBFT.Prelude where
 
   open import Data.List.Relation.Unary.All
     using (All; []; _∷_)
-    renaming (head to All-head; tail to All-tail;
-              lookup to All-lookup; tabulate to All-tabulate;
-              reduce to All-reduce)
+    renaming (head     to All-head;   tail     to All-tail;
+              lookup   to All-lookup; tabulate to All-tabulate;
+              reduce   to All-reduce; map      to All-map)
     public
 
   open import Data.List.Relation.Unary.All.Properties
+    hiding   (All-map)
     renaming ( tabulate⁻ to All-tabulate⁻
              ; tabulate⁺ to All-tabulate⁺
              ; map⁺      to All-map⁺
@@ -241,12 +242,12 @@ module LibraBFT.Prelude where
     public
 
 
-  module _ {ℓ : Level} {A : Set} where
-    NoneOfKind : ∀ {P : A → Set ℓ} → List A → (p : (a : A) → Dec (P a)) → Set
+  module _ {ℓA} {A : Set ℓA} where
+    NoneOfKind : ∀ {ℓ} {P : A → Set ℓ} → List A → (p : (a : A) → Dec (P a)) → Set ℓA
     NoneOfKind xs p = List-filter p xs ≡ []
 
     postulate -- TODO-1: Replace with or prove using library properties?  Move to Lemmas?
-      NoneOfKind⇒ : ∀ {P : A → Set ℓ} {Q : A → Set ℓ} {xs : List A}
+      NoneOfKind⇒ : ∀ {ℓ} {P : A → Set ℓ} {Q : A → Set ℓ} {xs : List A}
                   → (p : (a : A) → Dec (P a))
                   → {q : (a : A) → Dec (Q a)}
                   → (∀ {a} → P a → Q a)  -- TODO-1: Use proper notation (Relation.Unary?)

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -97,6 +97,7 @@ module LibraBFT.Prelude where
              ; tabulate⁺ to All-tabulate⁺
              ; map⁺      to All-map⁺
              ; map⁻      to All-map⁻
+             ; ++⁺       to All-++
              )
     public
 

--- a/LibraBFT/Yasm/System.agda
+++ b/LibraBFT/Yasm/System.agda
@@ -313,15 +313,6 @@ module LibraBFT.Yasm.System
                → Step pre (StepPeer-post pstep)
 
 
-   stepOuts : ∀ {st₁ st₂} → Step st₁ st₂ → List (LYT.Action Msg)
-   stepOuts (step-peer{outs = outs} pstep) = outs
-
-   stepPid : ∀ {st₁ st₂} → Step st₁ st₂ → Maybe PeerId
-   stepPid (step-peer{pid} pstep) = just pid
-
-   stepSentMessages : ∀ {st₁ st₂} → Step st₁ st₂ → SentMessages
-   stepSentMessages step = maybe (λ pid → actionsToSentMessages pid (stepOuts step)) [] (stepPid step)
-
    msgs-stable : ∀ {pre : SystemState} {post : SystemState} {m}
                → (theStep : Step pre post)
                → m ∈ msgPool pre
@@ -372,26 +363,6 @@ module LibraBFT.Yasm.System
                    → peerStates (StepPeer-post {pre = st} (step-honest stP)) pid ≡ s
                    → s ≡ s'
    peerStatePostSt _ _ ps≡s = trans (sym ps≡s) override-target-≡
-
-   Step*-prev
-     : ∀ {st₁ st₂}
-       → Step* st₁ st₂
-       → (∃[ st' ] Step* st₁ st') × SentMessages
-   Step*-prev step-0 = (_ , step-0) , []
-   Step*-prev (step-s {pre = pre} steps (step-peer{pid}{outs = outs} pstep)) =
-     (pre , steps) , actionsToSentMessages pid outs
-
-   Step*-prev-msgPool : ∀ {st₁ st₂} → Step* st₁ st₂ → SentMessages
-   Step*-prev-msgPool = msgPool ∘ proj₁ ∘ proj₁ ∘ Step*-prev
-
-   Step*-prev-acts : ∀ {st₁ st₂} → Step* st₁ st₂ → SentMessages
-   Step*-prev-acts = proj₂ ∘ Step*-prev
-
-   Step*-prev-msgPool-lemma₁
-     : ∀ {st₁ st₂} (steps : Step* st₁ st₂)
-       → msgPool st₂ ≡ Step*-prev-acts steps ++ Step*-prev-msgPool steps
-   Step*-prev-msgPool-lemma₁ step-0 = refl
-   Step*-prev-msgPool-lemma₁ (step-s steps (step-peer pstep)) = refl
 
    Step*-trans : ∀ {st st' st''}
                → Step* st st'


### PR DESCRIPTION
This PR clarifies what I meant by my earlier comment that the message pool mentioned in the type of `RoundManagerInv`, in the proof of `invariantsCorrect`, should be the pool _prior_ to the last step of the system. It also contains progress and some cleanup for the parts of the peer handler contracts used to prove `qcVoteSigsSentB4`