### PR TITLE
Extend `handleProposalMsg` approach to `handleVoteMsg`, eliminate Contracts' dependence on message pool, various refactoring

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
@@ -108,7 +108,7 @@ module insertQuorumCertMSpec
 module addCertsMSpec
   (syncInfo : SyncInfo) (retriever : BlockRetriever) where
 
-  module _ (pool : SentMessages) (pre : RoundManager) where
+  module _ (pre : RoundManager) where
 
     record Contract (r : Either ErrLog Unit) (post : RoundManager) (outs : List Output) : Set where
       constructor mkContract

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Properties/SyncInfo.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Properties/SyncInfo.agda
@@ -39,7 +39,7 @@ module verifyMSpec (self : SyncInfo) (validator : ValidatorVerifier) where
       sivpHccVer    : maybeS (self ^∙ sixxxHighestCommitCert) Unit $ λ qc → QC.Contract qc validator
       -- Waiting on TimeoutCertificate Contract : sivpHtcVer    : maybeS (self ^∙ siHighestTimeoutCert  ) Unit $ λ tc → {!!}
 
-  module _ (pool : SentMessages) (pre : RoundManager) where
+  module _ (pre : RoundManager) where
 
    record Contract (r : Either ErrLog Unit) (post : RoundManager) (outs : List Output) : Set where
      constructor mkContract

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -115,7 +115,6 @@ module syncUpM (now : Instant) (syncInfo : SyncInfo) (author : Author) (_helpRem
   step₀       :                                LBFT (Either ErrLog Unit)
   step₁ step₂ : SyncInfo                     → LBFT (Either ErrLog Unit)
   step₃ step₄ : SyncInfo → ValidatorVerifier → LBFT (Either ErrLog Unit)
-  step₁-else  :                                LBFT (Either ErrLog Unit)
 
   here' : List String.String → List String.String
 
@@ -127,8 +126,8 @@ module syncUpM (now : Instant) (syncInfo : SyncInfo) (author : Author) (_helpRem
 
   step₁ localSyncInfo = do
     if-RWST SyncInfo.hasNewerCertificates syncInfo localSyncInfo
-      then (do step₂ localSyncInfo)
-      else step₁-else
+      then step₂ localSyncInfo
+      else ok unit
 
   step₂ localSyncInfo = do
         vv ← use (lRoundManager ∙ rmEpochState ∙ esVerifier)
@@ -141,9 +140,6 @@ module syncUpM (now : Instant) (syncInfo : SyncInfo) (author : Author) (_helpRem
   step₄ localSyncInfo vv = do
             processCertificatesM now
             ok unit
-
-  step₁-else =
-        ok unit
 
   here' t = "RoundManager" ∷ "syncUpM" ∷ t
 

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -137,9 +137,9 @@ qcVoteSigsSentB4 pid st (step-s rss (step-peer{pid'}{pre = pre} (step-honest sps
 ...| step-msg{sndr , C cm} m∈pool init = obm-dangerous-magic' "TODO: waiting on `handleCommitSpec`"
 
 qcVoteSigsSentB4-sps
-  : ∀ pid (pre : SystemState) {s msgs}
+  : ∀ pid (pre : SystemState) {s acts}
     → ReachableSystemState pre
-    → (StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (s , msgs))
+    → (StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (s , acts))
     → ∀ {qc v pk} → qc QCProps.∈RoundManager s
     → WithVerSig pk v
     → ∀ {vs : Author × Signature} → let (pid , sig) = vs in

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -87,7 +87,7 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
       proj₁ (contract-step₁ (myEpoch@._ , vv@._) refl) (inj₂ i) pp≡Left =
         contractBail _ refl
       proj₂ (contract-step₁ (myEpoch@._ , vv@._) refl) unit pp≡Right =
-        processProposalMsgMSpec.contract now pm pool pre Contract pf
+        processProposalMsgMSpec.contract now pm pre Contract pf
         where
         module PPM = processProposalMsgMSpec now pm
 
@@ -96,7 +96,7 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
           with processProposalSpec.contract pm myEpoch vv
         ...| con rewrite pp≡Right = sym con
 
-        pf : RWST-Post-⇒ (PPM.Contract pool pre) Contract
+        pf : RWST-Post-⇒ (PPM.Contract pre) Contract
         pf unit st outs con =
           mkContract PPMSpec.rmInv PPMSpec.noEpochChange
             vac PPMSpec.outQcs∈RM PPMSpec.qcPost

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -126,7 +126,7 @@ module handleVoteSpec (now : Instant) (vm : VoteMsg) where
         noVotes       : OutputProps.NoVotes outs
         -- Signatures
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
-        qcSigsB4  : QCProps.MsgRequirements pool (V vm) → Preserves (QCProps.SigsForVotes∈Rm-SentB4 pool) pre post
+        qcPost    : QCProps.∈Post⇒∈PreOr pre post (_QC∈NM (V vm))
 
     postulate -- TODO-2: prove (waiting on: refinement of `Contract`)
       contract : LBFT-weakestPre (handleVote now vm) Contract pre

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -242,7 +242,9 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s{pre = pre} preach step@(step-peer sp@
        ⊥-elim ∘′ ¬msb4 $ qcVoteSigsSentB4-handle pid preach sps m'∈acts qc∈m' sig' vs∈qc v≈rbld ¬gen
 
 sameERasLV⇒sameId{pid = .pid“}{pid'}{pk} (step-s{pre = pre} preach step@(step-peer{pid“} sp@(step-honest sps@(step-msg{sndr , P pm} pm∈pool ini)))){v}{v'} hpk ≡pidLV pcsfpk ._ _ sig' ¬gen ≡epoch ≡round
-   | inj₁ (m∈outs , pcsfpk' , ¬msb4) | refl | vote∈vm = ret
+   | Left (m∈outs , pcsfpk' , ¬msb4)
+   | refl
+   | vote∈vm = ret
   where
   -- Definitions
   hpPool = msgPool pre
@@ -275,7 +277,9 @@ sameERasLV⇒sameId{pid = .pid“}{pid'}{pk} (step-s{pre = pre} preach step@(ste
       just v' ∎
 
 sameERasLV⇒sameId{pid}{pid'}{pk} (step-s{pre = pre} preach step@(step-peer sp@(step-honest sps@(step-msg{_ , V vm} m∈pool ini)))){v}{v'}{m'} hpk ≡pidLV pcsfpk v'⊂m' m'∈pool sig' ¬gen ≡epoch ≡round
-  | Left (m∈outs , pcsfpk' , ¬msb4) | pid≡ | vote∈vm = sameERasLV⇒sameId{pid}{pid'} preach{m' = m'} hpk ≡pidLVPre pcsfpkPre vote∈vm m'∈poolPre sig' ¬gen ≡epoch ≡round
+  | Left (m∈outs , pcsfpk' , ¬msb4)
+  | refl
+  | vote∈vm = sameERasLV⇒sameId{pid}{pid'} preach{m' = m'} hpk ≡pidLVPre pcsfpkPre vote∈vm m'∈poolPre sig' ¬gen ≡epoch ≡round
   where
   hvPre = peerStates pre pid
   hvPos = LBFT-post (handleVote 0 vm) hvPre


### PR DESCRIPTION
* Refactoring to enable proving all `qvVoteSigSentB4` cases in `VotesOnce` proof, and do it
* Make `handleVoteSpec.Contract` independent of pool, like handleProposalSpec.Contract`
* Remove now-unnecessary pool argument from various Contracts
* Refactor `qcVoteSigsSentB4`
* Other small edits