### PR TITLE
NeedFetch continued3

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockRetriever.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockRetriever.agda
@@ -8,6 +8,7 @@ import      LibraBFT.Base.KVMap                                   as Map
 import      LibraBFT.Impl.Consensus.ConsensusTypes.BlockRetrieval as BlockRetrieval
 import      LibraBFT.Impl.IO.OBM.ObmNeedFetch                     as ObmNeedFetch
 open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
 open import LibraBFT.ImplShared.Util.Util

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -35,6 +35,10 @@ executeBlockE
   : BlockStore → Block
   → Either ErrLog ExecutedBlock
 
+insertSingleQuorumCertE
+  : BlockStore → QuorumCert
+  → Either ErrLog (BlockStore × List InfoLog)
+
 pathFromRoot
   : HashValue → BlockStore
   → Either ErrLog (List ExecutedBlock)
@@ -45,12 +49,36 @@ pathFromRootM
 
 ------------------------------------------------------------------------------
 
-postulate
-  build
-    : RootInfo      → RootMetadata
-    → List Block    → List QuorumCert           → Maybe TimeoutCertificate
-    → {-StateComputer →-} PersistentLivenessStorage → Usize
-    → Either ErrLog BlockStore
+build
+  : RootInfo      → RootMetadata
+  → List Block    → List QuorumCert           → Maybe TimeoutCertificate
+  → {-StateComputer →-} PersistentLivenessStorage → Usize
+  → Either ErrLog BlockStore
+build root _rootRootMetadata blocks quorumCerts highestTimeoutCert
+           {-stateComputer-} storage maxPrunedBlocksInMem = do
+  let (RootInfo∙new rootBlock rootQc rootLi) = root
+      {- LBFT-OBM-DIFF : OBM does not implement RootMetadata
+        assert_eq!(
+            root_qc.certified_block().version(),
+            root_metadata.version())
+        assert_eq!(
+            root_qc.certified_block().executed_state_id(),
+            root_metadata.accu_hash)
+      -}
+      executedRootBlock = ExecutedBlock∙new
+                            rootBlock
+                            stateComputeResult -- (StateComputeResult (stateComputer ^∙ scObmVersion) Nothing)
+  tree ← BlockTree.new executedRootBlock rootQc rootLi maxPrunedBlocksInMem highestTimeoutCert
+  bs1  ← (foldM) (λ bs b → fst <$> executeAndInsertBlockE bs b)
+                 (BlockStore∙new tree {-stateComputer-} storage)
+                 blocks
+  (foldM) go bs1 quorumCerts
+ where
+  go : BlockStore → QuorumCert
+     → Either ErrLog BlockStore
+  go bs qc = case insertSingleQuorumCertE bs qc of λ where
+    (Left e)              → Left e
+    (Right (bs' , _info)) → Right bs'
 
 ------------------------------------------------------------------------------
 
@@ -170,10 +198,6 @@ executeBlockE bs block = do
   pure (ExecutedBlock∙new block stateComputeResult)
 
 ------------------------------------------------------------------------------
-
-insertSingleQuorumCertE
-  : BlockStore → QuorumCert
-  → Either ErrLog (BlockStore × List InfoLog)
 
 insertSingleQuorumCertM
   : QuorumCert

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -14,6 +14,7 @@ open import LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock as ExecutedBloc
 open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote          as Vote
 open import LibraBFT.Impl.Consensus.PersistentLivenessStorage    as PersistentLivenessStorage
 open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -13,6 +13,7 @@ open import LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock as ExecutedBloc
 open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote          as Vote
 open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.Impl.OBM.Prelude
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Interface.Output
@@ -27,9 +28,10 @@ import      Data.String as String
 module LibraBFT.Impl.Consensus.BlockStorage.BlockTree where
 
 postulate
-  addChild : LinkableBlock → HashValue → Either ErrLog LinkableBlock
+  linkableBlockNew : ExecutedBlock → LinkableBlock
 
-------------------------------------------------------------------------------
+postulate
+  addChild : LinkableBlock → HashValue → Either ErrLog LinkableBlock
 
 -- addChild : LinkableBlock → HashValue → Either ErrLog LinkableBlock
 -- addChild lb hv =
@@ -37,9 +39,25 @@ postulate
 --   then Left  fakeErr
 --   else Right (lb & lbChildren %~ Set.insert hv)
 
-postulate
-  new : ExecutedBlock → QuorumCert → QuorumCert → Usize → Maybe TimeoutCertificate
-      → Either ErrLog BlockTree
+new : ExecutedBlock → QuorumCert → QuorumCert → Usize → Maybe TimeoutCertificate
+    → Either ErrLog BlockTree
+new root0 rootQuorumCert rootLedgerInfo maxPruned mHighestTimeoutCert = do
+  lcheck ((root0 ^∙ ebId) == (rootLedgerInfo ^∙ qcCommitInfo ∙ biId))
+         ("BlockTree" ∷ "newBlockTree" ∷ "inconsistent root and ledger info" ∷ [])
+  let idToBlock      = Map.insert (root0 ^∙ ebId) (linkableBlockNew root0) Map.empty
+      idToQuorumCert = Map.insert (rootQuorumCert ^∙ qcCertifiedBlock ∙ biId) rootQuorumCert Map.empty
+      prunedBlockIds = vdNew -- TODO
+   in pure $ mkBlockTree
+    idToBlock
+    (root0 ^∙ ebId)     -- _btRootId
+    (root0 ^∙ ebId)     -- _btHighestCertifiedBlockId
+    rootQuorumCert      -- _btHighestQuorumCert
+    mHighestTimeoutCert
+    rootLedgerInfo      -- _btHighestCommitCert
+    idToQuorumCert
+    prunedBlockIds
+    maxPruned
+
 
 replaceTimeoutCertM : TimeoutCertificate → LBFT Unit
 replaceTimeoutCertM tc = do

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -37,6 +37,10 @@ postulate
 --   then Left  fakeErr
 --   else Right (lb & lbChildren %~ Set.insert hv)
 
+postulate
+  new : ExecutedBlock → QuorumCert → QuorumCert → Usize → Maybe TimeoutCertificate
+      → Either ErrLog BlockTree
+
 replaceTimeoutCertM : TimeoutCertificate → LBFT Unit
 replaceTimeoutCertM tc = do
   lBlockStore ∙ bsInner ∙ btHighestTimeoutCert ?= tc

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
@@ -34,6 +34,7 @@ isNilBlock : Block → Bool
 isNilBlock b = BlockData.isNilBlock (b ^∙ bBlockData)
 
 postulate
+  -- This is not needed until epoch change is implements/supported.
   makeGenesisBlockFromLedgerInfo : LedgerInfo → Block
 
 newProposalFromBlockDataAndSignature : BlockData → Signature → Block

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
@@ -33,6 +33,9 @@ isGenesisBlock b = BlockData.isGenesisBlock (b ^∙ bBlockData)
 isNilBlock : Block → Bool
 isNilBlock b = BlockData.isNilBlock (b ^∙ bBlockData)
 
+postulate
+  makeGenesisBlockFromLedgerInfo : LedgerInfo → Block
+
 newProposalFromBlockDataAndSignature : BlockData → Signature → Block
 newProposalFromBlockDataAndSignature blockData signature =
   Block∙new (hashBD blockData) blockData (just signature)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/BlockRetrieval.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/BlockRetrieval.agda
@@ -4,8 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-{-# OPTIONS --allow-unsolved-metas #-}
-
 open import LibraBFT.Base.PKCS hiding (verify)
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
@@ -41,7 +39,7 @@ verify self blockId numBlocks sigVerifier =
   verifyBlock : HashValue → Block → Either ErrLog HashValue
 
   verifyBlocks : List Block → Either ErrLog Unit
-  verifyBlocks blks = {!!} -- foldM_ verifyBlock blockId blks
+  verifyBlocks blks = foldM_ verifyBlock blockId blks
 
   verifyBlock expectedId block = do
     Block.validateSignature block sigVerifier

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/BlockRetrieval.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/BlockRetrieval.agda
@@ -14,6 +14,7 @@ import      LibraBFT.Impl.Types.BlockInfo                     as BlockInfo
 import      LibraBFT.Impl.Types.ValidatorVerifier             as ValidatorVerifier
 open import LibraBFT.Impl.OBM.Crypto hiding (verify)
 open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
@@ -22,6 +22,7 @@ import      Data.String                                     as String
 module LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert where
 
 postulate
+  -- not needed until epoch change is supported
   certificateForGenesisFromLedgerInfo : LedgerInfo → HashValue → QuorumCert
 
 verify : QuorumCert → ValidatorVerifier → Either ErrLog Unit

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
@@ -21,6 +21,9 @@ import      Data.String                                     as String
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert where
 
+postulate
+  certificateForGenesisFromLedgerInfo : LedgerInfo → HashValue → QuorumCert
+
 verify : QuorumCert → ValidatorVerifier → Either ErrLog Unit
 verify self validator = do
   let voteHash = hashVD (self ^∙ qcVoteData)

--- a/LibraBFT/Impl/Consensus/LedgerRecoveryData.agda
+++ b/LibraBFT/Impl/Consensus/LedgerRecoveryData.agda
@@ -4,8 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-{-# OPTIONS --allow-unsolved-metas #-}
-
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
 import      LibraBFT.Impl.Consensus.ConsensusTypes.Block      as Block
@@ -20,7 +18,7 @@ module LibraBFT.Impl.Consensus.LedgerRecoveryData where
 
 postulate
   compareX  : (Epoch × Round) → (Epoch × Round) → Ordering
-  sortBy    : ((Epoch × Round) → (Epoch × Round) → Ordering) → List Block → List Block
+  sortBy    : (Block → Block → Ordering) → List Block → List Block
   findIndex : (Block → Bool) → List Block → Maybe ℕ
   deleteAt  : ℕ → List Block → List Block
   find      : (QuorumCert → Bool) → List QuorumCert -> Maybe QuorumCert
@@ -37,8 +35,8 @@ findRoot blocks0 quorumCerts0 (LedgerRecoveryData∙new storageLedger) = do
         else
            (storageLedger ^∙ liConsensusBlockId , (blocks0 , quorumCerts0))
       sorter : Block → Block → Ordering
-      sorter bl br = {!!} -- (bl ^∙ bEpoch , bl ^∙ bRound) ` compareX ` (br ^∙ bEpoch , br ^∙ bRound)
-      sortedBlocks = blocks0 -- TODO : ******************** sortBy sorter blocks1
+      sorter = λ bl br → compareX (bl ^∙ bEpoch , bl ^∙ bRound) (br ^∙ bEpoch , br ^∙ bRound)
+      sortedBlocks = sortBy sorter blocks1
   rootIdx          ← maybeS
         (findIndex (λ x → x ^∙ bId == rootId) sortedBlocks)
         (Left fakeErr) -- ["unable to find root", show rootId]

--- a/LibraBFT/Impl/Consensus/PendingVotes.agda
+++ b/LibraBFT/Impl/Consensus/PendingVotes.agda
@@ -7,6 +7,7 @@ open import LibraBFT.Base.KVMap                                       as Map
 open import LibraBFT.Hash
 open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote               as Vote
 open import LibraBFT.Impl.Consensus.ConsensusTypes.TimeoutCertificate as TimeoutCertificate
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.Impl.Types.CryptoProxies                         as CryptoProxies
 open import LibraBFT.Impl.Types.LedgerInfoWithSignatures              as LedgerInfoWithSignatures
 open import LibraBFT.Impl.Types.ValidatorVerifier                     as ValidatorVerifier

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -413,11 +413,7 @@ processBlockRetrievalRequestM _now request = do
     r  ← use (lRoundManager ∙ rmRoundState ∙ rsCurrentRound)
     let meer = (me , e , r)
     bs ← use lBlockStore
-    -- TODO-1: define and use SendBRP
-    -- act (SendBRP lSI (request^∙brqObmFrom) (xxx meer bs [] (request^∙brqBlockId)))
-    -- The following is just to get parts of the "act" together.
-    let rsp = mkRsp request meer bs [] (request ^∙ brqBlockId)
-    pure unit
+    act (SendBRP (request ^∙ brqObmFrom) (mkRsp request meer bs [] (request ^∙ brqBlockId)))
 
 mkRsp request meer bs blocks id =
     if-dec length blocks <? request ^∙ brqNumBlocks

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -412,7 +412,7 @@ processBlockRetrievalRequestM _now request = do
     e  ← use (lRoundManager ∙ rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch)
     r  ← use (lRoundManager ∙ rmRoundState ∙ rsCurrentRound)
     let meer = (me , e , r)
-    bs   ← use lBlockStore
+    bs ← use lBlockStore
     -- TODO-1: define and use SendBRP
     -- act (SendBRP lSI (request^∙brqObmFrom) (xxx meer bs [] (request^∙brqBlockId)))
     -- The following is just to get parts of the "act" together.

--- a/LibraBFT/Impl/OBM/Rust/RustTypes.agda
+++ b/LibraBFT/Impl/OBM/Rust/RustTypes.agda
@@ -14,9 +14,8 @@ U64 = ℕ
 Usize : Set
 Usize = ℕ
 
-data VecDeque : Set where
-
 postulate
+  VecDeque : Set
   vdNew : VecDeque
 
 

--- a/LibraBFT/Impl/OBM/Rust/RustTypes.agda
+++ b/LibraBFT/Impl/OBM/Rust/RustTypes.agda
@@ -1,0 +1,22 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Prelude
+
+module LibraBFT.Impl.OBM.Rust.RustTypes where
+
+U64 : Set
+U64 = ℕ
+
+Usize : Set
+Usize = ℕ
+
+data VecDeque : Set where
+
+postulate
+  vdNew : VecDeque
+
+

--- a/LibraBFT/Impl/OBM/Rust/RustTypes.agda
+++ b/LibraBFT/Impl/OBM/Rust/RustTypes.agda
@@ -8,6 +8,8 @@ open import LibraBFT.Prelude
 
 module LibraBFT.Impl.OBM.Rust.RustTypes where
 
+-- TODO-2 : reasoning about integer overflow
+
 U64 : Set
 U64 = ℕ
 

--- a/LibraBFT/Impl/Types/ValidatorVerifier.agda
+++ b/LibraBFT/Impl/Types/ValidatorVerifier.agda
@@ -7,6 +7,7 @@
 open import LibraBFT.Base.KVMap                            as Map
 open import LibraBFT.Base.PKCS                             hiding (verify)
 import      LibraBFT.Impl.OBM.Crypto                       as Crypto
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
 open import LibraBFT.Prelude

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -10,6 +10,7 @@ open import LibraBFT.Base.KVMap            as Map
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.Prelude
 open import Optics.All
@@ -38,12 +39,6 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
 
   aAuthorName : Lens Author AuthorName
   aAuthorName = mkLens' (λ x → x) (λ x → const x)
-
-  U64 : Set
-  U64 = ℕ
-
-  Usize : Set
-  Usize = ℕ
 
   HashValue : Set
   HashValue = Hash
@@ -918,19 +913,18 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
       _btHighestQuorumCert       : QuorumCert
       _btHighestTimeoutCert      : Maybe TimeoutCertificate
       _btHighestCommitCert       : QuorumCert
-      _btPendingVotes            : PendingVotes
-      _btPrunedBlockIds          : List HashValue
-      _btMaxPrunedBlocksInMem    : ℕ
       _btIdToQuorumCert          : KVMap HashValue QuorumCert
+      _btPrunedBlockIds          : VecDeque
+      _btMaxPrunedBlocksInMem    : ℕ
   open BlockTree public
-  unquoteDecl btIdToBlock   btRootId   btHighestCertifiedBlockId   btHighestQuorumCert
-              btHighestTimeoutCert
-              btHighestCommitCert   btPendingVotes   btPrunedBlockIds
-              btMaxPrunedBlocksInMem btIdToQuorumCert = mkLens (quote BlockTree)
+  unquoteDecl btIdToBlock   btRootId  btHighestCertifiedBlockId   btHighestQuorumCert
+              btHighestTimeoutCert   btHighestCommitCert
+              btIdToQuorumCert   btPrunedBlockIds
+              btMaxPrunedBlocksInMem = mkLens (quote BlockTree)
              (btIdToBlock ∷ btRootId ∷ btHighestCertifiedBlockId ∷ btHighestQuorumCert ∷
-              btHighestTimeoutCert ∷
-              btHighestCommitCert ∷ btPendingVotes ∷ btPrunedBlockIds ∷
-              btMaxPrunedBlocksInMem ∷ btIdToQuorumCert ∷ [])
+              btHighestTimeoutCert ∷ btHighestCommitCert ∷
+              btIdToQuorumCert ∷ btPrunedBlockIds ∷
+              btMaxPrunedBlocksInMem ∷ [])
 
   btGetLinkableBlock : HashValue → BlockTree → Maybe LinkableBlock
   btGetLinkableBlock hv bt = Map.lookup hv (bt ^∙ btIdToBlock)

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -3,6 +3,7 @@
    Copyright (c) 2020, 2021, Oracle and/or its affiliates.
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
+
 open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap            as Map
@@ -864,6 +865,21 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     BRSSucceeded BRSIdNotFound BRSNotEnoughBlocks : BlockRetrievalStatus
   open BlockRetrievalStatus public
   postulate instance enc-BlockRetrievalState : Encoder BlockRetrievalStatus
+
+  brs-eq : (brs₁ brs₂ : BlockRetrievalStatus) → Dec (brs₁ ≡ brs₂)
+  brs-eq BRSSucceeded       BRSSucceeded       = yes refl
+  brs-eq BRSSucceeded       BRSIdNotFound      = no λ ()
+  brs-eq BRSSucceeded       BRSNotEnoughBlocks = no λ ()
+  brs-eq BRSIdNotFound      BRSSucceeded       = no λ ()
+  brs-eq BRSIdNotFound      BRSIdNotFound      = yes refl
+  brs-eq BRSIdNotFound      BRSNotEnoughBlocks = no λ ()
+  brs-eq BRSNotEnoughBlocks BRSSucceeded       = no λ ()
+  brs-eq BRSNotEnoughBlocks BRSIdNotFound      = no λ ()
+  brs-eq BRSNotEnoughBlocks BRSNotEnoughBlocks = yes refl
+
+  instance
+    Eq-BlockRetrievalStatus : Eq BlockRetrievalStatus
+    Eq._≟_ Eq-BlockRetrievalStatus = brs-eq
 
   record BlockRetrievalResponse : Set where
     constructor BlockRetrievalResponse∙new

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -192,6 +192,15 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     s : LedgerInfo → Maybe EpochState → LedgerInfo
     s l _ = l -- TODO-1 : cannot be done: need a way to defined only getters
 
+  -- GETTER only in Haskell
+  liEndsEpoch : Lens LedgerInfo Bool
+  liEndsEpoch = mkLens' g s
+   where
+    g : LedgerInfo → Bool
+    g = is-just ∘ (_^∙ liNextEpochState)
+    s : LedgerInfo → Bool → LedgerInfo
+    s l _ = l -- TODO-1 : cannot be done: need a way to defined only getters
+
   LedgerInfo-η : ∀ {ci1 ci2 : BlockInfo} {cdh1 cdh2 : Hash}
              → ci1  ≡ ci2
              → cdh1 ≡ cdh2
@@ -465,6 +474,10 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   bEpoch = bBlockData ∙ bdEpoch
 
   -- getter only in Haskell
+  bRound : Lens Block Round
+  bRound = bBlockData ∙ bdRound
+
+  -- getter only in Haskell
   bQuorumCert : Lens Block QuorumCert
   bQuorumCert  = bBlockData ∙ bdQuorumCert
 
@@ -475,10 +488,6 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   -- getter only in Haskell
   bPayload : Lens Block (Maybe TX)
   bPayload = bBlockData ∙ bdPayload
-
-  -- getter only in Haskell
-  bRound : Lens Block Round
-  bRound =  bBlockData ∙ bdRound
 
   record BlockRetriever : Set where
     constructor BlockRetriever∙new

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -910,7 +910,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   -- A block tree depends on a epoch config but works regardlesss of which
   -- EpochConfig we have.
   record BlockTree : Set where
-    constructor BlockTree∙new
+    constructor mkBlockTree
     field
       _btIdToBlock               : KVMap HashValue LinkableBlock
       _btRootId                  : HashValue

--- a/LibraBFT/ImplShared/Interface/Output.agda
+++ b/LibraBFT/ImplShared/Interface/Output.agda
@@ -21,7 +21,8 @@ module LibraBFT.ImplShared.Interface.Output where
     BroadcastSyncInfo : SyncInfo    → List Author     → Output
     LogErr            : ErrLog                        → Output
     LogInfo           : InfoLog                       → Output
-    SendVote          : VoteMsg → List Author → Output
+    SendBRP           : Author      → BlockRetrievalResponse → Output
+    SendVote          : VoteMsg     → List Author     → Output
   open Output public
 
   SendVote-inj-v : ∀ {x1 x2 y1 y2} → SendVote x1 y1 ≡ SendVote x2 y2 → x1 ≡ x2
@@ -35,6 +36,7 @@ module LibraBFT.ImplShared.Interface.Output where
   IsSendVote (BroadcastSyncInfo _ _) = ⊥
   IsSendVote (LogErr _) = ⊥
   IsSendVote (LogInfo _) = ⊥
+  IsSendVote (SendBRP _ _) = ⊥
   IsSendVote (SendVote _ _) = ⊤
 
   IsBroadcastProposal : Output → Set
@@ -42,6 +44,7 @@ module LibraBFT.ImplShared.Interface.Output where
   IsBroadcastProposal (BroadcastSyncInfo _ _) = ⊥
   IsBroadcastProposal (LogErr _) = ⊥
   IsBroadcastProposal (LogInfo _) = ⊥
+  IsBroadcastProposal (SendBRP _ _) = ⊥
   IsBroadcastProposal (SendVote _ _) = ⊥
 
   IsBroadcastSyncInfo : Output → Set
@@ -49,6 +52,7 @@ module LibraBFT.ImplShared.Interface.Output where
   IsBroadcastSyncInfo (BroadcastSyncInfo _ _) = ⊤
   IsBroadcastSyncInfo (LogErr _)              = ⊥
   IsBroadcastSyncInfo (LogInfo _)             = ⊥
+  IsBroadcastSyncInfo (SendBRP _ _)           = ⊥
   IsBroadcastSyncInfo (SendVote _ _)          = ⊥
 
   IsLogErr : Output → Set
@@ -56,6 +60,7 @@ module LibraBFT.ImplShared.Interface.Output where
   IsLogErr (BroadcastSyncInfo _ _) = ⊥
   IsLogErr (LogErr _)            = ⊤
   IsLogErr (LogInfo _)           = ⊥
+  IsLogErr (SendBRP _ _)         = ⊥
   IsLogErr (SendVote _ _)        = ⊥
 
   isSendVote? : (out : Output) → Dec (IsSendVote out)
@@ -63,6 +68,7 @@ module LibraBFT.ImplShared.Interface.Output where
   isSendVote? (BroadcastSyncInfo _ _) = no λ ()
   isSendVote? (LogErr _)            = no λ ()
   isSendVote? (LogInfo _)           = no λ ()
+  isSendVote? (SendBRP _ _)         = no λ ()
   isSendVote? (SendVote mv pid)     = yes tt
 
   isBroadcastProposal? : (out : Output) →  Dec (IsBroadcastProposal out)
@@ -70,6 +76,7 @@ module LibraBFT.ImplShared.Interface.Output where
   isBroadcastProposal? (BroadcastSyncInfo _ _) = no λ ()
   isBroadcastProposal? (LogErr _)            = no λ ()
   isBroadcastProposal? (LogInfo _)           = no λ ()
+  isBroadcastProposal? (SendBRP _ _)         = no λ ()
   isBroadcastProposal? (SendVote _ _)        = no λ ()
 
   isBroadcastSyncInfo? : (out : Output) →  Dec (IsBroadcastSyncInfo out)
@@ -77,6 +84,7 @@ module LibraBFT.ImplShared.Interface.Output where
   isBroadcastSyncInfo? (BroadcastSyncInfo _ _) = yes tt
   isBroadcastSyncInfo? (LogErr _)              = no λ ()
   isBroadcastSyncInfo? (LogInfo _)             = no λ ()
+  isBroadcastSyncInfo? (SendBRP _ _)           = no λ ()
   isBroadcastSyncInfo? (SendVote _ _)          = no λ ()
 
   isLogErr? : (out : Output) → Dec (IsLogErr out)
@@ -84,6 +92,7 @@ module LibraBFT.ImplShared.Interface.Output where
   isLogErr? (BroadcastSyncInfo x _) = no λ ()
   isLogErr? (LogErr x)            = yes tt
   isLogErr? (LogInfo x)           = no λ ()
+  isLogErr? (SendBRP _ _)         = no λ ()
   isLogErr? (SendVote x x₁)       = no λ ()
 
   IsOutputMsg : Output → Set

--- a/LibraBFT/ImplShared/Interface/Output.agda
+++ b/LibraBFT/ImplShared/Interface/Output.agda
@@ -115,6 +115,7 @@ module LibraBFT.ImplShared.Interface.Output where
   outputToActions _  (LogErr x)            = []
   outputToActions _  (LogInfo x)           = []
   outputToActions _  (SendVote vm rcvrs)   = List-map (const (send (V vm))) rcvrs
+  outputToActions _  (SendBRP p brr)       = [] -- TODO-1: Update `NetworkMsg`
 
   outputsToActions : ∀ {State} → List Output → List (Action NetworkMsg)
   outputsToActions {st} = concat ∘ List-map (outputToActions st)
@@ -154,6 +155,8 @@ module LibraBFT.ImplShared.Interface.Output where
   sendVote∈actions {outs = LogErr x ∷ outs}{st = st} outs≡ m∈acts =
     sendVote∈actions{outs = outs}{st = st} outs≡ m∈acts
   sendVote∈actions {outs = LogInfo x ∷ outs}{st = st} outs≡ m∈acts =
+    sendVote∈actions{outs = outs}{st = st} outs≡ m∈acts
+  sendVote∈actions {vm}{vm'}{outs = SendBRP pid brr ∷ outs}{st = st} outs≡ m∈acts =
     sendVote∈actions{outs = outs}{st = st} outs≡ m∈acts
   sendVote∈actions {vm}{vm'}{outs = SendVote vm“ pids' ∷ outs}{st = st} outs≡ m∈acts
     with ∷-injective outs≡

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -225,6 +225,8 @@ module LibraBFT.Prelude where
     hiding (zip)
     public
 
+  fst = proj₁
+
   open import Data.Product.Properties
     public
 

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -495,6 +495,17 @@ module LibraBFT.Prelude where
   foldrM _ b      []  = return b
   foldrM f b (a ∷ as) = foldrM f b as >>= f a
 
+  foldlM : ∀ {ℓ₁ ℓ₂} {A B : Set ℓ₁} {M : Set ℓ₁ → Set ℓ₂} ⦃ _ : Monad M ⦄ → (B → A → M B) → B → List A → M B
+  foldlM _ z      []  = pure z
+  foldlM f z (x ∷ xs) = do
+    z' ← f z x
+    foldlM f z' xs
+
+  foldM = foldlM
+
+  foldM_ : {A B : Set} {M : Set → Set} ⦃ _ : Monad M ⦄ → (B → A → M B) → B → List A → M Unit
+  foldM_ f a xs = foldlM f a xs >> pure unit
+
   open import LibraBFT.Base.Util public
 
   record Eq {a} (A : Set a) : Set a where


### PR DESCRIPTION
This is a continuation of https://github.com/oracle/bft-consensus-agda/pull/117
It is the last NeedFetch PR.

- defined Output . SendBRP
- finished RoundManager.processBlockRetrievalRequestM so that is does SendBRP
- implement BlockStore.build
- BlockTree
  - implement new
  - postulate linkableBlockNew
- postulate Block.makeGenesisBlockFromLedgerInfo
- implement BlockRetrieval.verify
- postulate QuorumCert.certificateForGenesisFromLedgerInfo
- LedgerRecoveryData
  - implement findRoot
  - postulate several "library" functions
- RecoveryData.new : update to handle LedgerRecoveryData.findRoot errors
- RustTypes : define and use (and move some things from EpochIndep to here)
- EpochIndep
  - implement liEndsEpoch, bRound, equality instance on BlockRetrievalStatus
  - removed PendingVotes field from BlockTree
    - it lives in RoundState
    - it used to be here but move (in Rust and Haskell) a long time ago
- Prelude
  - implement fst, foldlM, foldM, foldM_
