### PR TITLE
StateComputer.compute state/exceptions

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -163,6 +163,7 @@ executeAndInsertBlockE bs0 block =
 
 executeBlockE bs block = do
   -- let compute        = bs ^. bsStateComputer.scCompute
+  -- StateComputer may update its internal state and/or throw and exception.
   -- stateComputeResult ← compute (bs^.bsStateComputer) block (block^.bParentId)
   pure (ExecutedBlock∙new block stateComputeResult)
 

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -143,12 +143,14 @@ executeAndInsertBlockE bs0 block =
       eb ← case executeBlockE bs0 block of λ where
         (Right res) → Right res
         -- OBM-LBFT-DIFF : This is never thrown in OBM.
-        -- Because it is thrown by StateComputer in Rust (but not in OBM).
+        -- It is thrown by StateComputer in Rust (but not in OBM).
         (Left (ErrECCBlockNotFound parentBlockId)) → do
           eitherS (pathFromRoot parentBlockId bs0) Left $ λ blocksToReexecute →
             -- OBM-LBFT-DIFF : OBM StateComputer does NOT have state.
             -- If it ever does have state then the following 'forM' will
-            -- need to change to some sort of 'fold'.
+            -- need to change to some sort of 'fold' because 'executeBlockE'
+            -- would change the state, so the state passed to 'executeBlockE'
+            -- would no longer be 'bs0'.
             case (forM) blocksToReexecute (executeBlockE bs0 ∘ (_^∙ ebBlock)) of λ where
               (Left  e) → Left e
               (Right _) → executeBlockE bs0 block

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -208,8 +208,11 @@ module LibraBFT.ImplShared.Consensus.Types where
   -- The Haskell implementation has many more constructors.
   -- Constructors are being added incrementally as needed for the verification effort.
   data ErrLog : Set where
-    ErrBlockNotFound : HashValue   → ErrLog
-    ErrVerify        : VerifyError → ErrLog
+    -- Consensus_BlockNotFound
+    ErrCBlockNotFound   : HashValue   → ErrLog
+    -- ExecutionCorrectnessClient_BlockNotFound
+    ErrECCBlockNotFound : HashValue   → ErrLog
+    ErrVerify           : VerifyError → ErrLog
 
   -- To enable modeling of logging errors that have not been added yet,
   -- an inhabitant of ErrLog is postulated.


### PR DESCRIPTION
added comment about StateComputer.compute not throwing exception nor maintaining state (but the possibility these may happen in the future)

Changed existing exception `ErrBlockNotFound` to `ErrCBlockNotFound` - that is used when the consensus level cannot find an expected block.

Added `ErrECCBlockNotFound` - that would be used inside the state computer, inside its "execution correction client".  It is never thrown in the Agda code (nor in the Haskell code).   But it is caught in `BlockStore.executeAndInsertBlockM`.  See the comment there.

