### PR TITLE
NeedFetch aka "catchup"

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockRetriever.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockRetriever.agda
@@ -1,0 +1,14 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+
+module LibraBFT.Impl.Consensus.BlockStorage.BlockRetriever where
+
+postulate
+  retrieveBlockForQCM : BlockRetriever → QuorumCert → U64 → LBFT (Either ErrLog (List Block))

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -78,6 +78,12 @@ commitM finalityProof = do
 
 ------------------------------------------------------------------------------
 
+postulate
+  rebuildM : RootInfo → RootMetadata → List Block → List QuorumCert
+           → LBFT (Either ErrLog Unit)
+
+------------------------------------------------------------------------------
+
 executeAndInsertBlockM : Block → LBFT (Either ErrLog ExecutedBlock)
 executeAndInsertBlockM b = do
   bs ← use lBlockStore
@@ -177,6 +183,9 @@ insertTimeoutCertificateM tc = do
         ok unit
 
 ------------------------------------------------------------------------------
+
+blockExists : HashValue → BlockStore → Bool
+blockExists hv bs = Map.kvm-member hv (bs ^∙ bsInner ∙ btIdToBlock)
 
 getBlock hv bs = btGetBlock hv (bs ^∙ bsInner)
 

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -129,7 +129,7 @@ hereFQCM' t = "SyncManager" ∷ "fetchQuorumCertM" ∷ t
 
 syncToHighestCommitCertM highestCommitCert retriever = do
   bs ← use lBlockStore
-  eitherS (needSyncForQuorumCert highestCommitCert bs) bail $ λ b →
+  eitherS-RWST (needSyncForQuorumCert highestCommitCert bs) bail $ λ b →
     if not b
       then ok unit
       else

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -4,14 +4,17 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore   as BlockStore
-import      LibraBFT.Impl.Consensus.BlockStorage.BlockTree    as BlockTree
-open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote       as Vote
+open import LibraBFT.Impl.Consensus.BlockStorage.BlockRetriever as BlockRetriever
+open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore     as BlockStore
+import      LibraBFT.Impl.Consensus.BlockStorage.BlockTree      as BlockTree
+open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote         as Vote
 open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
+------------------------------------------------------------------------------
+import      Data.String                                       as String
 
 module LibraBFT.Impl.Consensus.BlockStorage.SyncManager where
 
@@ -19,21 +22,35 @@ data NeedFetchResult : Set where
   QCRoundBeforeRoot QCAlreadyExist QCBlockExist NeedFetch : NeedFetchResult
 
 ------------------------------------------------------------------------------
-postulate
 
-  needFetchForQuorumCert
-    : QuorumCert → BlockStore
-    → Either ErrLog NeedFetchResult
+fastForwardSyncM         : QuorumCert → BlockRetriever → LBFT (Either ErrLog RecoveryData)
+fetchQuorumCertM         : QuorumCert → BlockRetriever → LBFT (Either ErrLog Unit)
+insertQuorumCertM        : QuorumCert → BlockRetriever → LBFT (Either ErrLog Unit)
+syncToHighestCommitCertM : QuorumCert → BlockRetriever → LBFT (Either ErrLog Unit)
 
-  fetchQuorumCertM
-    : QuorumCert → BlockRetriever
-    → LBFT (Either ErrLog Unit)
+------------------------------------------------------------------------------
 
-  syncToHighestCommitCertM
-    : QuorumCert → BlockRetriever
-    → LBFT (Either ErrLog Unit)
+needSyncForQuorumCert : QuorumCert → BlockStore → Either ErrLog Bool
+needSyncForQuorumCert qc bs = maybeS (bs ^∙ bsRoot) (Left fakeErr) {-bsRootErrL here-} $ λ btr → Right
+  (not (  BlockStore.blockExists (qc ^∙ qcCommitInfo ∙ biId) bs
+        ∨ ⌊ btr ^∙ ebRound ≥?ℕ qc ^∙ qcCommitInfo ∙ biRound ⌋ ))
+ where
+  here' : List String.String → List String.String
+  here' t = "SyncManager" ∷ "needSyncForQuorumCert" ∷ t
 
