### PR TITLE
Sketch different approach to tracking provenance of signatures in output QCs

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -11,6 +11,7 @@ open import LibraBFT.Hash
 open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote as Vote
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore
@@ -19,6 +20,7 @@ open import LibraBFT.Prelude
 open import Optics.All
 
 open RoundManagerInvariants
+open RoundManagerTransProps
 
 module LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockStore where
 
@@ -43,6 +45,22 @@ module executeAndInsertBlockMSpec (b : Block) where
   proj₁ (contract pre Post pfBail pfOk ._ refl) e eaibLeft = pfBail e (sym eaibLeft)
   proj₂ (contract pre Post pfBail pfOk ._ refl) (bs' , eb) eaibRight ._ refl ._ refl =
     pfOk bs' eb (sym eaibRight)
+
+module insertSingleQuorumCertMSpec
+  (qc : QuorumCert) where
+
+  module _ (pre : RoundManager) where
+
+    record Contract (r : Either ErrLog Unit) (post : RoundManager) (outs : List Output) : Set where
+      constructor mkContract
+      field
+        -- General invariants / properties
+        rmInv         : Preserves RoundManagerInv pre post
+        noEpochChange : NoEpochChange pre post
+        noVoteOuts    : OutputProps.NoVotes outs
+        -- Voting
+        noVote        : VoteNotGenerated pre post true
+        outQcs∈RMor   : QCProps.OutputQc∈RmOr outs pre post (_≡ qc)
 
 module syncInfoMSpec where
   syncInfo : RoundManager → SyncInfo

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -1,0 +1,36 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Consensus.BlockStorage.BlockTree
+open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote as Vote
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Crypto
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore
+open import LibraBFT.Impl.Properties.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+open RoundManagerInvariants
+open QCProps
+
+module LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockTree where
+
+
+module insertQuorumCertESpec
+  (qc : QuorumCert) (bt0  : BlockTree) where
+
+  Contract : Either ErrLog (BlockTree × List InfoLog) → Set
+  Contract (Left _) = Unit
+  Contract (Right (bt1 , il)) = ∀ {qc'} → qc' ∈BlockTree bt1 → qc' ∈BlockTree bt0 ⊎ qc' ≡ qc
+
+  postulate -- TODO-1: prove it
+    contract : Contract (insertQuorumCertE qc bt0)

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
@@ -1,0 +1,60 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote as Vote
+open import LibraBFT.Impl.Properties.Util
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Interface.Output
+open import LibraBFT.ImplShared.Util.Crypto
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore
+open import LibraBFT.Impl.Properties.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+open RoundManagerInvariants
+open RoundManagerTransProps
+
+module LibraBFT.Impl.Consensus.BlockStorage.Properties.SyncManager where
+
+
+module addCertsMSpec
+  (syncInfo : SyncInfo) (retriever : BlockRetriever) where
+
+  module _ (pre : RoundManager) where
+
+    record Contract (r : Either ErrLog Unit) (post : RoundManager) (outs : List Output) : Set where
+      constructor mkContract
+      field
+        -- General invariants / properties
+        rmInv         : Preserves RoundManagerInv pre post
+        noEpochChange : NoEpochChange pre post
+        noVoteOuts    : OutputProps.NoVotes outs
+        -- Voting
+        noVote        : VoteNotGenerated pre post true
+        outQcs∈RMor   : QCProps.OutputQc∈RmOr outs pre post (_QC∈SyncInfo syncInfo)
+
+
+module insertQuorumCertMSpec
+  (qc : QuorumCert) (retriever : BlockRetriever) where
+
+  module _ (pre : RoundManager) where
+
+    record Contract (r : Either ErrLog Unit) (post : RoundManager) (outs : List Output) : Set where
+      constructor mkContract
+      field
+        -- General invariants / properties
+        rmInv         : Preserves RoundManagerInv pre post
+        noEpochChange : NoEpochChange pre post
+        noVoteOuts    : OutputProps.NoVotes outs
+        -- Voting
+        noVote        : VoteNotGenerated pre post true
+        outQcs∈RMor   : QCProps.OutputQc∈RmOr outs pre post (_≡ qc)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Properties/SyncInfo.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Properties/SyncInfo.agda
@@ -39,13 +39,13 @@ module verifyMSpec (self : SyncInfo) (validator : ValidatorVerifier) where
       sivpHccVer    : maybeS (self ^∙ sixxxHighestCommitCert) Unit $ λ qc → QC.Contract qc validator
       -- Waiting on TimeoutCertificate Contract : sivpHtcVer    : maybeS (self ^∙ siHighestTimeoutCert  ) Unit $ λ tc → {!!}
 
-  module _ (pool : SentMessages) (pre : RoundManager) where
+  module _ (pre : RoundManager) where
 
    record Contract (r : Either ErrLog Unit) (post : RoundManager) (outs : List Output) : Set where
      constructor mkContract
      field
        -- General properties / invariants
-       rmInv         : Preserves (RoundManagerInv pool) pre post
+       rmInv         : Preserves RoundManagerInv pre post
        noStateChange : pre ≡ post
        -- Output
        noMsgOuts     : OutputProps.NoMsgs outs

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -3,6 +3,7 @@
    Copyright (c) 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+{-# OPTIONS --allow-unsolved-metas #-}
 open import Optics.All
 open import LibraBFT.Base.KVMap                               as Map
 open import LibraBFT.Base.PKCS

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -3,6 +3,7 @@
    Copyright (c) 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+{-# OPTIONS --allow-unsolved-metas #-}
 
 open import LibraBFT.Base.Types
 open import LibraBFT.Concrete.System

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -53,7 +53,7 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
         -- Voting
         voteAttemptCorrect : Voting.VoteAttemptCorrectWithEpochReq pre post outs (pm ^∙ pmProposal)
         -- Signatures
-        outQcs∈RM : QCProps.OutputQc∈RmOrMsg outs pre (P pm)
+        outQcs∈RM : QCProps.OutputQc∈RmOr outs pre post (_QC∈NM (P pm))
         qcSigsB4  : QCProps.MsgRequirements pool (P pm) → Preserves (QCProps.SigsForVotes∈Rm-SentB4 pool) pre post
         -- QCProps.MsgRequirements pool (P pm)
 
@@ -70,7 +70,7 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
       contractBail : ∀ outs → OutputProps.NoMsgs outs → Contract unit pre outs
       contractBail outs noMsgs =
         mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
-          vac outQcs∈RM qcSigsB4
+          vac {! outQcs∈RM !} qcSigsB4
         where
         vac : Voting.VoteAttemptCorrectWithEpochReq pre pre outs (pm ^∙ pmProposal)
         vac = Voting.mkVoteAttemptCorrectWithEpochReq

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -104,11 +104,14 @@ module QCProps where
       syncInfo∈msg : syncInfo SyncInfo∈NM msg
     open MsgRequirements msgReqs
 
-  data _∈RoundManager_ (qc : QuorumCert) (rm : RoundManager) : Set where
-    inHQC : qc ≡ rm ^∙ lBlockStore ∙ bsInner ∙ btHighestQuorumCert → qc ∈RoundManager rm
-    inHCC : qc ≡ rm ^∙ lBlockStore ∙ bsInner ∙ btHighestCommitCert → qc ∈RoundManager rm
+  data _∈BlockTree_ (qc : QuorumCert) (bt : BlockTree) : Set where
+    inHQC : qc ≡ bt ^∙ btHighestQuorumCert → qc ∈BlockTree bt
+    inHCC : qc ≡ bt ^∙ btHighestCommitCert → qc ∈BlockTree bt
     -- NOTE: When `need/fetch` is implemented, we will need an additional
     -- constructor for sent qcs taken from the blockstore.
+
+  _∈RoundManager_ : (qc : QuorumCert) (rm : RoundManager) → Set
+  qc ∈RoundManager rm =  qc ∈BlockTree (rm ^∙ lBlockStore ∙ bsInner)
 
   OutputQc∈RmOrMsg : List Output → RoundManager → NetworkMsg → Set
   OutputQc∈RmOrMsg outs rm msg =

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -114,6 +114,11 @@ module QCProps where
   OutputQc∈RmOrMsg outs rm msg =
     All (λ out → ∀ qc nm → qc QC∈NM nm → nm Msg∈Out out → qc ∈RoundManager rm ⊎ qc QC∈NM msg) outs
 
+  OutputQc∈RmOr : List Output → RoundManager → RoundManager
+                → (Q : QuorumCert → Set) → Set
+  OutputQc∈RmOr outs pre post Q =
+    All (λ out → ∀ qc nm → qc QC∈NM nm → nm Msg∈Out out → qc ∈RoundManager post → qc ∈RoundManager pre ⊎ Q qc) outs
+
   ++-OutputQc∈RmOrMsg
     : ∀ {rm msg outs₁ outs₂}
       → OutputQc∈RmOrMsg outs₁ rm msg → OutputQc∈RmOrMsg outs₂ rm msg

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -3,6 +3,7 @@
    Copyright (c) 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+{-# OPTIONS --allow-unsolved-metas #-}
 
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System
@@ -62,7 +63,7 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach sps@(step-msg{sndr , nm} m∈
   hpPst  = LBFT-post (handle pid nm 0) hpPre
 
   nmSentQcs∈RM : (nm1 : NetworkMsg) → nm1 ≡ nm → QCProps.OutputQc∈RmOrMsg hpOut hpPre nm1
-  nmSentQcs∈RM (P pm) refl = outQcs∈RM
+  nmSentQcs∈RM (P pm) refl = ? -- outQcs∈RM
     where
     open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
   nmSentQcs∈RM (V vm) refl = outQcs∈RM


### PR DESCRIPTION
Sorry this is rushed.

It sketches a different way to track provenance of signatures in output QCs, so that each function's doesn't have to know about things outside it (such as network messages, message pools, etc.)

The key idea is to replace `OutputQc∈RmOrMsg` by `OutputQc∈RmOr`, which takes a predicate that must hold for a `QC` that is in the poststate but not in the prestate.  By making this a predicate over pre and post states, it becomes simple to stitch these together up and down the call stack, so we can relate `QC`s to what we know about (with respect to the whole step's prestate and the message pool) them near the top level.

Very much a sketch, but hope the idea is clear/useful.