### PR TITLE
Progress on `insertQuorumCertE Spec`, generalise `∈Post⇒∈PreOr`, eliminate unnecessary pools

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -60,44 +60,56 @@ insertBlockE block bt = do
 
 ------------------------------------------------------------------------------
 
-insertQuorumCertE : QuorumCert → BlockTree → Either ErrLog (BlockTree × List InfoLog)
-insertQuorumCertE qc bt0 = do
-  let blockId = qc ^∙ qcCertifiedBlock ∙ biId
+module insertQuorumCertE (qc : QuorumCert) (bt0 : BlockTree) where
 
-  let safetyInvariant : Either ErrLog Unit
-      safetyInvariant = forM_ (Map.elems (bt0 ^∙ btIdToQuorumCert)) $ \x →
-        lcheck (   (x  ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash
-                ==  qc ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash)
-                ∨  (x  ^∙ qcCertifiedBlock ∙ biRound
-                /=  qc ^∙ qcCertifiedBlock ∙ biRound))
-               (here' ("failed check" ∷ "existing qc == qc || existing qc.round /= qc.round" ∷ []))
-
-  case safetyInvariant of λ where
-    (Left  e)    → Left e
-    (Right unit) →
-      maybeS (btGetBlock blockId bt0) (Left fakeErr) $ λ block →
-      maybeS (bt0 ^∙ btHighestCertifiedBlock) (Left fakeErr) $ λ hcb →
-      if-dec ((block ^∙ ebRound) >? (hcb ^∙ ebRound))
-      then
-       (let bt   = bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId
-                       & btHighestQuorumCert       ∙~ qc
-            info = (fakeInfo ∷ [])
-         in pure (continue1 bt  blockId block info))
-      else  pure (continue1 bt0 blockId block [])
- where
-  continue2 : BlockTree → List InfoLog → (BlockTree × List InfoLog)
-
+  step₀     : Either ErrLog (BlockTree × List InfoLog)
+  step₁     : HashValue → Either ErrLog (BlockTree × List InfoLog)
+  step₂     : HashValue → ExecutedBlock → Either ErrLog (BlockTree × List InfoLog)
+  step₃     : HashValue → ExecutedBlock → ExecutedBlock → Either ErrLog (BlockTree × List InfoLog)
   continue1 : BlockTree → HashValue → ExecutedBlock → List InfoLog → (BlockTree × List InfoLog)
+  continue2 : BlockTree → List InfoLog → (BlockTree × List InfoLog)
+  here' : List String.String → List String.String
+  here' t = "BlockTree" ∷ "insertQuorumCert" ∷ t
+
+  blockId = qc ^∙ qcCertifiedBlock ∙ biId
+
+  safetyInvariant = forM_ (Map.elems (bt0 ^∙ btIdToQuorumCert)) $ \x →
+          lcheck (   (x  ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash
+                  ==  qc ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash)
+                  ∨  (x  ^∙ qcCertifiedBlock ∙ biRound
+                  /=  qc ^∙ qcCertifiedBlock ∙ biRound))
+                 (here' ("failed check" ∷ "existing qc == qc || existing qc.round /= qc.round" ∷ []))
+  step₀ =
+    case safetyInvariant of λ where
+      (Left  e)    → Left e
+      (Right unit) → step₁ blockId
+
+  step₁ blockId =
+        maybeS (btGetBlock blockId bt0) (Left fakeErr) $ step₂ blockId
+
+  step₂ blockId block =
+        maybeS (bt0 ^∙ btHighestCertifiedBlock) (Left fakeErr) $ step₃ blockId block 
+
+  step₃ blockId block hcb =
+        if-dec ((block ^∙ ebRound) >? (hcb ^∙ ebRound))
+        then
+         (let bt   = bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId
+                         & btHighestQuorumCert       ∙~ qc
+              info = (fakeInfo ∷ [])
+           in pure (continue1 bt  blockId block info))
+        else  pure (continue1 bt0 blockId block [])
+
   continue1 bt blockId block info =
     continue2 ( bt & btIdToQuorumCert ∙~ lookupOrInsert blockId qc (bt ^∙ btIdToQuorumCert))
               ( (fakeInfo ∷ info) ++ (if ExecutedBlock.isNilBlock block then fakeInfo ∷ [] else [] ))
+
   continue2 bt info =
     if-dec (bt ^∙ btHighestCommitCert ∙ qcCommitInfo ∙ biRound) <? (qc ^∙ qcCommitInfo ∙ biRound)
     then ((bt & btHighestCommitCert ∙~ qc) , info)
     else (bt , info)
 
-  here' : List String.String → List String.String
-  here' t = "BlockTree" ∷ "insertQuorumCert" ∷ t
+insertQuorumCertE : QuorumCert → BlockTree → Either ErrLog (BlockTree × List InfoLog)
+insertQuorumCertE = insertQuorumCertE.step₀
 
 insertQuorumCertM : QuorumCert → LBFT Unit
 insertQuorumCertM qc = do

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -194,7 +194,7 @@ module executeAndInsertBlockMSpec (b : Block) where
 module insertSingleQuorumCertMSpec
   (qc : QuorumCert) where
 
-  module _ (pool : SentMessages) (pre : RoundManager) where
+  module _ (pre : RoundManager) where
 
     record Contract (r : Either ErrLog Unit) (post : RoundManager) (outs : List Output) : Set where
       constructor mkContract
@@ -206,8 +206,8 @@ module insertSingleQuorumCertMSpec
         -- Voting
         noVote        : VoteNotGenerated pre post true
         -- Signatures
-        qcSigsB4 : QCProps.QCRequirements pool qc
-                   → Preserves (QCProps.SigsForVotes∈Rm-SentB4 pool) pre post
+        qcSigsB4      : ∀ {pool} → QCProps.QCRequirements pool qc
+                        → Preserves (QCProps.SigsForVotes∈Rm-SentB4 pool) pre post
 
 
     postulate -- TODO-2: prove

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -72,8 +72,7 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
       ebBlockData≡ : eb ^∙ ebBlock ≡L block at bBlockData
       bsInv        : ∀ pre → pre ^∙ lBlockStore ≡ bs0
                      → Preserves BlockStoreInv pre (pre & lBlockStore ∙~ bs')
-      qcPost       : ∀ qc → qc QCProps.∈BlockTree (bs' ^∙ bsInner)
-                     → qc QCProps.∈BlockTree (bs0 ^∙ bsInner) ⊎ qc ≡ block ^∙ bQuorumCert
+      qcPost       : QCProps.∈Post⇒∈PreOrBT (_≡ block ^∙ bQuorumCert) (bs' ^∙ bsInner) (bs0 ^∙ bsInner)
 
   contract : (isOk : Ok) → let (bs' , eb , _) = isOk in ContractOk bs' eb
   contract (bs' , eb , isOk)
@@ -166,7 +165,7 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
         ...| Right col = ⊥-elim col -- TODO: propagate hash collision upward
         ...| Left pres = pres
 
-        qcPost : ∀ qc → qc QCProps.∈BlockTree bt' → qc QCProps.∈BlockTree (bs0 ^∙ bsInner) ⊎ qc ≡ block ^∙ bQuorumCert
+        qcPost : QCProps.∈Post⇒∈PreOrBT (_≡ block ^∙ bQuorumCert) bt' (bs0 ^∙ bsInner)
         qcPost
            with insertBlockESpec.qcPost eb' (bs0 ^∙ bsInner) bt' eb“ IBCon
         ...| qcPost' rewrite ebbd≡ = qcPost'

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -5,6 +5,7 @@
 -}
 
 open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.KVMap as Map
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
@@ -15,6 +16,8 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore
+open import LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock as ExecutedBlock
+open import LibraBFT.Impl.OBM.Prelude
 open import LibraBFT.Impl.Properties.Util
 open import LibraBFT.Prelude
 open import Optics.All
@@ -54,10 +57,98 @@ module insertBlockESpec (block : ExecutedBlock) (bt : BlockTree) where
 
 module insertQuorumCertESpec
   (qc : QuorumCert) (bt0  : BlockTree) where
+  open insertQuorumCertE qc bt0
+
+  Ok : Set
+  Ok = ∃₂ λ bt1 il → insertQuorumCertE qc bt0 ≡ Right (bt1 , il)
+
+  private
+    Ok' : BlockTree → List InfoLog → Either ErrLog (BlockTree × List InfoLog) → Set
+    Ok' bt il m = m ≡ Right (bt , il)
 
   Contract : Either ErrLog (BlockTree × List InfoLog) → Set
   Contract (Left _) = Unit
   Contract (Right (bt1 , il)) = ∈Post⇒∈PreOrBT (_≡ qc) bt0 bt1
+                              -- TODO: this is only part of what we need.  We want to also prove
+                              -- that QCs in the pre are also in the post.  Make a record?
 
-  postulate -- TODO-1: prove it
-    contract : Contract (insertQuorumCertE qc bt0)
+  contract : (isOk : Ok) → let (bt1 , il , _) = isOk in Contract (Right (bt1 , il))
+  contract (bt1 , il , isOk)
+     with safetyInvariant
+  ...| Right unit
+    with pf1 isOk
+    where
+    pf1 : Ok' bt1 il (step₁ blockId) → ∃[ block ] (just block ≡ btGetBlock blockId bt0 × Ok' bt1 il (step₂ blockId block))
+    pf1 isOk
+       with  btGetBlock blockId bt0
+    ...| just block = block , refl , isOk
+  ...| block , lookupJust₁ , step2-ok
+    with pf2 step2-ok
+    where
+    pf2 : Ok' bt1 il (step₂ blockId block) → ∃[ hcb ](just hcb ≡ bt0 ^∙ btHighestCertifiedBlock × Ok' bt1 il (step₃ blockId block hcb))
+    pf2 isOk
+       with bt0 ^∙ btHighestCertifiedBlock
+    ...| just hcb   = hcb , refl , isOk
+  ...| hcb , lookupJust₂ , step3-ok
+    with          bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId &    btHighestQuorumCert ∙~ qc
+       | inspect (bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId &_) (btHighestQuorumCert ∙~ qc)
+       | fakeInfo ∷ []
+  ...| bt₃-true | [ R ] | il₃-true
+    with  if ⌊ (block ^∙ ebRound) >? (hcb ^∙ ebRound) ⌋ then bt₃-true else   bt0               | inspect
+         (if ⌊ (block ^∙ ebRound) >? (hcb ^∙ ebRound) ⌋ then bt₃-true else_) bt0               |
+          if ⌊ (block ^∙ ebRound) >? (hcb ^∙ ebRound) ⌋ then il₃-true else   []                | inspect
+         (if ⌊ (block ^∙ ebRound) >? (hcb ^∙ ebRound) ⌋ then il₃-true else_) []
+  ...| bt₃ | [ refl ] | il₃ | [ refl ]
+    with  bt₃ &    btIdToQuorumCert ∙~ lookupOrInsert blockId qc (bt₃ ^∙ btIdToQuorumCert)     | inspect
+         (bt₃ &_) (btIdToQuorumCert ∙~ lookupOrInsert blockId qc (bt₃ ^∙ btIdToQuorumCert))    |
+          (fakeInfo ∷ il₃) ++   (if ExecutedBlock.isNilBlock block then fakeInfo ∷ [] else []) | inspect
+         ((fakeInfo ∷ il₃) ++_) (if ExecutedBlock.isNilBlock block then fakeInfo ∷ [] else [])
+  ...| bt-c₁ | [ refl ] | il-c₁ | [ refl ]
+    with pf3 step3-ok
+    where
+    pf3 : Ok' bt1 il (step₃ blockId block hcb) → ∈Post⇒∈PreOrBT (_≡ qc) bt0 bt₃
+                                               × continue1 bt₃ blockId block il₃ ≡ (bt1 , il)
+    proj₂ (pf3 isOk)
+      with ⌊ (block ^∙ ebRound) >? (hcb ^∙ ebRound) ⌋
+          -- I thought I might be stuck with pure vs. Right, so made the silly xxx below, but now if
+          -- I try to put refl in the hole below, I see something about NilBlock in the error,
+          -- suggesting it's looking into continue2.  Maybe I could try making an abstract alias for
+          -- continue2 and working with that, but it feels like I'm in the weeds, so taking a break
+          -- here and sharing in case someone else has some insight.
+    ... | false = xxx isOk (obm-dangerous-magic' "stuck here, see notes above") 
+       where
+         xxx : ∀ {A : Set} {a : A} {x : A} {y : Either ErrLog A} → y ≡ Right a → pure x ≡ y → x ≡ a
+         xxx {A} {a} {x} refl refl = refl
+    ... | true  =  obm-dangerous-magic' "TODO: first resolve 'easy' case above"
+    proj₁ (pf3 isOk) qc' qc'∈bt₃ = obm-dangerous-magic' "TODO: very similar to two proofs below, not identical, generalise?"
+
+  ...| bt0→bt3 , continue1-ok
+    with pf-continue1 continue1-ok
+    where
+    pf-continue1 : continue1 bt₃ blockId block il₃ ≡ (bt1 , il)
+                 → ∈Post⇒∈PreOrBT (_≡ qc) bt0 bt-c₁
+                 × continue2 bt-c₁ il-c₁ ≡ (bt1 , il)
+    proj₂ (pf-continue1 refl) = refl
+    proj₁ (pf-continue1 refl)  = ∈Post⇒∈PreOrBT-trans (_≡ qc) bt0→bt3 bt3→bt-c1
+      where
+        bt3→bt-c1 : ∈Post⇒∈PreOrBT (_≡ qc) bt₃ bt-c₁
+        bt3→bt-c1 qc' qc'∈bt-c₁
+           with Map.kvm-member blockId (bt₃ ^∙ btIdToQuorumCert)
+        ... | true  = Left qc'∈bt-c₁
+        ... | false
+           with qc'∈bt-c₁
+        ... | inHQC x = Left (inHQC x)
+        ... | inHCC x = Left (inHCC x)
+  ...| bt0→bt-c₁ , continue2-ok = pf-continue2 continue2-ok
+    where
+    pf-continue2 : continue2 bt-c₁ il-c₁ ≡ (bt1 , il) → Contract (Right (bt1 , il))
+    pf-continue2 refl = ∈Post⇒∈PreOrBT-trans (_≡ qc) {bt0} {bt-c₁} {bt1} bt0→bt-c₁ bt-c₁→bt1
+      where
+      bt-c₁→bt1 : _
+      bt-c₁→bt1 qc' qc'∈bt1
+         with (bt-c₁ ^∙ btHighestCommitCert ∙ qcCommitInfo ∙ biRound) <? (qc ^∙ qcCommitInfo ∙ biRound)
+      ...| no  hcR≥qcR = Left qc'∈bt1
+      ...| yes hcR<qcR
+        with qc'∈bt1
+      ...| inHQC x = Left (inHQC x)
+      ...| inHCC x = Right x

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -50,15 +50,14 @@ module insertBlockESpec (block : ExecutedBlock) (bt : BlockTree) where
                 -- between b ^∙ ebBlock ∙ bBlockData and block ^∙ ebBlock ∙
                 -- bBlockdata
 
-      qcPost : ∀ qc → qc QCProps.∈BlockTree bt“ → qc QCProps.∈BlockTree bt ⊎ qc ≡ block ^∙ ebBlock ∙ bQuorumCert
-
+      qcPost : QCProps.∈Post⇒∈PreOrBT (_≡ block ^∙ ebBlock ∙ bQuorumCert) bt“ bt
 
 module insertQuorumCertESpec
   (qc : QuorumCert) (bt0  : BlockTree) where
 
   Contract : Either ErrLog (BlockTree × List InfoLog) → Set
   Contract (Left _) = Unit
-  Contract (Right (bt1 , il)) = ∀ {qc'} → qc' ∈BlockTree bt1 → qc' ∈BlockTree bt0 ⊎ qc' ≡ qc
+  Contract (Right (bt1 , il)) = ∈Post⇒∈PreOrBT (_≡ qc) bt0 bt1
 
   postulate -- TODO-1: prove it
     contract : Contract (insertQuorumCertE qc bt0)

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
@@ -121,7 +121,7 @@ module addCertsMSpec
         noVote        : VoteNotGenerated pre post true
         -- Signatures
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
-        qcPost    : QCProps.∈Post⇒∈PreOr pre post (_QC∈SyncInfo syncInfo)
+        qcPost    : QCProps.∈Post⇒∈PreOr (_QC∈SyncInfo syncInfo) pre post
 
     postulate
       contract' : LBFT-weakestPre (addCertsM syncInfo retriever) Contract pre

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
@@ -67,7 +67,7 @@ module insertQuorumCertMSpec
     proj₂ (contract' bs@._ refl) NeedFetch nf≡ =
       obm-dangerous-magic' "TODO: waiting on contract for `fetchQuorumCertM`"
     proj₂ (contract' bs@._ refl) QCBlockExist nf≡ =
-      insertSingleQuorumCertMSpec.contract qc pool pre Post₁ contract₁
+      insertSingleQuorumCertMSpec.contract qc pre Post₁ contract₁
       where
       Post₁ : LBFT-Post (Either ErrLog Unit)
       Post₁ =
@@ -75,7 +75,7 @@ module insertQuorumCertMSpec
           (RWST-weakestPre-ebindPost unit (λ _ → use lBlockStore >>= (λ _ → logInfo fakeInfo) >> ok unit)
             (RWST-weakestPre-bindPost unit (λ _ → step₁ bs) (Contract pool pre))))
 
-      module _ (r₁ : Either ErrLog Unit) (st₁ : RoundManager) (outs₁ : List Output) (con₁ : insertSingleQuorumCertMSpec.Contract qc pool pre r₁ st₁ outs₁) where
+      module _ (r₁ : Either ErrLog Unit) (st₁ : RoundManager) (outs₁ : List Output) (con₁ : insertSingleQuorumCertMSpec.Contract qc pre r₁ st₁ outs₁) where
         module ISQC = insertSingleQuorumCertMSpec.Contract con₁
 
         contract₁' : ∀ outs' → NoMsgs outs' → RWST-Post-⇒ (Contract pool st₁) (RWST-Post++ (Contract pool pre) outs')
@@ -90,7 +90,7 @@ module insertQuorumCertMSpec
           where
           module Step₁ = Contract con₂
 
-      contract₁ : RWST-Post-⇒ (insertSingleQuorumCertMSpec.Contract qc pool pre) Post₁
+      contract₁ : RWST-Post-⇒ (insertSingleQuorumCertMSpec.Contract qc pre) Post₁
       contract₁ (Left _) st₁ outs₁ con₁ ._ refl ._ refl =
         step₁Spec.contract bs pool st₁ (RWST-Post++ (Contract pool pre) (outs₁ ++ []))
           (contract₁' _ _ _ con₁ (outs₁ ++ [])

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -65,7 +65,7 @@ module executeAndVoteMSpec (b : Block) where
         lvr≡?             : Bool
         voteResultCorrect : VoteResultCorrect pre post lvr≡? r
         -- QCs
-        qcPost : QCProps.∈Post⇒∈PreOr pre post (_≡ b ^∙ bQuorumCert)
+        qcPost : QCProps.∈Post⇒∈PreOr (_≡ b ^∙ bQuorumCert) pre post
         qcPres : ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre post
 
     contract'
@@ -86,7 +86,7 @@ module executeAndVoteMSpec (b : Block) where
         vrc : VoteResultCorrect pre pre true (Left e)
         vrc = inj₁ reflVoteNotGenerated
 
-        qcPost : QCProps.∈Post⇒∈PreOr pre pre (_≡ b ^∙ bQuorumCert)
+        qcPost : QCProps.∈Post⇒∈PreOr (_≡ b ^∙ bQuorumCert) pre pre
         qcPost qc = Left
 
         qcPres : ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre pre
@@ -117,7 +117,7 @@ module executeAndVoteMSpec (b : Block) where
         invP₁ : Preserves RoundManagerInv pre preUpdateBS
         invP₁ = mkPreservesRoundManagerInv id id bsP srP
 
-        qcPost₁ : QCProps.∈Post⇒∈PreOr pre preUpdateBS (_≡ b ^∙ bQuorumCert)
+        qcPost₁ : QCProps.∈Post⇒∈PreOr (_≡ b ^∙ bQuorumCert) pre preUpdateBS
         qcPost₁ qc qc∈preUpdateBS = obm-dangerous-magic' "TODO: waiting on contract for `BlockStore.executeAndInsertBlockM`"
 
         qcPres₁ : ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre preUpdateBS
@@ -161,7 +161,7 @@ module executeAndVoteMSpec (b : Block) where
                 (inj₁ (transVoteNotGenerated (mkVoteNotGenerated refl refl) vc))
                 qcPost qcPres
               where
-              qcPost : QCProps.∈Post⇒∈PreOr pre st (_≡ b ^∙ bQuorumCert)
+              qcPost : QCProps.∈Post⇒∈PreOr (_≡ b ^∙ bQuorumCert) pre st
               qcPost qc qc∈st = obm-dangerous-magic' "TODO: waiting on `constructAndSignVoteM` contract"
 
               qcPres : ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre st
@@ -219,7 +219,7 @@ module processProposalMSpec (proposal : Block) where
         voteAttemptCorrect : Voting.VoteAttemptCorrect pre post outs proposal
         -- QCs
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
-        qcPost    : QCProps.∈Post⇒∈PreOr pre post (_≡ proposal ^∙ bQuorumCert)
+        qcPost    : QCProps.∈Post⇒∈PreOr (_≡ proposal ^∙ bQuorumCert) pre post
         qcsPres   : ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre post
 
     contract' : LBFT-weakestPre (processProposalM proposal) Contract pre
@@ -253,7 +253,7 @@ module processProposalMSpec (proposal : Block) where
           outQcs : QCProps.OutputQc∈RoundManager outs pre
           outQcs = QCProps.NoMsgs⇒OutputQc∈RoundManager outs pre nmo
 
-          qcPost : QCProps.∈Post⇒∈PreOr pre pre _
+          qcPost : QCProps.∈Post⇒∈PreOr _ pre pre
           qcPost qc = Left
 
           qcPres : ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre pre
@@ -351,7 +351,7 @@ module processProposalMSpec (proposal : Block) where
                     ... | false = refl
                     ... | true = absurd false ≡ true case isj of λ ()
 
-                qcPost : QCProps.∈Post⇒∈PreOr pre stUpdateRS (_≡ proposal ^∙ bQuorumCert)
+                qcPost : QCProps.∈Post⇒∈PreOr (_≡ proposal ^∙ bQuorumCert) pre stUpdateRS
                 qcPost qc qc∈st = obm-dangerous-magic' "TODO: waiting on contract for executeAndVoteM"
 
                 qcPres : ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre stUpdateRS
@@ -393,7 +393,7 @@ module syncUpMSpec
         noVote        : VoteNotGenerated pre post true
         -- QCs
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
-        qcPost    : QCProps.∈Post⇒∈PreOr pre post (_QC∈SyncInfo syncInfo)
+        qcPost    : QCProps.∈Post⇒∈PreOr (_QC∈SyncInfo syncInfo) pre post
 
     contract' : LBFT-weakestPre (syncUpM now syncInfo author _helpRemote) Contract pre
     contract' =
@@ -412,7 +412,7 @@ module syncUpMSpec
         outQcs : QCProps.OutputQc∈RoundManager [] pre
         outQcs = QCProps.NoMsgs⇒OutputQc∈RoundManager [] pre refl
 
-        qcPost : QCProps.∈Post⇒∈PreOr pre pre _
+        qcPost : QCProps.∈Post⇒∈PreOr _ pre pre
         qcPost qc = Left
       proj₁ (contract₁ localSyncInfo lsi≡) hcn≡true vv@._ refl =
         verifyMSpec.contract syncInfo vv pre Post₁
@@ -439,7 +439,7 @@ module syncUpMSpec
                       (QCProps.NoMsgs⇒OutputQc∈RoundManager outs st VSpec.noMsgOuts)
                       (QCProps.NoMsgs⇒OutputQc∈RoundManager [] st refl)
 
-           qcPost : QCProps.∈Post⇒∈PreOr st st _
+           qcPost : QCProps.∈Post⇒∈PreOr _ st st
            qcPost qc = Left
         contract₃ (Right y) st₃ outs₃ con₃ ._ refl
            | refl = λ where
@@ -506,7 +506,7 @@ module ensureRoundAndSyncUpMSpec
         noVote        : VoteNotGenerated pre post true
         -- Signatures
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
-        qcPost   : QCProps.∈Post⇒∈PreOr pre post (_QC∈SyncInfo syncInfo)
+        qcPost   : QCProps.∈Post⇒∈PreOr (_QC∈SyncInfo syncInfo) pre post
 
     contract'
       : LBFT-weakestPre (ensureRoundAndSyncUpM now messageRound syncInfo author helpRemote) Contract pre
@@ -519,7 +519,7 @@ module ensureRoundAndSyncUpMSpec
         outqcs : QCProps.OutputQc∈RoundManager [] pre
         outqcs = QCProps.NoMsgs⇒OutputQc∈RoundManager [] pre refl
 
-        qcPost : QCProps.∈Post⇒∈PreOr pre pre _
+        qcPost : QCProps.∈Post⇒∈PreOr _ pre pre
         qcPost qc = Left
 
     proj₂ (contract' ._ refl) mrnd≥crnd = contract-step₁
@@ -579,7 +579,7 @@ module processProposalMsgMSpec
         voteAttemptCorrect : Voting.VoteAttemptCorrect pre post outs proposal
         -- QCs
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
-        qcPost    : QCProps.∈Post⇒∈PreOr pre post (_QC∈NM (P pm))
+        qcPost    : QCProps.∈Post⇒∈PreOr (_QC∈NM (P pm)) pre post
 
     contract' : LBFT-weakestPre (processProposalMsgM now pm) Contract pre
     contract' rewrite processProposalMsgM≡ = contract
@@ -594,7 +594,7 @@ module processProposalMsgMSpec
         outqcs : QCProps.OutputQc∈RoundManager outs pre
         outqcs = QCProps.NoMsgs⇒OutputQc∈RoundManager outs pre nmo
 
-        qcPost : QCProps.∈Post⇒∈PreOr pre pre _
+        qcPost : QCProps.∈Post⇒∈PreOr _ pre pre
         qcPost qc = Left
 
       contract : LBFT-weakestPre step₀ Contract pre
@@ -626,7 +626,7 @@ module processProposalMsgMSpec
                          ERASU.outQcs∈RM
                          (QCProps.NoMsgs⇒OutputQc∈RoundManager outs' st noMsgs')
 
-              qcPost : QCProps.∈Post⇒∈PreOr pre st (_QC∈NM (P pm))
+              qcPost : QCProps.∈Post⇒∈PreOr (_QC∈NM (P pm)) pre st
               qcPost qc qc∈st
                  with ERASU.qcPost qc qc∈st
               ... | Left qc∈pre = Left qc∈pre
@@ -659,7 +659,7 @@ module processProposalMsgMSpec
                              ERASU.outQcs∈RM)
                            (PP.outQcs∈RM con)
 
-                qcPost : QCProps.∈Post⇒∈PreOr pre st' (_QC∈NM (P pm))
+                qcPost : QCProps.∈Post⇒∈PreOr (_QC∈NM (P pm)) pre st'
                 qcPost qc qc∈st'
                    with PP.qcPost con qc qc∈st'
                 ...| Right refl = Right inP

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -103,7 +103,7 @@ handlePreservesSigsB4 {nm} {pid} {pre} {sndr} preach m∈pool {qc} {v} {pk} = hy
 
    hPost = LBFT-post (handle pid nm 0) hPre
 
-   qcPost' : (nm' : NetworkMsg) → nm' ≡ nm → QCProps.∈Post⇒∈PreOr hPre hPost (_QC∈NM nm)
+   qcPost' : (nm' : NetworkMsg) → nm' ≡ nm → QCProps.∈Post⇒∈PreOr (_QC∈NM nm) hPre hPost
    qcPost' (P pm) refl = qcPost
       where open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hPool hPre)
    qcPost' (V vm) refl = qcPost

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -54,7 +54,7 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
         voteAttemptCorrect : Voting.VoteAttemptCorrectWithEpochReq pre post outs (pm ^∙ pmProposal)
         -- QCs
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
-        qcPost    : QCProps.∈Post⇒∈PreOr pre post (_QC∈NM (P pm))
+        qcPost    : QCProps.∈Post⇒∈PreOr (_QC∈NM (P pm)) pre post
 
     contract : LBFT-weakestPre (handleProposal now pm) Contract pre
     contract =
@@ -78,7 +78,7 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs pre
         outQcs∈RM = QCProps.NoMsgs⇒OutputQc∈RoundManager outs pre noMsgs
 
-        qcPost : QCProps.∈Post⇒∈PreOr pre pre _
+        qcPost : QCProps.∈Post⇒∈PreOr _  pre pre
         qcPost qc = Left
 
       contract-step₁ : Post-epvv (myEpoch , vv) pre []
@@ -126,7 +126,7 @@ module handleVoteSpec (now : Instant) (vm : VoteMsg) where
         noVotes       : OutputProps.NoVotes outs
         -- Signatures
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
-        qcPost    : QCProps.∈Post⇒∈PreOr pre post (_QC∈NM (V vm))
+        qcPost    : QCProps.∈Post⇒∈PreOr (_QC∈NM (V vm)) pre post
 
     postulate -- TODO-2: prove (waiting on: refinement of `Contract`)
       contract : LBFT-weakestPre (handleVote now vm) Contract pre

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -123,8 +123,35 @@ module QCProps where
   _∈RoundManager_ : (qc : QuorumCert) (rm : RoundManager) → Set
   qc ∈RoundManager rm =  qc ∈BlockTree (rm ^∙ lBlockStore ∙ bsInner)
 
-  ∈Post⇒∈PreOr : (pre post : RoundManager) (Q : QuorumCert → Set) → Set
-  ∈Post⇒∈PreOr pre post Q = ∀ qc → qc ∈RoundManager post → qc ∈RoundManager pre ⊎ Q qc
+
+  ∈Post⇒∈PreOr' : ∀ {A : Set} (_QC∈_ : QuorumCert → A → Set) (Q : QuorumCert → Set) (pre post : A) → Set
+  ∈Post⇒∈PreOr' _QC∈_ Q pre post = ∀ qc → qc QC∈ post → qc QC∈ pre ⊎ Q qc
+
+  ∈Post⇒∈PreOrBT : (Q : QuorumCert → Set) (pre post : BlockTree) → Set
+  ∈Post⇒∈PreOrBT = ∈Post⇒∈PreOr' _∈BlockTree_
+
+  ∈Post⇒∈PreOr : (Q : QuorumCert → Set) (pre post : RoundManager) → Set
+  ∈Post⇒∈PreOr = ∈Post⇒∈PreOr' _∈RoundManager_
+
+  ∈Post⇒∈PreOr'-trans : ∀ {A : Set}
+                      → (_QC∈_ : QuorumCert → A → Set) (Q : QuorumCert → Set)
+                      → ∀ {pre int post : A}
+                      → ∈Post⇒∈PreOr' _QC∈_ Q pre int
+                      → ∈Post⇒∈PreOr' _QC∈_ Q int post
+                      → ∈Post⇒∈PreOr' _QC∈_ Q pre post
+  ∈Post⇒∈PreOr'-trans _QC∈_ Q pre→int int→post qc qc∈post
+     with int→post qc qc∈post
+  ... | Right y = Right y
+  ... | Left  x
+     with pre→int qc x
+  ... | Right y = Right y
+  ... | Left x₁ = Left x₁
+
+  ∈Post⇒∈PreOrBT-trans : ∀ (Q : QuorumCert → Set) {pre int post}
+                       → ∈Post⇒∈PreOrBT Q pre int
+                       → ∈Post⇒∈PreOrBT Q int post
+                       → ∈Post⇒∈PreOrBT Q pre post
+  ∈Post⇒∈PreOrBT-trans = ∈Post⇒∈PreOr'-trans _∈BlockTree_
 
   OutputQc∈RoundManager : List Output → RoundManager → Set
   OutputQc∈RoundManager outs rm =


### PR DESCRIPTION
Significant progress on `insertQuorumCertE Spec` but I've left one proof that's similar to some others, suggesting a general lemma may be worthwhile, and one case where I'm stuck and could use some input and/or sleep.  I've left some notes about where I'm up to.

Also generalised `∈Post⇒∈PreOr` so we can use similar functionality further down the stack.  This required reordering some parameters, which has caused some conflicts with #119.

Also eliminated `pool` module parameters where they are unnecessary.