-insertQuorumCertM : QuorumCert → BlockRetriever → LBFT (Either ErrLog Unit)
+needFetchForQuorumCert : QuorumCert → BlockStore → Either ErrLog NeedFetchResult
+needFetchForQuorumCert qc bs = maybeS (bs ^∙ bsRoot) (Left fakeErr) {-bsRootErrL here-} $ λ btr →
+ grd‖ qc ^∙ qcCertifiedBlock ∙ biRound <?ℕ btr ^∙ ebRound                           ≔
+      Right QCRoundBeforeRoot
+    ‖ is-just (BlockStore.getQuorumCertForBlock (qc ^∙ qcCertifiedBlock ∙ biId) bs) ≔
+      Right QCAlreadyExist
+    ‖ BlockStore.blockExists (qc ^∙ qcCertifiedBlock ∙ biId) bs                     ≔
+      Right QCBlockExist
+    ‖ otherwise≔
+      Right NeedFetch
+ where
+  here' : List String.String → List String.String
+  here' t = "SyncManager" ∷ "needFetchForQuorumCert" ∷ t
 
 ------------------------------------------------------------------------------
 
@@ -72,3 +89,65 @@ insertQuorumCertM qc retriever = do
       else
         ok unit
 
+------------------------------------------------------------------------------
+
+loop1     : BlockRetriever → List Block → QuorumCert → LBFT (Either ErrLog (List Block))
+loop2     : List Block → LBFT (Either ErrLog Unit)
+hereFQCM' : List String.String → List String.String
+
+fetchQuorumCertM qc retriever =
+  loop1 retriever [] qc ∙?∙ loop2
+
+-- TODO-1 PROVE IT TERMINATES
+{-# TERMINATING #-}
+loop1 retriever pending retrieveQC = do
+    bs ← use lBlockStore
+    if-RWST (BlockStore.blockExists (retrieveQC ^∙ qcCertifiedBlock ∙ biId) bs)
+      then ok pending
+      else
+        BlockRetriever.retrieveBlockForQCM retriever retrieveQC 1
+          ∙^∙ withErrCtx (hereFQCM' ("loop1" ∷ [])) ∙?∙ λ where
+            (block ∷ []) → loop1 retriever (block ∷ pending) (block ^∙ bQuorumCert)
+            _ -> do
+              -- let msg = here ["loop1", "retrieveBlockForQCM returned more than asked for"]
+              -- logErrExit msg
+              bail fakeErr -- (ErrL msg)
+
+loop2 = λ where
+    [] -> ok unit
+    (block ∷ bs) →
+      BlockStore.insertSingleQuorumCertM (block ^∙ bQuorumCert)
+        ∙^∙ withErrCtx (hereFQCM' ("loop2" ∷ [])) ∙?∙ \_ ->
+          BlockStore.executeAndInsertBlockM block ∙?∙ \_ ->
+            loop2 bs
+
+hereFQCM' t = "SyncManager" ∷ "fetchQuorumCertM" ∷ t
+
+------------------------------------------------------------------------------
+
+syncToHighestCommitCertM highestCommitCert retriever = do
+  bs ← use lBlockStore
+  pure true >>= λ b → -- TODO: eitherS (needSyncForQuorumCert highestCommitCert bs) (λ _ → bail fakeErr) $ λ b →
+    if-RWST not b
+      then ok unit
+      else
+        fastForwardSyncM highestCommitCert retriever ∙?∙ \rd -> do
+          -- logInfoL lSI (here ["fastForwardSyncM success", lsRD rd])
+          BlockStore.rebuildM (rd ^∙ rdRoot) (rd ^∙ rdRootMetadata) (rd ^∙ rdBlocks) (rd ^∙ rdQuorumCerts)
+            ∙^∙ withErrCtx (here' []) ∙?∙ λ _ -> do
+            when (highestCommitCert ^∙ qcEndsEpoch) $ do
+              me ← use (lRoundManager ∙ rmObmMe)
+              -- TODO-1 : Epoch Change Proof
+              -- let ecp = EpochChangeProof ∙ new [highestCommitCert ^∙ qcLedgerInfo] False
+              -- logInfo lEC (InfoL (here ["fastForwardSyncM detected an EpochChange"]))
+              -- act (BroadcastEpochChangeProof lEC ecp (mkNodesInOrder1 me))
+              RWST-return unit -- TODO : why does not "ok unit" work?
+            ok unit
+ where
+  here' : List String.String → List String.String
+  here' t = "SyncManager" ∷ "syncToHighestCommitCertM" ∷ t
+
+------------------------------------------------------------------------------
+
+fastForwardSyncM highestCommitCert retriever = do
+  bail fakeErr -- TODO-1 : IMPLEMENT

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -129,9 +129,8 @@ hereFQCM' t = "SyncManager" ∷ "fetchQuorumCertM" ∷ t
 
 syncToHighestCommitCertM highestCommitCert retriever = do
   bs ← use lBlockStore
-  pure true >>= λ b →
-  -- eitherS (needSyncForQuorumCert highestCommitCert bs) (λ _ → bail fakeErr) $ λ b →
-    if-RWST not b
+  eitherS (needSyncForQuorumCert highestCommitCert bs) bail $ λ b →
+    if not b
       then ok unit
       else
         fastForwardSyncM highestCommitCert retriever ∙?∙ \rd -> do

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -153,15 +153,15 @@ syncToHighestCommitCertM highestCommitCert retriever = do
 ------------------------------------------------------------------------------
 
 fastForwardSyncM highestCommitCert retriever = do
-  logInfo fakeInfo -- (here [ "start state sync with peer", lsA (retriever^.brPreferredPeer)
-                   --       , "to block", lsBI (highestCommitCert^.qcCommitInfo) ])
+  logInfo fakeInfo -- (here' [ "start state sync with peer", lsA (retriever^.brPreferredPeer)
+                   --        , "to block", lsBI (highestCommitCert^.qcCommitInfo) ])
   BlockRetriever.retrieveBlockForQCM retriever highestCommitCert 3 ∙?∙ λ where
     blocks@(_ ∷ _ ∷ i ∷ []) ->
       if highestCommitCert ^∙ qcCommitInfo ∙ biId /= i ^∙ bId
-      then bail fakeErr -- (here [ "should have a 3-chain"
-                        --      , lsHV (highestCommitCert^.qcCommitInfo.biId), lsHV (i^.bId) ]))
+      then bail fakeErr -- (here' [ "should have a 3-chain"
+                        --        , lsHV (highestCommitCert^.qcCommitInfo.biId), lsHV (i^.bId) ]))
       else continue blocks
-    x -> bail fakeErr -- (here ["incorrect number of blocks returned", show (length x)]))
+    x -> bail fakeErr -- (here' ["incorrect number of blocks returned", show (length x)]))
 
  where
 
@@ -176,35 +176,30 @@ fastForwardSyncM highestCommitCert retriever = do
 
   continue : List Block → LBFT (Either ErrLog RecoveryData)
   continue blocks = do
-    logInfo fakeInfo -- (here (["received blocks"] <> fmap (lsHV . (^.bId)) blocks))
+    logInfo fakeInfo -- (here' (["received blocks"] <> fmap (lsHV . (^.bId)) blocks))
     let quorumCerts = highestCommitCert ∷ fmap (_^∙ bQuorumCert) blocks
-    logInfo fakeInfo -- (here (["quorumCerts"]     <> fmap (lsHV . (^.qcCommitInfo.biId)) quorumCerts))
+    logInfo fakeInfo -- (here' (["quorumCerts"]     <> fmap (lsHV . (^.qcCommitInfo.biId)) quorumCerts))
     checkBlocksMatchQCs quorumCerts (zipIt 0 blocks)  ∙?∙ λ _ →
       PersistentLivenessStorage.saveTreeM blocks quorumCerts ∙?∙ λ _ → do
         -- TODO-1 : requires adding bsStorage to BlockStore
-        -- use (lBlockStore ∙ bsStorage) >>= λ x → logInfo fakeInfo -- (here ["XXX", lsPLS x])
+        -- use (lBlockStore ∙ bsStorage) >>= λ x → logInfo fakeInfo -- (here' ["XXX", lsPLS x])
         -- OBM NOT NEEDED: state_computer.sync_to
         -- This returns recovery data
         PersistentLivenessStorage.startM ∙^∙ withErrCtx (here' [])
-{-
--}
+
   checkBlocksMatchQCs quorumCerts = λ where
     []                 → ok unit
     ((i , block) ∷ xs) →
-      ok unit
-      -- if-RWST block ^∙ bId /= (quorumCerts Prelude.!! i) ^∙ qcCertifiedBlock ∙ biId
-      -- then (do
-      --   ok unit)
-      -- else
-      --   ok unit
-
-{-
-      then do
-        logInfoL lSI [lsHV (block^.bId), lsB block]
-        logInfoL lSI [lsHV (quorumCerts Prelude.!! i ^.qcCertifiedBlock.biId)
-                     ,lsQC (quorumCerts Prelude.!! i)]
-        bail (ErrL (here ["checkBlocksMatchQCs", "/="]))
+      maybeS-RWST (quorumCerts !? i)
+                  (bail fakeErr) -- (here' ["checkBlocksMatchQCs", "!?"])
+                  $ λ qc →
+      if-RWST (block ^∙ bId /= qc ^∙ qcCertifiedBlock ∙ biId)
+      then (do
+        logInfo fakeInfo -- [lsHV (block^.bId), lsB block]
+        logInfo fakeInfo -- [lsHV (quorumCerts Prelude.!! i ^.qcCertifiedBlock.biId)
+                         -- ,lsQC (quorumCerts Prelude.!! i)]
+        bail fakeErr) -- (here' ("checkBlocksMatchQCs" ∷ "/=" ∷ []))
       else checkBlocksMatchQCs quorumCerts xs
--}
+
   here' t = "SyncManager" ∷ "fastForwardSyncM" ∷ t
 

--- a/LibraBFT/Impl/Consensus/PersistentLivenessStorage.agda
+++ b/LibraBFT/Impl/Consensus/PersistentLivenessStorage.agda
@@ -16,4 +16,7 @@ module LibraBFT.Impl.Consensus.PersistentLivenessStorage where
 postulate -- TODO-2: implement
   saveHighestTimeoutCertM : TimeoutCertificate → LBFT (Either ErrLog Unit)
   saveTreeE : BlockStore → List Block → List QuorumCert → Either ErrLog (BlockStore)
+  saveTreeM : List Block → List QuorumCert → LBFT (Either ErrLog Unit)
   saveVoteM : Vote → LBFT (Either ErrLog Unit)
+  startM    : LBFT (Either ErrLog RecoveryData)
+

--- a/LibraBFT/Impl/Consensus/RecoveryData.agda
+++ b/LibraBFT/Impl/Consensus/RecoveryData.agda
@@ -17,6 +17,7 @@ postulate
   → List QuorumCert
   → Maybe TimeoutCertificate
   → RecoveryData
+-- TODO-1 : IMPLEMENT THE FOLLOWING
 {-
 new lastVote storageLedger blocks0 rootMetadata quorumCerts0 highestTimeoutCertificate =
   let (root@(RootInfo rb _ _), blocks1, quorumCerts1)

--- a/LibraBFT/Impl/Consensus/RecoveryData.agda
+++ b/LibraBFT/Impl/Consensus/RecoveryData.agda
@@ -1,0 +1,35 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.Prelude
+
+module LibraBFT.Impl.Consensus.RecoveryData where
+
+postulate
+ new
+  : Maybe Vote
+  → LedgerRecoveryData
+  → List Block
+  → RootMetadata
+  → List QuorumCert
+  → Maybe TimeoutCertificate
+  → RecoveryData
+{-
+new lastVote storageLedger blocks0 rootMetadata quorumCerts0 highestTimeoutCertificate =
+  let (root@(RootInfo rb _ _), blocks1, quorumCerts1)
+            = LedgerRecoveryData.findRoot blocks0 quorumCerts0 storageLedger
+      (blocksToPrune, blocks, quorumCerts)
+            = findBlocksToPrune (rb^.bId) blocks1 quorumCerts1
+      epoch = rb^.bEpoch
+   in RecoveryData
+      (case lastVote of Just v | v^.vEpoch == epoch → Just v; _ → Nothing)
+      root
+      rootMetadata
+      blocks
+      quorumCerts
+      (Just blocksToPrune)
+      (case highestTimeoutCertificate of Just tc | tc^.tcEpoch == epoch → Just tc; _ → Nothing)
+-}

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -224,7 +224,7 @@ constructAndSignVoteM-continue2 = constructAndSignVoteM-continue2.step₀
 signProposalM : BlockData → LBFT (Either ErrLog Block)
 signProposalM blockData = do
  vs ← use (lSafetyRules ∙ srValidatorSigner)
- maybeS vs (bail fakeErr) {-ErrL (here' ["srValidatorSigner", "Nothing"])-} $ λ validatorSigner -> do
+ maybeS-RWST vs (bail fakeErr) {-ErrL (here' ["srValidatorSigner", "Nothing"])-} $ λ validatorSigner -> do
   safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
   verifyAuthorM (blockData ^∙ bdAuthor) ∙?∙ λ _ →
     verifyEpochM (blockData ^∙ bdEpoch) safetyData ∙?∙ λ _ →
@@ -248,7 +248,7 @@ signProposalM blockData = do
 signTimeoutM : Timeout → LBFT (Either ErrLog Signature)
 signTimeoutM timeout = do
  vs ← use (lSafetyRules ∙ srValidatorSigner)
- maybeS vs (bail fakeErr) {-"srValidatorSigner", "Nothing"-} $ λ validatorSigner → do
+ maybeS-RWST vs (bail fakeErr) {-"srValidatorSigner", "Nothing"-} $ λ validatorSigner → do
    safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
    verifyEpochM (timeout ^∙ toEpoch) safetyData ∙^∙ withErrCtx (here' []) ∙?∙ λ _ -> do
      ifM‖ timeout ^∙ toRound ≤? safetyData ^∙ sdPreferredRound ≔

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -224,7 +224,7 @@ constructAndSignVoteM-continue2 = constructAndSignVoteM-continue2.step₀
 signProposalM : BlockData → LBFT (Either ErrLog Block)
 signProposalM blockData = do
  vs ← use (lSafetyRules ∙ srValidatorSigner)
- maybeS-RWST vs (bail fakeErr) {-ErrL (here' ["srValidatorSigner", "Nothing"])-} $ λ validatorSigner -> do
+ maybeS vs (bail fakeErr) {-ErrL (here' ["srValidatorSigner", "Nothing"])-} $ λ validatorSigner -> do
   safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
   verifyAuthorM (blockData ^∙ bdAuthor) ∙?∙ λ _ →
     verifyEpochM (blockData ^∙ bdEpoch) safetyData ∙?∙ λ _ →
@@ -248,7 +248,7 @@ signProposalM blockData = do
 signTimeoutM : Timeout → LBFT (Either ErrLog Signature)
 signTimeoutM timeout = do
  vs ← use (lSafetyRules ∙ srValidatorSigner)
- maybeS-RWST vs (bail fakeErr) {-"srValidatorSigner", "Nothing"-} $ λ validatorSigner → do
+ maybeS vs (bail fakeErr) {-"srValidatorSigner", "Nothing"-} $ λ validatorSigner → do
    safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
    verifyEpochM (timeout ^∙ toEpoch) safetyData ∙^∙ withErrCtx (here' []) ∙?∙ λ _ -> do
      ifM‖ timeout ^∙ toRound ≤? safetyData ^∙ sdPreferredRound ≔

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -636,6 +636,25 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   vmEpoch : Lens VoteMsg Epoch
   vmEpoch = vmVote ∙ vEpoch
 
+  data RootInfo : Set where RootInfo∙new : Block → QuorumCert → QuorumCert → RootInfo
+  data RootMetadata : Set where RootMetadata∙new : RootMetadata
+
+  record RecoveryData : Set where
+    constructor mkRecoveryData
+    field
+      _rdLastVote                  : Maybe Vote
+      _rdRoot                      : RootInfo
+      _rdRootMetadata              : RootMetadata
+      _rdBlocks                    : List Block
+      _rdQuorumCerts               : List QuorumCert
+      _rdBlocksToPrune             : Maybe (List HashValue)
+      _rdHighestTimeoutCertificate : Maybe TimeoutCertificate
+  open RecoveryData public
+  unquoteDecl rdLastVote      rdRoot            rdRootMetadata                rdBlocks
+              rdQuorumCerts   rdBlocksToPrune   rdHighestTimeoutCertificate = mkLens (quote RecoveryData)
+             (rdLastVote    ∷ rdRoot          ∷ rdRootMetadata              ∷ rdBlocks ∷
+              rdQuorumCerts ∷ rdBlocksToPrune ∷ rdHighestTimeoutCertificate ∷ [])
+
   -- This is a notification of a commit.  It may not be explicitly included in an implementation,
   -- but we need something to be able to express correctness conditions.  It will
   -- probably have something different in it, but will serve the purpose for now.
@@ -909,3 +928,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   bsHighestTimeoutCert : Lens BlockStore (Maybe TimeoutCertificate)
   bsHighestTimeoutCert = bsInner ∙ btHighestTimeoutCert
 
+  record LedgerRecoveryData : Set where
+    constructor LedgerRecoveryData∙new
+    field
+      _lrdStorageLedger : LedgerInfo

--- a/LibraBFT/ImplShared/Util/RWST/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/RWST/Syntax.agda
@@ -94,6 +94,10 @@ caseM⊎ e of f = RWST-either e (f ∘ Left) (f ∘ Right)
 caseMM_of_ : Maybe B → (Maybe B → RWST Ev Wr St A) → RWST Ev Wr St A
 caseMM m of f = RWST-maybe m (f nothing) (f ∘ just)
 
+eitherS-RWST : ∀ {A B C} → Either B C
+               → (B → RWST Ev Wr St A) → (C → RWST Ev Wr St A)   → RWST Ev Wr St A
+eitherS-RWST = RWST-either
+
 when : ∀ {ℓ} {B : Set ℓ} ⦃ _ : ToBool B ⦄ → B → RWST Ev Wr St Unit → RWST Ev Wr St Unit
 when b f = if-RWST toBool b then f else pure unit
 

--- a/LibraBFT/ImplShared/Util/RWST/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/RWST/Syntax.agda
@@ -101,6 +101,9 @@ eitherS-RWST = RWST-either
 when : ∀ {ℓ} {B : Set ℓ} ⦃ _ : ToBool B ⦄ → B → RWST Ev Wr St Unit → RWST Ev Wr St Unit
 when b f = if-RWST toBool b then f else pure unit
 
+when-RWST : ⦃ _ : ToBool B ⦄ → B → (c : RWST Ev Wr St Unit) → RWST Ev Wr St Unit
+when-RWST b c = if-RWST b then c else pure unit
+
 -- Composition with error monad
 ok : A → RWST Ev Wr St (B ⊎ A)
 ok = pure ∘ Right

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -326,7 +326,7 @@ module LibraBFT.Prelude where
   isRight = Data.Bool.not ∘ isLeft
 
   -- a non-dependent eliminator
-  eitherS : ∀ {a b} {A : Set a} {B : Set b} {C : Set (a ℓ⊔ b)}
+  eitherS : ∀ {a b c} {A : Set a} {B : Set b} {C : Set c}
             (x : Either A B) → ((x : A) → C) → ((x : B) → C) → C
   eitherS eab fa fb = case eab of λ where
     (Left  a) → fa a

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -46,6 +46,8 @@ module LibraBFT.Prelude where
     hiding (fromMaybe; [_])
     public
 
+  fmap = List-map
+
   open import Data.List.Properties
     renaming (≡-dec to List-≡-dec; length-map to List-length-map; map-compose to List-map-compose; filter-++ to List-filter-++)
     using (∷-injective; length-++; map-++-commute; sum-++-commute; map-tabulate; ++-identityʳ)

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -521,3 +521,9 @@ module LibraBFT.Prelude where
        with a ≟ b
     ... | no  proof = no λ where refl → proof refl
     ... | yes refl = yes refl
+
+  infixl 9 _!?_
+  _!?_ : {A : Set} → List A → ℕ → Maybe A
+  []       !? _  = nothing
+  (x ∷ _ ) !? 0  = just x
+  (_ ∷ xs) !? n  = xs !? (n ∸ 1)

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -324,7 +324,8 @@ module LibraBFT.Prelude where
   isRight = Data.Bool.not ∘ isLeft
 
   -- a non-dependent eliminator
-  eitherS : ∀ {A B C : Set} (x : Either A B) → ((x : A) → C) → ((x : B) → C) → C
+  eitherS : ∀ {a b} {A : Set a} {B : Set b} {C : Set (a ℓ⊔ b)}
+            (x : Either A B) → ((x : A) → C) → ((x : B) → C) → C
   eitherS eab fa fb = case eab of λ where
     (Left  a) → fa a
     (Right b) → fb b

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -524,6 +524,6 @@ module LibraBFT.Prelude where
 
   infixl 9 _!?_
   _!?_ : {A : Set} → List A → ℕ → Maybe A
-  []       !? _  = nothing
-  (x ∷ _ ) !? 0  = just x
-  (_ ∷ xs) !? n  = xs !? (n ∸ 1)
+  []       !?      _   = nothing
+  (x ∷ _ ) !?      0   = just x
+  (_ ∷ xs) !? (suc n)  = xs !? n


### PR DESCRIPTION
This implements the majority of NeedFetch/catchup.
A subsequent PR will implement the things postulated here.

- BlockRetriever (new file)
  - postulate retrieveBlockForQCM
- BlockStore
  - postulate rebuildM
  - implement blockExists
- SyncManager
  - implement needSyncForQuorumCert, needFetchForQuorumCert, fetchQuorumCertM
  - implement syncToHighestCommitCertM, fastForwardSync
- RecoveryData (new file)
- EpochIndep
  - define RootInfo, RootMetadata, RecoveryData, LedgerRecoveryData
- PersistentLivenessStorage
  - postulate saveTreeM, startM
- Syntax
  - define eitherS-RWST
- Prelude
  - fix eitherS type
  - implement !?
