### PR TITLE
Weakest precondition infrastructure for `Error`

### DIFF
--- a/LibraBFT/Base/KVMap.agda
+++ b/LibraBFT/Base/KVMap.agda
@@ -57,6 +57,7 @@ module LibraBFT.Base.KVMap  where
                   → lookup k kvm ≡ nothing
                   → KVMap Key Val
    elems          : KVMap Key Val → List Val
+   delete         : Key → KVMap Key Val → KVMap Key Val
 
    -- TODO-3: update properties to reflect kvm-update, consider combining insert/update
    kvm-update     : (k : Key)(v : Val)(kvm : KVMap Key Val)

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockRetriever.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockRetriever.agda
@@ -37,7 +37,7 @@ retrieveBlockForQCM _retriever qc numBlocks =
                       -- , lsHV blockId, show attempt ]
     peers0@(_ ∷ _) → do
       mme               ← use (lRoundManager ∙ rmObmMe)
-      maybeS-RWST mme (bail fakeErr) $ λ me → do
+      maybeSD mme (bail fakeErr) $ λ me → do
         nf                ← use lObmNeedFetch
         eitherS (pickPeer attempt peers0) bail $ λ (peer , peers) → do
           let request     = BlockRetrievalRequest∙new me blockId numBlocks

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockRetriever.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockRetriever.agda
@@ -8,6 +8,7 @@ import      LibraBFT.Base.KVMap                                   as Map
 import      LibraBFT.Impl.Consensus.ConsensusTypes.BlockRetrieval as BlockRetrieval
 import      LibraBFT.Impl.IO.OBM.ObmNeedFetch                     as ObmNeedFetch
 open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
 open import LibraBFT.ImplShared.Util.Util

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -30,7 +30,8 @@ module LibraBFT.Impl.Consensus.BlockStorage.BlockStore where
 
 getBlock : HashValue → BlockStore → Maybe ExecutedBlock
 
-executeAndInsertBlockE : BlockStore → Block → Either ErrLog (BlockStore × ExecutedBlock)
+executeAndInsertBlockE  : BlockStore → Block → Either  ErrLog (BlockStore × ExecutedBlock)
+executeAndInsertBlockE₀ : BlockStore → Block → EitherD ErrLog (BlockStore × ExecutedBlock)
 
 executeBlockE
   : BlockStore → Block
@@ -212,6 +213,8 @@ module executeAndInsertBlockE (bs0 : BlockStore) (block : Block) where
         pure ((bs0 & bsInner ∙~ bt') , eb')
 
 executeAndInsertBlockE bs block = toEither $ executeAndInsertBlockE.step₀ bs block
+
+executeAndInsertBlockE₀ bs block = fromEither $ executeAndInsertBlockE bs block
 
 executeBlockE bs block = do
   -- let compute        = bs ^. bsStateComputer.scCompute

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -13,6 +13,7 @@ open import LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock as ExecutedBloc
 open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote          as Vote
 open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.Impl.OBM.Prelude
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Interface.Output
@@ -27,15 +28,36 @@ import      Data.String as String
 module LibraBFT.Impl.Consensus.BlockStorage.BlockTree where
 
 postulate
-  addChild : LinkableBlock → HashValue → Either ErrLog LinkableBlock
+  linkableBlockNew : ExecutedBlock → LinkableBlock
 
-------------------------------------------------------------------------------
+postulate
+  addChild : LinkableBlock → HashValue → Either ErrLog LinkableBlock
 
 -- addChild : LinkableBlock → HashValue → Either ErrLog LinkableBlock
 -- addChild lb hv =
 --   if Set.member hv (lb ^∙ lbChildren)
 --   then Left  fakeErr
 --   else Right (lb & lbChildren %~ Set.insert hv)
+
+new : ExecutedBlock → QuorumCert → QuorumCert → Usize → Maybe TimeoutCertificate
+    → Either ErrLog BlockTree
+new root0 rootQuorumCert rootLedgerInfo maxPruned mHighestTimeoutCert = do
+  lcheck ((root0 ^∙ ebId) == (rootLedgerInfo ^∙ qcCommitInfo ∙ biId))
+         ("BlockTree" ∷ "newBlockTree" ∷ "inconsistent root and ledger info" ∷ [])
+  let idToBlock      = Map.insert (root0 ^∙ ebId) (linkableBlockNew root0) Map.empty
+      idToQuorumCert = Map.insert (rootQuorumCert ^∙ qcCertifiedBlock ∙ biId) rootQuorumCert Map.empty
+      prunedBlockIds = vdNew -- TODO
+   in pure $ mkBlockTree
+    idToBlock
+    (root0 ^∙ ebId)     -- _btRootId
+    (root0 ^∙ ebId)     -- _btHighestCertifiedBlockId
+    rootQuorumCert      -- _btHighestQuorumCert
+    mHighestTimeoutCert
+    rootLedgerInfo      -- _btHighestCommitCert
+    idToQuorumCert
+    prunedBlockIds
+    maxPruned
+
 
 replaceTimeoutCertM : TimeoutCertificate → LBFT Unit
 replaceTimeoutCertM tc = do
@@ -57,6 +79,10 @@ insertBlockE block bt = do
         let bt' = bt & btIdToBlock ∙~ Map.insert (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
         pure (  (bt' & btIdToBlock ∙~ Map.insert blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
              , block))
+
+insertBlockE₀ : ExecutedBlock → BlockTree
+              → EitherD ErrLog (BlockTree × ExecutedBlock)
+insertBlockE₀ block bt = fromEither $ insertBlockE block bt
 
 ------------------------------------------------------------------------------
 

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -88,10 +88,10 @@ insertBlockE₀ block bt = fromEither $ insertBlockE block bt
 
 module insertQuorumCertE (qc : QuorumCert) (bt0 : BlockTree) where
 
-  step₀     : Either ErrLog (BlockTree × List InfoLog)
-  step₁     : HashValue → Either ErrLog (BlockTree × List InfoLog)
-  step₂     : HashValue → ExecutedBlock → Either ErrLog (BlockTree × List InfoLog)
-  step₃     : HashValue → ExecutedBlock → ExecutedBlock → Either ErrLog (BlockTree × List InfoLog)
+  step₀     : EitherD ErrLog (BlockTree × List InfoLog)
+  step₁     : HashValue → EitherD ErrLog (BlockTree × List InfoLog)
+  step₂     : HashValue → ExecutedBlock → EitherD ErrLog (BlockTree × List InfoLog)
+  step₃     : HashValue → ExecutedBlock → ExecutedBlock → EitherD ErrLog (BlockTree × List InfoLog)
   continue1 : BlockTree → HashValue → ExecutedBlock → List InfoLog → (BlockTree × List InfoLog)
   continue2 : BlockTree → List InfoLog → (BlockTree × List InfoLog)
   here' : List String.String → List String.String
@@ -107,17 +107,17 @@ module insertQuorumCertE (qc : QuorumCert) (bt0 : BlockTree) where
                  (here' ("failed check" ∷ "existing qc == qc || existing qc.round /= qc.round" ∷ []))
   step₀ =
     case safetyInvariant of λ where
-      (Left  e)    → Left e
+      (Left  e)    → LeftD e
       (Right unit) → step₁ blockId
 
   step₁ blockId =
-        maybeS (btGetBlock blockId bt0) (Left fakeErr) $ step₂ blockId
+        maybeSD (btGetBlock blockId bt0) (LeftD fakeErr) $ step₂ blockId 
 
   step₂ blockId block =
-        maybeS (bt0 ^∙ btHighestCertifiedBlock) (Left fakeErr) $ step₃ blockId block 
+        maybeSD (bt0 ^∙ btHighestCertifiedBlock) (LeftD fakeErr) $ step₃ blockId block
 
   step₃ blockId block hcb =
-        if-dec ((block ^∙ ebRound) >? (hcb ^∙ ebRound))
+        ifD ((block ^∙ ebRound) >? (hcb ^∙ ebRound))
         then
          (let bt   = bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId
                          & btHighestQuorumCert       ∙~ qc
@@ -135,7 +135,10 @@ module insertQuorumCertE (qc : QuorumCert) (bt0 : BlockTree) where
     else (bt , info)
 
 insertQuorumCertE : QuorumCert → BlockTree → Either ErrLog (BlockTree × List InfoLog)
-insertQuorumCertE = insertQuorumCertE.step₀
+insertQuorumCertE qc = toEither ∘ insertQuorumCertE.step₀ qc
+
+insertQuorumCertE₀ : QuorumCert → BlockTree → Either ErrLog (BlockTree × List InfoLog)
+insertQuorumCertE₀ qc = fromEither ∘ insertQuorumCertE qc
 
 insertQuorumCertM : QuorumCert → LBFT Unit
 insertQuorumCertM qc = do

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -57,6 +57,7 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
 
   open import LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockTree
 
+  ------   These are used only outside this module.  
   Ok : Set
   Ok = ∃₂ λ bs' eb → executeAndInsertBlockE bs0 block ≡ Right (bs' , eb)
 
@@ -66,6 +67,7 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
 
   Err : Set
   Err = ∃[ e ] (executeAndInsertBlockE bs0 block ≡ Left e)
+  ------
 
   record ContractOk (bs' : BlockStore) (eb : ExecutedBlock) : Set where
     constructor mkContractOk
@@ -77,8 +79,7 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
       -- for QCs then follows as a consequence
       qcPost : ∀ qc → qc QCProps.∈BlockTree (bs' ^∙ bsInner)
                → qc QCProps.∈BlockTree (bs0 ^∙ bsInner) ⊎ qc ≡ block ^∙ bQuorumCert
-      qcPres : ∀ pre → pre ^∙ rmBlockStore ≡ bs0
-               → ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre (pre & lBlockStore ∙~ bs')
+      qcPres : ∀ qc → PreservesL (qc QCProps.∈RoundManager_) (rmBlockStore) bs0 bs'
 
   Contract : EitherD-Post ErrLog (BlockStore × ExecutedBlock)
   Contract (Left x) = ⊤
@@ -98,8 +99,8 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
     btP : ∀ bs' pre → pre ^∙ lBlockStore ≡ bs' → Preserves BlockStoreInv pre (pre & lBlockStore ∙~ bs')
     btP bs' pre preBS≡ = substBlockStoreInv preBS≡ refl
 
-    qcPres : ∀ pre → pre ^∙ rmBlockStore ≡ bs0 → ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre (pre & rmBlockStore ∙~ bs0)
-    qcPres pre refl qc = id
+    qcPres : ∀ qc → PreservesL (qc QCProps.∈RoundManager_) rmBlockStore bs0 bs0
+    qcPres qc rm = id
 
   proj₁ contract' getBlock≡nothing = contract₁
     where
@@ -164,9 +165,8 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
                      bt' eb' con
            ...| qcPost' rewrite eb≈ = qcPost'
 
-           qcPres : ∀ pre → pre ^∙ rmBlockStore ≡ bs0
-                    → ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre (pre & rmBlockStore ∙~ BlockStore∙new bt' (bs0 ^∙ bsStorage))
-           qcPres = obm-dangerous-magic' "TODO: refine contract for `insertBlockE`"
+           qcPres : ∀ qc → PreservesL (qc QCProps.∈RoundManager_) rmBlockStore bs0 (BlockStore∙new bt' (bs0 ^∙ bsStorage))
+           qcPres qc rm = obm-dangerous-magic' "TODO: refine contract for `insertBlockE`"
 
   contract : Contract (executeAndInsertBlockE bs0 block)
   contract = EitherD-contract (executeAndInsertBlockE.step₀ bs0 block) Contract contract'

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -80,11 +80,11 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
       qcPres : ∀ pre → pre ^∙ rmBlockStore ≡ bs0
                → ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre (pre & lBlockStore ∙~ bs')
 
-  Contract : Error-Post ErrLog (BlockStore × ExecutedBlock)
+  Contract : EitherD-Post ErrLog (BlockStore × ExecutedBlock)
   Contract (Left x) = ⊤
   Contract (Right (bs' , eb)) = ContractOk bs' eb
 
-  contract' : Error-weakestPre (executeAndInsertBlockE.step₀ bs0 block) Contract
+  contract' : EitherD-weakestPre (executeAndInsertBlockE.step₀ bs0 block) Contract
   proj₂ contract' eb eb≡ =
     mkContractOk ebBlock≈ (btP bs0) (λ qc → Left) qcPres
     where
@@ -103,17 +103,17 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
 
   proj₁ contract' getBlock≡nothing = contract₂
     where
-    contract₂ : Error-weakestPre step₂ Contract
+    contract₂ : EitherD-weakestPre step₂ Contract
     proj₁ contract₂ _ = tt
     proj₂ contract₂ bsr bsr≡ = contract₃
       where
-      contract₃ : Error-weakestPre (step₃ bsr) Contract
+      contract₃ : EitherD-weakestPre (step₃ bsr) Contract
       proj₁ contract₃ _ = tt
       proj₂ contract₃ btr<br = contract₄
         where
-        contract₅ : ∀ eb → eb ^∙ ebBlock ≈Block block → Error-weakestPre (step₅ bsr eb) Contract
+        contract₅ : ∀ eb → eb ^∙ ebBlock ≈Block block → EitherD-weakestPre (step₅ bsr eb) Contract
 
-        contract₄ : Error-weakestPre (step₄ bsr) Contract
+        contract₄ : EitherD-weakestPre (step₄ bsr) Contract
         contract₄
            with executeBlockE bs0 block
            |    inspect (executeBlockE bs0) block
@@ -127,7 +127,6 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
         ...| Left _ = tt
         ...| Right _
            with executeBlockE bs0 block
-        ...| Right _ = obm-dangerous-magic' "TODO-1: prove (waiting on: update to `executeAndInsertBlockE`)"
         ...| Left  _ = tt
         contract₄ | Left (ErrVerify _) | [ executeBlockE≡ ] = tt
 
@@ -136,7 +135,7 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
         ...| Left _ = tt
         ...| Right bs1 = λ where ._ refl → contract₆
            where
-           contract₆ : Error-weakestPre (step₆ bsr eb) Contract
+           contract₆ : EitherD-weakestPre (step₆ bsr eb) Contract
            contract₆
               with insertBlockESpec.contract eb (bs0 ^∙ bsInner)
            ...| con
@@ -172,7 +171,7 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
               qcPres = obm-dangerous-magic' "TODO: refine contract for `insertBlockE`"
 
   contract : Contract (executeAndInsertBlockE bs0 block)
-  contract = Error-contract (executeAndInsertBlockE.step₀ bs0 block) Contract contract'
+  contract = EitherD-contract (executeAndInsertBlockE.step₀ bs0 block) Contract contract'
 
 
 module executeAndInsertBlockMSpec (b : Block) where

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -80,111 +80,100 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
       qcPres : ∀ pre → pre ^∙ rmBlockStore ≡ bs0
                → ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre (pre & lBlockStore ∙~ bs')
 
-  Contract : Set
-  Contract = (isOk : Ok) → let (bs' , eb , _) = isOk in ContractOk bs' eb
+  Contract : Error-Post ErrLog (BlockStore × ExecutedBlock)
+  Contract (Left x) = ⊤
+  Contract (Right (bs' , eb)) = ContractOk bs' eb
 
-  contract : (isOk : Ok) → let (bs' , eb , _) = isOk in ContractOk bs' eb
-  contract (bs' , eb , isOk)
-     with getBlock (block ^∙ bId) bs0
-     |    inspect (getBlock (block ^∙ bId)) bs0
-  contract (bs' , .eb , refl) | just eb | [ getbId≡ ] =
-    mkContractOk ebBlock≈ {- ebBlockData≡ -} (btP bs') (λ qc → Left) qcPres
+  contract' : Error-weakestPre (executeAndInsertBlockE.step₀ bs0 block) Contract
+  proj₂ contract' eb eb≡ =
+    mkContractOk ebBlock≈ (btP bs0) (λ qc → Left) qcPres
     where
-    btP : ∀ bs' pre → pre ^∙ lBlockStore ≡ bs' → Preserves BlockStoreInv pre (pre & lBlockStore ∙~ bs')
-    btP bs' pre preBS≡ = substBlockStoreInv preBS≡ refl
-
     ebBlock≈ : eb ^∙ ebBlock ≈Block block
     ebBlock≈ =
       getBlockSpec.correctBlockData (block ^∙ bId) bs0 (block ^∙ bBlockData)
-        (obm-dangerous-magic' "TODO: propagate this information from `Network.processProposal`")
-        (eb , getbId≡)
+        (hashBD (block ^∙ bBlockData) ≡ block ^∙ bId
+         ∋ obm-dangerous-magic' "TODO: propagate this information from `Network.processProposal`")
+        (eb , eb≡)
 
-    qcPres : ∀ pre → pre ^∙ rmBlockStore ≡ bs' → ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre (pre & rmBlockStore ∙~ bs')
+    btP : ∀ bs' pre → pre ^∙ lBlockStore ≡ bs' → Preserves BlockStoreInv pre (pre & lBlockStore ∙~ bs')
+    btP bs' pre preBS≡ = substBlockStoreInv preBS≡ refl
+
+    qcPres : ∀ pre → pre ^∙ rmBlockStore ≡ bs0 → ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre (pre & rmBlockStore ∙~ bs0)
     qcPres pre refl qc = id
 
-  ...| nothing | [ getbId≡ ]
-    with pf-step₂ isOk
+  proj₁ contract' getBlock≡nothing = contract₂
     where
-    pf-step₂ : Ok' bs' eb step₂ → ∃[ bsr ] (just bsr ≡ bs0 ^∙ bsRoot × Ok' bs' eb (step₃ bsr))
-    pf-step₂ isOk
-       with bs0 ^∙ bsRoot
-    ... | just bsr = bsr , (refl , isOk)
-  ...| (bsr , bsr≡ , isOk₂)
-     with pf-step₃ isOk₂
-     where
-     pf-step₃ : Ok' bs' eb (step₃ bsr) → (block ^∙ bRound > bsr ^∙ ebRound) × Ok' bs' eb (step₄ bsr)
-     pf-step₃ isOk
-        with bsr ^∙ ebRound ≥?ℕ block ^∙ bRound
-     ... | yes round≥ = absurd Left _ ≡ Right _ case isOk of λ ()
-     ... | no  round< = ≰⇒> round< , isOk
-  ...| br>bsrr , isOk₃
-     with pf-step₄ isOk₃
-     where
-     pf-step₄ : Ok' bs' eb (step₄ bsr) → ∃[ eb' ] (eb' ^∙ ebBlock ≈Block block × Ok' bs' eb (step₅ bsr eb'))
-     pf-step₄ isOk
-        with executeBlockE bs0 block
-        |    inspect (executeBlockE bs0) block
-     ...| Right res | [ ebe≡ ] = res , EB.ebBlock≈ , isOk
-       where
-       module EB = executeBlockESpec.ContractOk (executeBlockESpec.contract bs0 block (res , ebe≡))
-     ...| Left (ErrBlockNotFound parentBlockId) | [ ebe≡ ]
-        with pathFromRoot parentBlockId bs0
-     ...| Right blocksToReexecute
-        with (forM) blocksToReexecute (executeBlockE bs0 ∘ (_^∙ ebBlock))
-     ...| Right _
-        with executeBlockE bs0 block
-        |    inspect (executeBlockE bs0) block
-     ...| Left _ | _ = absurd Left _ ≡ Right _ case isOk of λ ()
-     -- NOTE: The case below is unreachable, since we already know the result of
-     -- `executeBlockE bs0 block`. This likely means the model (and Haskell
-     -- prototype) needs to be updated.
-     ...| Right eb' | [ ebe≡₁ ] = eb' , EB.ebBlock≈ , isOk
+    contract₂ : Error-weakestPre step₂ Contract
+    proj₁ contract₂ _ = tt
+    proj₂ contract₂ bsr bsr≡ = contract₃
+      where
+      contract₃ : Error-weakestPre (step₃ bsr) Contract
+      proj₁ contract₃ _ = tt
+      proj₂ contract₃ btr<br = contract₄
         where
-        module EB = executeBlockESpec.ContractOk (executeBlockESpec.contract bs0 block (eb' , ebe≡₁))
-  ...| eb' , eb≈ , isOk₅
-     with pf-step₅ isOk₅
-     where
-     pf-step₅ : Ok' bs' eb (step₅ bsr eb') → Ok' bs' eb (step₆ bsr eb')
-     pf-step₅ isOk
-        with PersistentLivenessStorage.saveTreeE bs0 (eb' ^∙ ebBlock ∷ []) []
-     ... | Right bs1 = isOk
-  ...| isOk₆ = pf-step₆ isOk₆
-     where
-     pf-step₆ : Ok' bs' eb (step₆ bsr eb') → ContractOk bs' eb
-     pf-step₆ isOk
-        with insertBlockESpec.contract eb' (bs0 ^∙ bsInner)
-     ...| IBCon
-        with BlockTree.insertBlockE eb' (bs0 ^∙ bsInner)
-        |    inspect (BlockTree.insertBlockE eb') (bs0 ^∙ bsInner)
-     pf-step₆ isOk | IBCon | Right (bt' , eb“) | [ insp ]
-        with isOk
-     ...| refl =
-        mkContractOk ebBlock≈ btP qcPost {- qcPost -} qcPres
-        where
-        module IBE = insertBlockESpec.ContractOk IBCon
+        contract₅ : ∀ eb → eb ^∙ ebBlock ≈Block block → Error-weakestPre (step₅ bsr eb) Contract
 
-        ebBlock≈ : eb“ ^∙ ebBlock ≈Block block
-        ebBlock≈ = sym≈Block $ begin
-          block                                                  ≡⟨ sym≈Block eb≈ ⟩
-          (eb' ^∙ ebBlock & bSignature ∙~ (block ^∙ bSignature)) ≡⟨ sym≈Block IBE.block≈ ⟩
-          (eb“ ^∙ ebBlock & bSignature ∙~ (block ^∙ bSignature)) ∎
-          where open ≡-Reasoning
+        contract₄ : Error-weakestPre (step₄ bsr) Contract
+        contract₄
+           with executeBlockE bs0 block
+           |    inspect (executeBlockE bs0) block
+        ...| Right res | [ executeBlock≡ ] = λ where ._ refl → contract₅ res EB.ebBlock≈
+           where module EB = executeBlockESpec.ContractOk (executeBlockESpec.contract bs0 block (res , executeBlock≡))
+        ...| Left (ErrBlockNotFound parentBlockId) | [ executeBlockE≡ ]
+           with pathFromRoot parentBlockId bs0
+        ...| Left _ = tt
+        ...| Right blocksToReexecute
+           with (forM) blocksToReexecute (executeBlockE bs0 ∘ (_^∙ ebBlock))
+        ...| Left _ = tt
+        ...| Right _
+           with executeBlockE bs0 block
+        ...| Right _ = obm-dangerous-magic' "TODO-1: prove (waiting on: update to `executeAndInsertBlockE`)"
+        ...| Left  _ = tt
+        contract₄ | Left (ErrVerify _) | [ executeBlockE≡ ] = tt
 
-        btP : ∀ rm → rm ^∙ lBlockStore ≡ bs0 → Preserves BlockStoreInv rm (rm & rmBlockStore ∙~ bs')
-        btP rm bs≡
-          with insertBlockESpec.preservesBlockStoreInv eb' (bs0 ^∙ bsInner)
-                 (bs' ^∙ bsInner) eb“ IBCon rm (cong (_^∙ bsInner) bs≡)
-        ...| Right col = ⊥-elim col -- TODO: propagate hash collision upward
-        ...| Left pres = pres
+        contract₅ eb eb≈
+           with PersistentLivenessStorage.saveTreeE bs0 ((eb ^∙ ebBlock) ∷ []) []
+        ...| Left _ = tt
+        ...| Right bs1 = λ where ._ refl → contract₆
+           where
+           contract₆ : Error-weakestPre (step₆ bsr eb) Contract
+           contract₆
+              with insertBlockESpec.contract eb (bs0 ^∙ bsInner)
+           ...| con
+              with BlockTree.insertBlockE eb (bs0 ^∙ bsInner)
+           ...| Left  _ = tt
+           ...| Right (bt' , eb') =
+             λ where ._ refl → mkContractOk ebBlock≈ btP qcPost qcPres
+              where
+              module IBE = insertBlockESpec.ContractOk con
 
-        qcPost : QCProps.∈Post⇒∈PreOrBT (_≡ block ^∙ bQuorumCert) (bs0 ^∙ bsInner) bt'
-        qcPost
-           with insertBlockESpec.qcPost eb' (bs0 ^∙ bsInner) bt' eb“ IBCon
-        ...| qcPost' rewrite eb≈ = qcPost'
+              ebBlock≈ : eb' ^∙ ebBlock ≈Block block
+              ebBlock≈ = sym≈Block $ begin
+                block                                                  ≡⟨ sym≈Block eb≈ ⟩
+                (eb  ^∙ ebBlock & bSignature ∙~ (block ^∙ bSignature)) ≡⟨ sym≈Block IBE.block≈ ⟩
+                (eb' ^∙ ebBlock & bSignature ∙~ (block ^∙ bSignature)) ∎
+                where open ≡-Reasoning
 
-        qcPres : ∀ pre → pre ^∙ rmBlockStore ≡ bs0
-                 → ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre (pre & rmBlockStore ∙~ BlockStore∙new bt' (bs0 ^∙ bsStorage))
-        qcPres = obm-dangerous-magic' "TODO: refine contract for `executeAndInsertBlockE`"
+              btP : ∀ rm → rm ^∙ lBlockStore ≡ bs0 → Preserves BlockStoreInv rm (rm & rmBlockStore ∙~ (bs0 & bsInner ∙~ bt'))
+              btP rm bs≡
+                 with insertBlockESpec.preservesBlockStoreInv eb (bs0 ^∙ bsInner)
+                        bt' eb' con rm (cong (_^∙ bsInner) bs≡)
+              ...| Right hashCollision = ⊥-elim hashCollision -- TODO-2: propagate hash collision upward
+              ...| Left pres = pres
+
+              qcPost : QCProps.∈Post⇒∈PreOrBT (_≡ block ^∙ bQuorumCert) (bs0 ^∙ bsInner) bt'
+              qcPost
+                 with insertBlockESpec.qcPost eb (bs0 ^∙ bsInner)
+                        bt' eb' con
+              ...| qcPost' rewrite eb≈ = qcPost'
+
+              qcPres : ∀ pre → pre ^∙ rmBlockStore ≡ bs0
+                       → ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre (pre & rmBlockStore ∙~ BlockStore∙new bt' (bs0 ^∙ bsStorage))
+              qcPres = obm-dangerous-magic' "TODO: refine contract for `insertBlockE`"
+
+  contract : Contract (executeAndInsertBlockE bs0 block)
+  contract = Error-contract (executeAndInsertBlockE.step₀ bs0 block) Contract contract'
+
 
 module executeAndInsertBlockMSpec (b : Block) where
   -- NOTE: This function returns any errors, rather than producing them as output.
@@ -200,10 +189,9 @@ module executeAndInsertBlockMSpec (b : Block) where
            → Post (Right eb) (pre & rmBlockStore ∙~ bs') [])
         → LBFT-weakestPre (executeAndInsertBlockM b) Post pre
     proj₁ (contract Post pfBail pfOk ._ refl) e ≡left = pfBail e
-    proj₂ (contract Post pfBail pfOk ._ refl) (bs' , eb) ≡right ._ refl unit refl =
-      pfOk isOk (executeAndInsertBlockESpec.contract bs b isOk)
-      where
-      isOk = (bs' , eb , ≡right)
+    proj₂ (contract Post pfBail pfOk ._ refl) (bs' , eb) ≡right ._ refl unit refl
+       with executeAndInsertBlockESpec.contract bs b
+    ...| con rewrite ≡right = pfOk (bs' , eb , refl) con
 
 module insertSingleQuorumCertMSpec
   (qc : QuorumCert) where

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
@@ -33,6 +33,10 @@ isGenesisBlock b = BlockData.isGenesisBlock (b ^∙ bBlockData)
 isNilBlock : Block → Bool
 isNilBlock b = BlockData.isNilBlock (b ^∙ bBlockData)
 
+postulate
+  -- This is not needed until epoch change is implements/supported.
+  makeGenesisBlockFromLedgerInfo : LedgerInfo → Block
+
 newProposalFromBlockDataAndSignature : BlockData → Signature → Block
 newProposalFromBlockDataAndSignature blockData signature =
   Block∙new (hashBD blockData) blockData (just signature)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/BlockRetrieval.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/BlockRetrieval.agda
@@ -7,12 +7,14 @@
 open import LibraBFT.Base.PKCS hiding (verify)
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Block      as Block
 import      LibraBFT.Impl.Consensus.ConsensusTypes.BlockData  as BlockData
 import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert as QuorumCert
 import      LibraBFT.Impl.Types.BlockInfo                     as BlockInfo
 import      LibraBFT.Impl.Types.ValidatorVerifier             as ValidatorVerifier
 open import LibraBFT.Impl.OBM.Crypto hiding (verify)
 open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util
@@ -23,7 +25,27 @@ import      Data.String                                       as String
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.BlockRetrieval where
 
-postulate
-  verify
-    : BlockRetrievalResponse → HashValue → U64 → ValidatorVerifier
-    → Either ErrLog Unit
+verify : BlockRetrievalResponse → HashValue → U64 → ValidatorVerifier → Either ErrLog Unit
+verify self blockId numBlocks sigVerifier =
+  grd‖ self ^∙ brpStatus /= BRSSucceeded ≔
+       Left fakeErr -- here ["/= BRSSucceeded"]
+     ‖ length (self ^∙ brpBlocks) /= numBlocks ≔
+       Left fakeErr -- here ["not enough blocks returned", show (self^.brpBlocks), show numBlocks]
+     ‖ otherwise≔
+       verifyBlocks (self ^∙ brpBlocks)
+ where
+  here' : List String.String → List String.String
+  here' t = "BlockRetrieval" ∷ "verify" ∷ t
+
+  verifyBlock : HashValue → Block → Either ErrLog HashValue
+
+  verifyBlocks : List Block → Either ErrLog Unit
+  verifyBlocks blks = foldM_ verifyBlock blockId blks
+
+  verifyBlock expectedId block = do
+    Block.validateSignature block sigVerifier
+    Block.verifyWellFormed  block
+    lcheck (block ^∙ bId == expectedId)
+           (here' ("blocks do not form a chain" ∷ [])) -- lsHV (block^.bId), lsHV expectedId
+    pure (block ^∙ bParentId)
+

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
@@ -21,6 +21,10 @@ import      Data.String                                     as String
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert where
 
+postulate
+  -- not needed until epoch change is supported
+  certificateForGenesisFromLedgerInfo : LedgerInfo → HashValue → QuorumCert
+
 verify : QuorumCert → ValidatorVerifier → Either ErrLog Unit
 verify self validator = do
   let voteHash = hashVD (self ^∙ qcVoteData)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/TimeoutCertificate.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/TimeoutCertificate.agda
@@ -10,7 +10,7 @@ open import LibraBFT.Impl.OBM.Crypto              hiding (verify)
 open import LibraBFT.Impl.OBM.Logging.Logging
 import      LibraBFT.Impl.Types.ValidatorVerifier as ValidatorVerifier
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.ImplShared.Util.RWST.Syntax
+open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 

--- a/LibraBFT/Impl/Consensus/LedgerRecoveryData.agda
+++ b/LibraBFT/Impl/Consensus/LedgerRecoveryData.agda
@@ -5,6 +5,9 @@
 -}
 
 open import LibraBFT.Base.Types
+open import LibraBFT.Hash
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Block      as Block
+import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert as QuorumCert
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util
@@ -13,7 +16,48 @@ open import Optics.All
 
 module LibraBFT.Impl.Consensus.LedgerRecoveryData where
 
-postulate -- TODO-2: implement
-  findRoot
-   : List Block → List QuorumCert → LedgerRecoveryData
-   → (RootInfo × List Block × List QuorumCert)
+postulate
+  compareX  : (Epoch × Round) → (Epoch × Round) → Ordering
+  sortBy    : (Block → Block → Ordering) → List Block → List Block
+  findIndex : (Block → Bool) → List Block → Maybe ℕ
+  deleteAt  : ℕ → List Block → List Block
+  find      : (QuorumCert → Bool) → List QuorumCert -> Maybe QuorumCert
+
+findRoot : List Block → List QuorumCert → LedgerRecoveryData
+         → Either ErrLog (RootInfo × List Block × List QuorumCert)
+findRoot blocks0 quorumCerts0 (LedgerRecoveryData∙new storageLedger) = do
+  let (rootId , (blocks1 , quorumCerts)) =
+        if storageLedger ^∙ liEndsEpoch
+        then
+          (let genesis   = Block.makeGenesisBlockFromLedgerInfo storageLedger
+               genesisQC = QuorumCert.certificateForGenesisFromLedgerInfo storageLedger (genesis ^∙ bId)
+           in (genesis ^∙ bId , (genesis ∷ blocks0 , genesisQC ∷ quorumCerts0)))
+        else
+           (storageLedger ^∙ liConsensusBlockId , (blocks0 , quorumCerts0))
+      sorter : Block → Block → Ordering
+      sorter = λ bl br → compareX (bl ^∙ bEpoch , bl ^∙ bRound) (br ^∙ bEpoch , br ^∙ bRound)
+      sortedBlocks = sortBy sorter blocks1
+  rootIdx          ← maybeS
+        (findIndex (λ x → x ^∙ bId == rootId) sortedBlocks)
+        (Left fakeErr) -- ["unable to find root", show rootId]
+        (pure ∘ id)
+  rootBlock         ← maybeS
+        (sortedBlocks !? rootIdx)
+        (Left fakeErr) -- ["sortedBlocks !? rootIdx"]
+        (pure ∘ id)
+  let blocks       = deleteAt rootIdx sortedBlocks
+  rootQuorumCert   ← maybeS
+        (find (λ x → x ^∙ qcCertifiedBlock ∙ biId == rootBlock ^∙ bId) quorumCerts)
+        (Left fakeErr) -- ["No QC found for root", show rootId]
+        (pure ∘ id)
+  rootLedgerInfo   ← maybeS
+        (find (λ x → x ^∙ qcCommitInfo ∙ biId == rootBlock ^∙ bId) quorumCerts)
+        (Left fakeErr) -- ["No LI found for root", show rootId]
+        (pure ∘ id)
+  pure (RootInfo∙new rootBlock rootQuorumCert rootLedgerInfo , blocks , quorumCerts)
+{-
+ where
+  here t = "LedgerRecoveryData":"findRoot":t
+  deleteAt idx xs = lft ++ tail rgt where (lft, rgt) = splitAt idx xs
+  tail = \case [] -> []; (_:xs) -> xs
+-}

--- a/LibraBFT/Impl/Consensus/Liveness/ExponentialTimeInterval.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ExponentialTimeInterval.agda
@@ -1,0 +1,32 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.OBM.Rust.Duration     as Duration
+open import LibraBFT.Impl.OBM.Rust.RustTypes
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.Liveness.ExponentialTimeInterval where
+
+new : Duration → F64 → Usize → ExponentialTimeInterval
+new base exponentBase maxExponent =
+{- TODO-1
+  if | maxExponent >= 32
+       -> errorExit [ "ExponentialTimeInterval", "new"
+                    , "maxExponent for PacemakerTimeInterval should be < 32", show maxExponent ]
+     | ceiling (exponentBase ** fromIntegral maxExponent) >= {-F64-} (maxBound::Int)
+       -> errorExit [ "ExponentialTimeInterval", "new"
+                    , "maximum interval multiplier should be less then u32::Max"]
+     | otherwise
+       ->
+-}        mkExponentialTimeInterval
+            (Duration.asMillis base)
+            exponentBase
+            maxExponent

--- a/LibraBFT/Impl/Consensus/Liveness/Properties/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/Properties/ProposerElection.agda
@@ -30,7 +30,7 @@ module isValidProposalMSpec (b : Block) where
       → (Maybe-Any (getValidProposer (pe pre) round ≡_) mAuthor
          → Post (Right unit) pre [])
       → LBFT-weakestPre (isValidProposalM b) Post pre
-  -- 1. `isValidProposalM` begins with `caseMM`, so we must provide two cases:
+  -- 1. `isValidProposalM` begins with `RWST-maybe`, so we must provide two cases:
   --    one where `b ^∙ bAuthor` is `nothing` and one where it is `just`
   --    something
   -- 2. When it is nothing, we appeal to the assumed proof
@@ -50,11 +50,11 @@ module isValidProposalMSpec (b : Block) where
   --    `isValidProposer`, we perform case-analysis on each of the equality
   --    proofs (we can't pattern match on `ma≡just-a` directly)
   -- > proj₂ (contract pre Post pfNone pf≢ pfOk) a ma≡just-a ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl = {!!}
-  -- 5. Now we encounter an `ifM`, which means we must provide two cases, one corresponding to each branch.
+  -- 5. Now we encounter an `ifD`, which means we must provide two cases, one corresponding to each branch.
   proj₁ (proj₂ (contract pre Post pfNone pf≢ pfOk) a ma≡just-a ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl ._ refl) vp≡true
   -- 6. The types of `pfOk` and `pf≢` are still "stuck" on the expression
   -- > b ^∙ bAuthor
-  --    So, both the `false` and `true` cases we rewrite by `ma≡just-a`, which
+  --    So, in both the `false` and `true` cases we rewrite by `ma≡just-a`, which
   --    tells us that the result is `just a`
     rewrite ma≡just-a =
   -- 7. To finish, we use `toWitnessF` to convert between the two forms of evidence.

--- a/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposerElection.agda
@@ -21,10 +21,10 @@ isValidProposer : ProposerElection → Author → Round → Bool
 
 isValidProposalM : Block → LBFT (Either ObmNotValidProposerReason Unit)
 isValidProposalM b =
-  maybeS-RWST (b ^∙ bAuthor) (bail ProposalDoesNotHaveAnAuthor) $ λ a → do
+  maybeSD (b ^∙ bAuthor) (bail ProposalDoesNotHaveAnAuthor) $ λ a → do
     -- IMPL-DIFF: `ifM` in Haskell means something else
     vp ← isValidProposerM a (b ^∙ bRound)
-    if-RWST vp
+    ifD vp
       then ok unit
       else bail ProposerForBlockIsNotValidForThisRound
 

--- a/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
@@ -14,7 +14,9 @@ import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote             as Vote
 import      LibraBFT.Impl.Consensus.PendingVotes                    as PendingVotes
 import      LibraBFT.Impl.OBM.ECP-LBFT-OBM-Diff.ECP-LBFT-OBM-Diff-1 as ECP-LBFT-OBM-Diff-1
 open import LibraBFT.Impl.OBM.Logging.Logging
-open import LibraBFT.Impl.OBM.Rust.Duration
+open import LibraBFT.Impl.OBM.Rust.Duration                         as Duration
+open import LibraBFT.Impl.OBM.Rust.RustTypes
+open import LibraBFT.Impl.OBM.Time
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
@@ -22,15 +24,25 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+------------------------------------------------------------------------------
+open import Agda.Builtin.Float
 
 module LibraBFT.Impl.Consensus.Liveness.RoundState where
 
 ------------------------------------------------------------------------------
 
-postulate
-  setupTimeoutM : Instant → LBFT Duration
+new : RoundStateTimeInterval → Instant → RoundState
+new ti i = mkRoundState
+  {-_rsTimeInterval          =-} ti
+  {-_rsHighestCommittedRound =-} {-Round-} 0
+  {-_rsCurrentRound          =-} {-Round-} 0
+  {-_rsCurrentRoundDeadline  =-} i
+  {-_rsPendingVotes          =-} PendingVotes∙new
+  {-_rsVoteSent              =-} nothing
 
 ------------------------------------------------------------------------------
+
+setupTimeoutM : Instant → LBFT Duration
 
 processLocalTimeoutM : Instant → Epoch → Round → LBFT Bool
 processLocalTimeoutM now obmEpoch round = do
@@ -80,3 +92,39 @@ insertVoteM vote verifier = do
 recordVoteM : Vote → LBFT Unit
 recordVoteM v = rsVoteSent-rm ∙= just v
 
+------------------------------------------------------------------------------
+
+setupDeadlineM                : Instant → LBFT Duration
+roundIndexAfterCommittedRound : Round → Round → Round
+getRoundDuration              : ExponentialTimeInterval → Round → Duration
+
+setupTimeoutM now = do
+  timeout ← setupDeadlineM now
+  r       ← use (lRoundState ∙ rsCurrentRound)
+  -- act (SetTimeout timeout r)
+  pure timeout
+
+setupDeadlineM now = do
+  ti          ← use (lRoundState ∙ rsTimeInterval)
+  cr          ← use (lRoundState ∙ rsCurrentRound)
+  hcr         ← use (lRoundState ∙ rsHighestCommittedRound)
+  let timeout = getRoundDuration ti (roundIndexAfterCommittedRound cr hcr)
+  lRoundState ∙ rsCurrentRoundDeadline ∙= iPlus now timeout
+  pure timeout
+
+roundIndexAfterCommittedRound currentRound highestCommittedRound =
+  grd‖ highestCommittedRound == 0                 ≔ currentRound ∸ 1
+     ‖ currentRound <?ℕ highestCommittedRound + 3 ≔ 0
+     ‖ otherwise≔                                   currentRound ∸ highestCommittedRound ∸ 3
+
+postulate
+  _**_    : Float → Float → Float
+  ceiling : Float → U64
+
+getRoundDuration i r =
+  let pow            = min r (i ^∙ etiMaxExponent) -- TODO/NOTE: cap on max timeout
+                                                   -- undermines theoretical liveness properties
+      baseMultiplier = (i ^∙ etiExponentBase) ** {-fromIntegral-} primNatToFloat pow
+    --durationMs     = ceiling (fromIntegral (i^.etiBaseMs) * baseMultiplier)
+      durationMs     = ceiling (primFloatTimes (primNatToFloat (i ^∙ etiBaseMs)) baseMultiplier)
+   in Duration.fromMillis durationMs

--- a/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/RoundState.agda
@@ -35,7 +35,7 @@ postulate
 processLocalTimeoutM : Instant → Epoch → Round → LBFT Bool
 processLocalTimeoutM now obmEpoch round = do
   currentRound ← use (lRoundState ∙ rsCurrentRound)
-  if-RWST round /= currentRound
+  ifD round /= currentRound
     then pure false
     else do
       void (setupTimeoutM now) -- setup the next timeout
@@ -49,11 +49,11 @@ processCertificatesM : Instant → SyncInfo → LBFT (Maybe NewRoundEvent)
 processCertificatesM now syncInfo = do
   -- logEE ("RoundState" ∷ "processCertificatesM" {-∷ lsSI syncInfo-} ∷ []) $ do
   rshcr <- use (lRoundState ∙ rsHighestCommittedRound)
-  when (syncInfo ^∙ siHighestCommitRound >? rshcr) $ do
+  whenD (syncInfo ^∙ siHighestCommitRound >? rshcr) $ do
     lRoundState ∙ rsHighestCommittedRound ∙= (syncInfo ^∙ siHighestCommitRound)
     logInfo fakeInfo -- InfoUpdateHighestCommittedRound (syncInfo^.siHighestCommitRound)
   rscr ← use (lRoundState ∙ rsCurrentRound)
-  maybeS-RWST (maybeAdvanceRound rscr syncInfo) (pure nothing) $ λ (pcr' , reason) → do
+  maybeSD (maybeAdvanceRound rscr syncInfo) (pure nothing) $ λ (pcr' , reason) → do
     lRoundState ∙ rsCurrentRound ∙= pcr'
     lRoundState ∙ rsPendingVotes ∙= PendingVotes∙new
     lRoundState ∙ rsVoteSent     ∙= nothing
@@ -71,7 +71,7 @@ maybeAdvanceRound currentRound syncInfo =
 insertVoteM : Vote → ValidatorVerifier → LBFT VoteReceptionResult
 insertVoteM vote verifier = do
   currentRound ← use (lRoundState ∙ rsCurrentRound)
-  if-RWST vote ^∙ vVoteData ∙ vdProposed ∙ biRound == currentRound
+  ifD vote ^∙ vVoteData ∙ vdProposed ∙ biRound == currentRound
     then PendingVotes.insertVoteM vote verifier
     else pure (UnexpectedRound (vote ^∙ vVoteData ∙ vdProposed ∙ biRound) currentRound)
 

--- a/LibraBFT/Impl/Consensus/PendingVotes.agda
+++ b/LibraBFT/Impl/Consensus/PendingVotes.agda
@@ -22,9 +22,9 @@ insertVoteM : Vote → ValidatorVerifier → LBFT VoteReceptionResult
 insertVoteM vote vv = do
   let liDigest = hashLI (vote ^∙ vLedgerInfo)
   atv          ← use (lPendingVotes ∙ pvAuthorToVote)
-  case Map.lookup (vote ^∙ vAuthor) atv of λ where
+  caseMD Map.lookup (vote ^∙ vAuthor) atv of λ where
     (just previouslySeenVote) →
-      if-RWST liDigest ≟Hash (hashLI (previouslySeenVote ^∙ vLedgerInfo))
+      ifD liDigest ≟Hash (hashLI (previouslySeenVote ^∙ vLedgerInfo))
       then (do
         let newTimeoutVote = Vote.isTimeout vote ∧ not (Vote.isTimeout previouslySeenVote)
         if not newTimeoutVote
@@ -47,7 +47,7 @@ insertVoteM vote vv = do
                       (fromMaybe (LedgerInfoWithSignatures∙new (vote ^∙ vLedgerInfo) Map.empty)
                                  (Map.lookup liDigest (pv ^∙ pvLiDigestToVotes)))
     lPendingVotes ∙ pvLiDigestToVotes %= Map.kvm-insert-Haskell liDigest liWithSig
-    case ValidatorVerifier.checkVotingPower vv (Map.kvm-keys (liWithSig ^∙ liwsSignatures)) of λ where
+    case⊎D ValidatorVerifier.checkVotingPower vv (Map.kvm-keys (liWithSig ^∙ liwsSignatures)) of λ where
       (Right unit) →
         pure (NewQuorumCertificate (QuorumCert∙new (vote ^∙ vVoteData) liWithSig))
       (Left (ErrVerify (TooLittleVotingPower votingPower _))) →
@@ -56,14 +56,14 @@ insertVoteM vote vv = do
         pure VRR_TODO
 
   continue2 qcVotingPower =
-    case vote ^∙ vTimeoutSignature of λ where
+    caseMD vote ^∙ vTimeoutSignature of λ where
       (just timeoutSignature) → do
         pv            ← use lPendingVotes
         let partialTc = TimeoutCertificate.addSignature (vote ^∙ vAuthor) timeoutSignature
                           (fromMaybe (TimeoutCertificate∙new (Vote.timeout vote))
                                      (pv ^∙ pvMaybePartialTC))
         lPendingVotes ∙ pvMaybePartialTC %= const (just partialTc)
-        case ValidatorVerifier.checkVotingPower vv (Map.kvm-keys (partialTc ^∙ tcSignatures)) of λ where
+        case⊎D ValidatorVerifier.checkVotingPower vv (Map.kvm-keys (partialTc ^∙ tcSignatures)) of λ where
           (Right unit) →
             pure (NewTimeoutCertificate partialTc)
           (Left (ErrVerify (TooLittleVotingPower votingPower _))) →

--- a/LibraBFT/Impl/Consensus/PendingVotes.agda
+++ b/LibraBFT/Impl/Consensus/PendingVotes.agda
@@ -7,6 +7,7 @@ open import LibraBFT.Base.KVMap                                       as Map
 open import LibraBFT.Hash
 open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote               as Vote
 open import LibraBFT.Impl.Consensus.ConsensusTypes.TimeoutCertificate as TimeoutCertificate
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.Impl.Types.CryptoProxies                         as CryptoProxies
 open import LibraBFT.Impl.Types.LedgerInfoWithSignatures              as LedgerInfoWithSignatures
 open import LibraBFT.Impl.Types.ValidatorVerifier                     as ValidatorVerifier

--- a/LibraBFT/Impl/Consensus/PersistentLivenessStorage.agda
+++ b/LibraBFT/Impl/Consensus/PersistentLivenessStorage.agda
@@ -5,19 +5,66 @@
 -}
 
 open import LibraBFT.Base.Types
+import      LibraBFT.Impl.Consensus.TestUtils.MockStorage as MockStorage
+open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
+------------------------------------------------------------------------------
+import      Data.String                                   as String
 
 module LibraBFT.Impl.Consensus.PersistentLivenessStorage where
 
-postulate -- TODO-2: implement
-  pruneTreeM : List HashValue → LBFT (Either ErrLog Unit)
-  saveHighestTimeoutCertM : TimeoutCertificate → LBFT (Either ErrLog Unit)
-  saveTreeE : BlockStore → List Block → List QuorumCert → Either ErrLog (BlockStore)
-  saveTreeM : List Block → List QuorumCert → LBFT (Either ErrLog Unit)
-  saveVoteM : Vote → LBFT (Either ErrLog Unit)
-  startM    : LBFT (Either ErrLog RecoveryData)
+------------------------------------------------------------------------------
 
+obmUpdateM
+  : ( PersistentLivenessStorage → LBFT (Either ErrLog PersistentLivenessStorage) )
+  → LBFT (Either ErrLog Unit)
+
+obmUpdateE
+  : BlockStore
+  → ( PersistentLivenessStorage
+       → Either ErrLog PersistentLivenessStorage )
+  -> Either ErrLog BlockStore
+
+------------------------------------------------------------------------------
+
+saveTreeM : List Block → List QuorumCert → LBFT (Either ErrLog Unit)
+saveTreeM blocks qcs =
+  obmUpdateM (MockStorage.saveTreeM blocks qcs)
+
+saveTreeE : BlockStore → List Block → List QuorumCert → Either ErrLog BlockStore
+saveTreeE bs blocks qcs =
+  obmUpdateE bs (MockStorage.saveTreeE blocks qcs)
+
+pruneTreeM : List HashValue → LBFT (Either ErrLog Unit)
+pruneTreeM =
+  obmUpdateM ∘ MockStorage.pruneTreeM
+
+saveVoteM : Vote → LBFT (Either ErrLog Unit)
+saveVoteM =
+  obmUpdateM ∘ MockStorage.saveStateM
+
+startM : LBFT (Either ErrLog RecoveryData)
+startM =
+  use (lBlockStore ∙ bsStorage) >>= λ s → pure (MockStorage.start s) ∙^∙ withErrCtx (here' [])
+ where
+  here' : List String.String → List String.String
+  here' t = "PersistentLivenessStorage" ∷ "startM" ∷ t
+
+saveHighestTimeoutCertM : TimeoutCertificate → LBFT (Either ErrLog Unit)
+saveHighestTimeoutCertM =
+  obmUpdateM ∘ MockStorage.saveHighestTimeoutCertificateM
+
+------------------------------------------------------------------------------
+
+obmUpdateM f = do
+  s <- use (lBlockStore ∙ bsStorage)
+  f s ∙?∙ λ s' → do lBlockStore ∙ bsStorage ∙= s'; ok unit
+
+obmUpdateE bs f = do
+  let s = bs ^∙ bsStorage
+  s'    ← f s
+  pure (bs & bsStorage ∙~ s')

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -427,12 +427,8 @@ processBlockRetrievalRequestM _now request = do
     e  ← use (lRoundManager ∙ rmSafetyRules ∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch)
     r  ← use (lRoundManager ∙ rmRoundState ∙ rsCurrentRound)
     let meer = (me , e , r)
-    bs   ← use lBlockStore
-    -- TODO-1: define and use SendBRP
-    -- act (SendBRP lSI (request^∙brqObmFrom) (xxx meer bs [] (request^∙brqBlockId)))
-    -- The following is just to get parts of the "act" together.
-    let rsp = mkRsp request meer bs [] (request ^∙ brqBlockId)
-    pure unit
+    bs ← use lBlockStore
+    act (SendBRP (request ^∙ brqObmFrom) (mkRsp request meer bs [] (request ^∙ brqBlockId)))
 
 mkRsp request meer bs blocks id =
     if-dec length blocks <? request ^∙ brqNumBlocks

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -57,7 +57,7 @@ processNewRoundEventM now nre@(NewRoundEvent∙new r _ _) = do
     nothing       → logErr fakeErr -- (here ["lRoundManager.pgAuthor", "Nothing"])
     (just author) → do
       v ← ProposerElection.isValidProposer <$> use lProposerElection <*> pure author <*> pure r
-      when v $ do
+      whenD v $ do
         rcvrs ← use (lRoundManager ∙ rmObmAllAuthors)
         generateProposalM now nre >>= λ where
           -- (Left (ErrEpochEndedNoProposals t)) -> logInfoL (lEC.|.lPM) (here ("EpochEnded":t))
@@ -87,7 +87,7 @@ module processProposalMsgM (now : Instant) (pm : ProposalMsg) where
   step₂ : Either ErrLog Bool → LBFT Unit
 
   step₀ =
-    caseMM pm ^∙ pmProposer of λ where
+    caseMD pm ^∙ pmProposer of λ where
       nothing → logInfo fakeInfo -- proposal with no author
       (just pAuthor) → step₁ pAuthor
 
@@ -125,7 +125,7 @@ module syncUpM (now : Instant) (syncInfo : SyncInfo) (author : Author) (_helpRem
     step₁ localSyncInfo
 
   step₁ localSyncInfo = do
-    if-RWST SyncInfo.hasNewerCertificates syncInfo localSyncInfo
+    ifD SyncInfo.hasNewerCertificates syncInfo localSyncInfo
       then step₂ localSyncInfo
       else ok unit
 
@@ -156,7 +156,7 @@ module ensureRoundAndSyncUpM
 
   step₀ = do
     currentRound ← use (lRoundState ∙ rsCurrentRound)
-    if-RWST messageRound <? currentRound
+    ifD messageRound <? currentRound
       then ok false
       else step₁
 
@@ -165,7 +165,7 @@ module ensureRoundAndSyncUpM
 
   step₂ = do
           currentRound' ← use (lRoundState ∙ rsCurrentRound)
-          if-RWST messageRound /= currentRound'
+          ifD messageRound /= currentRound'
             then bail fakeErr -- error: after sync, round does not match local
             else ok true
 
@@ -201,7 +201,7 @@ processSyncInfoMsgM now syncInfo peer =
 processLocalTimeoutM : Instant → Epoch → Round → LBFT Unit
 processLocalTimeoutM now obmEpoch round = do
   -- logEE lTO (here []) $
-  ifM (RoundState.processLocalTimeoutM now obmEpoch round) continue1 (pure unit)
+  ifMD (RoundState.processLocalTimeoutM now obmEpoch round) continue1 (pure unit)
  where
   here'     : List String.String → List String.String
   continue2 : LBFT Unit
@@ -209,7 +209,7 @@ processLocalTimeoutM now obmEpoch round = do
   continue4 : Vote → LBFT Unit
 
   continue1 =
-    ifM (use (lRoundManager ∙ rmSyncOnly))
+    ifMD (use (lRoundManager ∙ rmSyncOnly))
       -- In Haskell, rmSyncOnly is ALWAYS false.
       -- It is used for an unimplemented "sync only" mode for nodes.
       -- "sync only" mode is an optimization for nodes catching up.
@@ -221,7 +221,7 @@ processLocalTimeoutM now obmEpoch round = do
   continue2 =
     use (lRoundState ∙ rsVoteSent) >>= λ where
       (just vote) →
-        if-RWST (vote ^∙ vVoteData ∙ vdProposed ∙ biRound == round)
+        ifD (vote ^∙ vVoteData ∙ vdProposed ∙ biRound == round)
           -- already voted in this round, so resend the vote, but with a timeout signature
           then continue3 (true , vote)
           else local-continue2-continue
@@ -283,7 +283,7 @@ module processProposalM (proposal : Block) where
     step₁ bs vp
 
   step₁ bs vp =
-    ifM‖ isLeft vp ≔
+    ifD‖ isLeft vp ≔
          logErr fakeErr -- proposer for block is not valid for this round
        ‖ is-nothing (BlockStore.getQuorumCertForBlock (proposal ^∙ bParentId) bs) ≔
          logErr fakeErr -- QC of parent is not in BS
@@ -324,7 +324,7 @@ module executeAndVoteM (b : Block) where
     cr ← use (lRoundState ∙ rsCurrentRound)
     vs ← use (lRoundState ∙ rsVoteSent)
     so ← use (lRoundManager ∙ rmSyncOnly)
-    ifM‖ is-just vs ≔
+    ifD‖ is-just vs ≔
          bail fakeErr -- error: already voted this round
        ‖ so ≔
          bail fakeErr -- error: sync-only set
@@ -353,7 +353,7 @@ processVoteMsgM now voteMsg = do
   processVoteM now (voteMsg ^∙ vmVote)
 
 processVoteM now vote =
-  if-RWST not (Vote.isTimeout vote)
+  ifD not (Vote.isTimeout vote)
   then (do
     let nextRound = vote ^∙ vVoteData ∙ vdProposed ∙ biRound + 1
     use (lRoundManager ∙ pgAuthor) >>= λ where
@@ -369,7 +369,7 @@ processVoteM now vote =
   continue = do
     let blockId = vote ^∙ vVoteData ∙ vdProposed ∙ biId
     bs ← use lBlockStore
-    if-RWST (is-just (BlockStore.getQuorumCertForBlock blockId bs))
+    ifD (is-just (BlockStore.getQuorumCertForBlock blockId bs))
       then logInfo fakeInfo -- "block already has QC", "dropping unneeded vote"
       else do
       logInfo fakeInfo -- "before"
@@ -379,8 +379,8 @@ processVoteM now vote =
 
 addVoteM now vote = do
   bs ← use lBlockStore
-  maybeS-RWST (bs ^∙ bsHighestTimeoutCert) continue λ tc →
-    if-RWST vote ^∙ vRound == tc ^∙ tcRound
+  maybeSD (bs ^∙ bsHighestTimeoutCert) continue λ tc →
+    ifD vote ^∙ vRound == tc ^∙ tcRound
       then logInfo fakeInfo -- "block already has TC", "dropping unneeded vote"
       else continue
  where

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -121,7 +121,7 @@ module executeAndVoteMSpec (b : Block) where
         qcPost₁ = EAIBECon.qcPost
 
         qcPres₁ : ∀ qc → Preserves (qc QCProps.∈RoundManager_) pre pre₁
-        qcPres₁ = EAIBECon.qcPres pre refl
+        qcPres₁ qc = EAIBECon.qcPres qc pre
 
         -- For the case any of the checks in `step₁` fails
         contractBail₁ : ∀ {e} outs → OutputProps.NoMsgs outs → Contract (Left e) pre₁ outs

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -195,45 +195,8 @@ module verifyQcMSpec (self : QuorumCert) where
                                    × QuorumCertProps.Contract self (getVv pre)
 
   contract' : ∀ pre → RWST-weakestPre (verifyQcM self) (Contract pre) unit pre
-  contract' pre _vv ._
-     with self ^∙ qcSignedLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash ≟ hashVD (self ^∙ qcVoteData)
-  ...| no neq = λ where _ refl → refl , refl
-  ...| yes refl
-     with self ^∙ qcCertifiedBlock ∙ biRound ≟ 0
-  ...| yes refl
-     with self ^∙ qcParentBlock ≟ self ^∙ qcCertifiedBlock
-  ...| no neq = λ where _ refl → refl , refl
-  ...| yes refl
-     with self ^∙ qcCertifiedBlock ≟ self ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liCommitInfo
-  ...| no neq = λ where _ refl → refl , refl
-  ...| yes refl
-     with Map.kvm-size (self ^∙ qcLedgerInfo ∙ liwsSignatures) ≟ 0
-  ...| no neq = λ where _ refl → refl , refl
-  ...| yes noSigs =
-         λ where _ refl →
-                  refl , refl , record { lihash≡ = refl
-                                       ; rnd≟0 = yes refl
-                                       ; parProp = record { par≡cert = refl
-                                                          ; cert≡li = refl
-                                                          ; noSigs = noSigs } }
-  contract' pre vv refl
-     | yes refl
-     | no neq
-     with  LedgerInfoWithSignatures.verifySignatures (self ^∙ qcLedgerInfo)  vv | inspect
-          (LedgerInfoWithSignatures.verifySignatures (self ^∙ qcLedgerInfo)) vv
-  ...| Left e     | _ = λ where _ refl → refl , refl
-  ...| Right unit | [ R ]
-     with VoteData.verify (self ^∙ qcVoteData) | inspect
-          VoteData.verify (self ^∙ qcVoteData)
-  ...| Left e     | _ = λ where _ refl → refl , refl
-  ...| Right unit | [ R' ] =
-         λ where _ refl →
-                  refl , refl , record { lihash≡ = refl
-                                       ; rnd≟0   = no neq
-                                       ; parProp = record { sigProp = R
-                                                          ; vdProp = VoteDataProps.contract
-                                                                       (self ^∙ qcVoteData)
-                                                                       R' }}
+  contract' _ _ _ (Left x₂) _ = refl , refl
+  contract' pre vv refl (Right unit) x₁ = refl , refl , QuorumCertProps.contract self vv (Right unit) refl (sym x₁)
 
   -- Suppose verifyQcM runs from prestate pre, and we wish to ensure that postcondition Post holds
   -- afterwards.  If P holds provided verifyQcM does not modify the state and does not produce any

--- a/LibraBFT/Impl/Consensus/TestUtils/MockStorage.agda
+++ b/LibraBFT/Impl/Consensus/TestUtils/MockStorage.agda
@@ -1,0 +1,74 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.KVMap                 as Map
+open import LibraBFT.Base.Types
+open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.ImplShared.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Consensus.TestUtils.MockStorage where
+
+postulate
+  tryStart : MockStorage → Either ErrLog RecoveryData
+
+------------------------------------------------------------------------------
+
+saveTreeE
+  : List Block → List QuorumCert → MockStorage
+  → Either ErrLog MockStorage
+
+saveTreeM
+  : List Block → List QuorumCert → MockStorage
+  → LBFT (Either ErrLog MockStorage)
+saveTreeM bs qcs db = do
+  logInfo fakeInfo -- [ "MockStorage", "saveTreeM", show (length bs), show (length qcs) ]
+  pure (saveTreeE bs qcs db)
+
+saveTreeE bs qcs db =
+  pure (db & msSharedStorage ∙ mssBlock %~ insertBs
+           & msSharedStorage ∙ mssQc    %~ insertQCs)
+ where
+  insertBs : Map.KVMap HashValue Block → Map.KVMap HashValue Block
+  insertBs  m = foldl' (λ acc b  → Map.insert (b ^∙ bId)                      b  acc) m bs
+
+  insertQCs : Map.KVMap HashValue QuorumCert → Map.KVMap HashValue QuorumCert
+  insertQCs m = foldl' (λ acc qc → Map.insert (qc ^∙ qcCertifiedBlock ∙ biId) qc acc) m qcs
+
+pruneTreeM
+  : List HashValue → MockStorage
+  → LBFT (Either ErrLog MockStorage)
+pruneTreeM ids db = do
+  logInfo fakeInfo -- ["MockStorage", "pruneTreeM", show (fmap lsHV ids)]
+  ok (db & msSharedStorage ∙ mssBlock %~ deleteBs
+         & msSharedStorage ∙ mssQc    %~ deleteQCs)
+  -- TODO : verifyConsistency
+ where
+  deleteBs : Map.KVMap HashValue Block → Map.KVMap HashValue Block
+  deleteBs  m = foldl' (flip Map.delete) m ids
+
+  deleteQCs : Map.KVMap HashValue QuorumCert → Map.KVMap HashValue QuorumCert
+  deleteQCs m = foldl' (flip Map.delete) m ids
+
+saveStateM
+  : Vote → MockStorage
+  → LBFT (Either ErrLog MockStorage)
+saveStateM v db = do
+  logInfo fakeInfo -- ["MockStorage", "saveStateM", lsV v]
+  ok (db & msSharedStorage ∙ mssLastVote ?~ v)
+
+start : MockStorage → Either ErrLog RecoveryData
+start  = tryStart
+
+saveHighestTimeoutCertificateM
+  : TimeoutCertificate → MockStorage
+  → LBFT (Either ErrLog MockStorage)
+saveHighestTimeoutCertificateM tc db = do
+  logInfo fakeInfo -- ["MockStorage", "saveHighestTimeoutCertificateM", lsTC tc]
+  ok (db & msSharedStorage ∙ mssHighestTimeoutCertificate ?~ tc)

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -14,7 +14,10 @@ open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Hash
+import      LibraBFT.Impl.Consensus.Liveness.RoundState as RoundState
 open import LibraBFT.Impl.IO.OBM.InputOutputHandlers
+open import LibraBFT.Impl.OBM.Init
+open import LibraBFT.Impl.OBM.Time
 open import LibraBFT.Impl.Consensus.RoundManager
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Interface.Output
@@ -63,7 +66,7 @@ postulate -- TODO-1: Implement this.
   initBS : BlockStore
 
 initRS : RoundState
-initRS = RoundState∙new 0 0 PendingVotes∙new nothing
+initRS = RoundState.new etiT timeT
 
 initRM : RoundManager
 initRM = RoundManager∙new

--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -33,7 +33,7 @@ module handleProposal (now : Instant) (pm : ProposalMsg) where
     step₁ myEpoch vv
 
   step₁ myEpoch vv = do
-    caseM⊎ Network.processProposal {- {!!} -} pm myEpoch vv of λ where
+    case⊎D Network.processProposal {- {!!} -} pm myEpoch vv of λ where
       (Left (Left e))  → logErr e
       (Left (Right i)) → logInfo i
       (Right _)        → RoundManager.processProposalMsgM now pm

--- a/LibraBFT/Impl/OBM/ConfigHardCoded.agda
+++ b/LibraBFT/Impl/OBM/ConfigHardCoded.agda
@@ -6,11 +6,7 @@
 
 open import LibraBFT.Impl.OBM.Rust.RustTypes
 
-module LibraBFT.Impl.OBM.Rust.Duration where
+module LibraBFT.Impl.OBM.ConfigHardCoded where
 
-record Duration : Set where
-  constructor Duration∙new
-
-postulate
-  fromMillis : U64 → Duration
-  asMillis   : Duration → U128
+roundInitialTimeoutMS : U64
+roundInitialTimeoutMS = 3000

--- a/LibraBFT/Impl/OBM/ECP-LBFT-OBM-Diff/ECP-LBFT-OBM-Diff-1.agda
+++ b/LibraBFT/Impl/OBM/ECP-LBFT-OBM-Diff/ECP-LBFT-OBM-Diff-1.agda
@@ -23,15 +23,15 @@ amIMemberOfCurrentEpochM : LBFT Bool
 
 e_RoundState_processLocalTimeoutM : Epoch → Round → LBFT Bool
 e_RoundState_processLocalTimeoutM e r =
-  if-RWST not ECP-LBFT-OBM-Diff-0.enabled
+  ifD not ECP-LBFT-OBM-Diff-0.enabled
   then yes'
   else
     -- LBFT-OBM-DIFF : do not broadcast timeouts if not member of epoch
-    ifM amIMemberOfCurrentEpochM
-        yes'
-        (do
-          logInfo fakeInfo -- ["not a member of Epoch", "ignoring timeout", lsE e, lsR r]
-          pure false)
+    ifMD amIMemberOfCurrentEpochM
+         yes'
+         (do
+           logInfo fakeInfo -- ["not a member of Epoch", "ignoring timeout", lsE e, lsR r]
+           pure false)
  where
   yes' : LBFT Bool
   yes' = do

--- a/LibraBFT/Impl/OBM/Init.agda
+++ b/LibraBFT/Impl/OBM/Init.agda
@@ -1,0 +1,28 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+import      LibraBFT.Impl.Consensus.Liveness.RoundState              as RoundState
+import      LibraBFT.Impl.Consensus.Liveness.ExponentialTimeInterval as ExponentialTimeInterval
+import      LibraBFT.Impl.OBM.ConfigHardCoded                        as ConfigHardCoded
+open import LibraBFT.Impl.OBM.Rust.Duration                          as Duration
+open import LibraBFT.Impl.OBM.Rust.RustTypes
+open import LibraBFT.Impl.OBM.Time
+open import LibraBFT.ImplShared.Consensus.Types
+
+module LibraBFT.Impl.OBM.Init where
+
+------------------------------------------------------------------------------
+
+-- TODO : get numbers from config
+
+dT : Duration
+dT = Duration.fromMillis ConfigHardCoded.roundInitialTimeoutMS
+
+etiT : ExponentialTimeInterval
+etiT = ExponentialTimeInterval.new dT 1.2 6
+
+rsT : RoundState
+rsT = RoundState.new etiT timeT

--- a/LibraBFT/Impl/OBM/Logging/Logging.agda
+++ b/LibraBFT/Impl/OBM/Logging/Logging.agda
@@ -35,6 +35,13 @@ withErrCtx' ctx = λ where
   (Left  e) → Left (withErrCtx ctx e)
   (Right b) → pure b
 
+withErrCtxD'
+  : ∀ {ℓ} {E : Set → Set → Set ℓ} ⦃ _ : EitherLike E ⦄
+    → ∀ {A : Set} → List String.String → E ErrLog A → EitherD ErrLog A
+withErrCtxD' ctx e = case toEither e of λ where
+  (Left  e) → fromEither $ Left (withErrCtx ctx e)
+  (Right b) → fromEither $ Right b
+
 lcheck : ∀ {ℓ} {B : Set ℓ} ⦃ _ : ToBool B ⦄ → B → List String.String → Either ErrLog Unit
 lcheck b t = case check (toBool b) t of λ where
   (Left  e) → Left  fakeErr -- (ErrL [e])

--- a/LibraBFT/Impl/OBM/Rust/RustTypes.agda
+++ b/LibraBFT/Impl/OBM/Rust/RustTypes.agda
@@ -1,0 +1,31 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Prelude
+------------------------------------------------------------------------------
+open import Agda.Builtin.Float
+
+module LibraBFT.Impl.OBM.Rust.RustTypes where
+
+-- TODO-2 : reasoning about integer overflow
+
+F64 : Set
+F64 = Float -- This is 'Double' in Haskell.  In Agda, 'Float' is represented as a Haskell 'Double'.
+
+U64 : Set
+U64 = ℕ
+
+U128 : Set
+U128 = ℕ
+
+Usize : Set
+Usize = ℕ
+
+postulate
+  VecDeque : Set
+  vdNew : VecDeque
+
+

--- a/LibraBFT/Impl/OBM/Time.agda
+++ b/LibraBFT/Impl/OBM/Time.agda
@@ -4,13 +4,12 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Impl.OBM.Rust.RustTypes
+open import LibraBFT.Prelude
+open import LibraBFT.Impl.OBM.Rust.Duration as Duration
+open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
 
-module LibraBFT.Impl.OBM.Rust.Duration where
-
-record Duration : Set where
-  constructor Duration∙new
+module LibraBFT.Impl.OBM.Time where
 
 postulate
-  fromMillis : U64 → Duration
-  asMillis   : Duration → U128
+  iPlus : Instant → Duration → Instant
+  timeT : Instant

--- a/LibraBFT/Impl/Types/ValidatorVerifier.agda
+++ b/LibraBFT/Impl/Types/ValidatorVerifier.agda
@@ -7,6 +7,7 @@
 open import LibraBFT.Base.KVMap                            as Map
 open import LibraBFT.Base.PKCS                             hiding (verify)
 import      LibraBFT.Impl.OBM.Crypto                       as Crypto
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
 open import LibraBFT.Prelude

--- a/LibraBFT/ImplFake/Handle.agda
+++ b/LibraBFT/ImplFake/Handle.agda
@@ -10,6 +10,9 @@ open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Hash
+import      LibraBFT.Impl.Consensus.Liveness.RoundState as RoundState
+open import LibraBFT.Impl.OBM.Init
+open import LibraBFT.Impl.OBM.Time
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Interface.Output
@@ -52,7 +55,7 @@ module LibraBFT.ImplFake.Handle where
  initPE = obm-dangerous-magic!
 
  initRS : RoundState
- initRS = RoundState∙new 0 0 PendingVotes∙new nothing
+ initRS = RoundState.new etiT timeT
 
  initRM : RoundManager
  initRM = RoundManager∙new

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -9,6 +9,7 @@ open import LibraBFT.Base.KVMap             as KVMap
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
 open import LibraBFT.Impl.OBM.Rust.Duration
+open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
@@ -48,20 +49,31 @@ module LibraBFT.ImplShared.Consensus.Types where
   unquoteDecl nreRound   nreReason   nreTimeout = mkLens (quote NewRoundEvent)
              (nreRound ∷ nreReason ∷ nreTimeout ∷ [])
 
-  record RoundState : Set where
-    constructor RoundState∙new
+  record ExponentialTimeInterval : Set where
+    constructor mkExponentialTimeInterval
     field
-      -- ...
+      _etiBaseMs       : U64
+      _etiExponentBase : F64
+      _etiMaxExponent  : Usize
+  unquoteDecl etiBaseMs   etiExponentBase   etiMaxExponent  = mkLens (quote ExponentialTimeInterval)
+             (etiBaseMs ∷ etiExponentBase ∷ etiMaxExponent ∷ [])
+
+  RoundStateTimeInterval = ExponentialTimeInterval
+
+  record RoundState : Set where
+    constructor mkRoundState
+    field
+      _rsTimeInterval          : RoundStateTimeInterval
       _rsHighestCommittedRound : Round
       _rsCurrentRound          : Round
+      _rsCurrentRoundDeadline  : Instant
       _rsPendingVotes          : PendingVotes
       _rsVoteSent              : Maybe Vote
-      -- ...
   open RoundState public
-  unquoteDecl rsHighestCommittedRound   rsCurrentRound   rsPendingVotes
-              rsVoteSent = mkLens (quote RoundState)
-             (rsHighestCommittedRound ∷ rsCurrentRound ∷ rsPendingVotes ∷
-              rsVoteSent ∷ [])
+  unquoteDecl rsTimeInterval           rsHighestCommittedRound   rsCurrentRound
+              rsCurrentRoundDeadline   rsPendingVotes            rsVoteSent = mkLens (quote RoundState)
+             (rsTimeInterval         ∷ rsHighestCommittedRound ∷ rsCurrentRound ∷
+              rsCurrentRoundDeadline ∷ rsPendingVotes          ∷ rsVoteSent ∷ [])
 
   record ObmNeedFetch : Set where
     constructor ObmNeedFetch∙new
@@ -208,8 +220,11 @@ module LibraBFT.ImplShared.Consensus.Types where
   -- The Haskell implementation has many more constructors.
   -- Constructors are being added incrementally as needed for the verification effort.
   data ErrLog : Set where
-    ErrBlockNotFound : HashValue   → ErrLog
-    ErrVerify        : VerifyError → ErrLog
+    -- Consensus_BlockNotFound
+    ErrCBlockNotFound   : HashValue   → ErrLog
+    -- ExecutionCorrectnessClient_BlockNotFound
+    ErrECCBlockNotFound : HashValue   → ErrLog
+    ErrVerify           : VerifyError → ErrLog
 
   -- To enable modeling of logging errors that have not been added yet,
   -- an inhabitant of ErrLog is postulated.

--- a/LibraBFT/ImplShared/Util/Dijkstra/EitherD.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/EitherD.agda
@@ -6,7 +6,7 @@
 
 open import LibraBFT.Prelude
 
-module LibraBFT.ImplShared.Util.Dijkstra.Error where
+module LibraBFT.ImplShared.Util.Dijkstra.EitherD where
 
 data EitherD (E : Set) : Set → Set₁ where
   -- Primitive combinators

--- a/LibraBFT/ImplShared/Util/Dijkstra/EitherD/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/EitherD/Syntax.agda
@@ -4,11 +4,11 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.ImplShared.Util.Dijkstra.Error
+open import LibraBFT.ImplShared.Util.Dijkstra.EitherD
 open import LibraBFT.ImplShared.Util.Dijkstra.Syntax
 open import LibraBFT.Prelude
 
-module LibraBFT.ImplShared.Util.Dijkstra.Error.Syntax where
+module LibraBFT.ImplShared.Util.Dijkstra.EitherD.Syntax where
 
 private
   variable

--- a/LibraBFT/ImplShared/Util/Dijkstra/Error.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/Error.agda
@@ -17,10 +17,22 @@ data Error (E : Set) : Set → Set₁ where
   Error-if     : ∀ {A} → Guards (Error E A) → Error E A
   Error-maybe  : ∀ {A B} → Maybe A → Error E B → (A → Error E B) → Error E B
 
+pattern LeftE  x = Error-bail   x
+pattern RightE x = Error-return x
+
 private
   variable
     E : Set
     A B C : Set
+
+fromEither : Either E A → Error E A
+fromEither (Left x) = LeftE x
+fromEither (Right y) = RightE y
+
+Error-bindE : Either E A → (A → Error E B) → Error E B
+Error-bindE e f = Error-bind (fromEither e) f
+
+syntax Error-bindE e₁ (λ x → e₂) = x ←E e₁ ﹔ e₂
 
 Error-run : Error E A → Either E A
 Error-run (Error-return x) = Right x

--- a/LibraBFT/ImplShared/Util/Dijkstra/Error/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/Error/Syntax.agda
@@ -17,18 +17,30 @@ private
 
 -- From this instance declaration, we get _<$>_, pure, and _<*>_ also.
 instance
-  Monad-Error : ∀ {E : Set} → Monad (Error E)
-  Monad.return Monad-Error = Error-return
-  Monad._>>=_  Monad-Error = Error-bind
+  Monad-EitherD : ∀ {E : Set} → Monad (EitherD E)
+  Monad.return Monad-EitherD = EitherD-return
+  Monad._>>=_  Monad-EitherD = EitherD-bind
 
 -- These instance declarations give us variant conditional operations that we
--- can define to play nice with `Error-weakestPre`
+-- can define to play nice with `EitherD-weakestPre`
 
 instance
-  Error-MonadIfD : MonadIfD{ℓ₃ = ℓ0} (Error E)
-  MonadIfD.monad Error-MonadIfD = Monad-Error
-  MonadIfD.ifD‖  Error-MonadIfD = Error-if
+  EitherD-MonadIfD : MonadIfD{ℓ₃ = ℓ0} (EitherD E)
+  MonadIfD.monad EitherD-MonadIfD = Monad-EitherD
+  MonadIfD.ifD‖  EitherD-MonadIfD = EitherD-if
 
-  Error-MonadMaybeD : MonadMaybeD (Error E)
-  MonadMaybeD.monad   Error-MonadMaybeD = Monad-Error
-  MonadMaybeD.maybeSD Error-MonadMaybeD = Error-maybe
+  EitherD-MonadMaybeD : MonadMaybeD (EitherD E)
+  MonadMaybeD.monad   EitherD-MonadMaybeD = Monad-EitherD
+  MonadMaybeD.maybeSD EitherD-MonadMaybeD = EitherD-maybe
+
+  EitherD-MonadEitherD : MonadEitherD (EitherD E)
+  MonadEitherD.monad    EitherD-MonadEitherD = Monad-EitherD
+  MonadEitherD.eitherSD EitherD-MonadEitherD = EitherD-either
+
+-- `EitherD` is Either-like
+instance
+  EitherD-EitherLike : EitherLike EitherD
+  EitherLike.fromEither EitherD-EitherLike (Left  a) = EitherD-bail a
+  EitherLike.fromEither EitherD-EitherLike (Right b) = EitherD-return b
+
+  EitherLike.toEither   EitherD-EitherLike = EitherD-run

--- a/LibraBFT/ImplShared/Util/Dijkstra/Error/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/Error/Syntax.agda
@@ -1,0 +1,34 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.ImplShared.Util.Dijkstra.Error
+open import LibraBFT.ImplShared.Util.Dijkstra.Syntax
+open import LibraBFT.Prelude
+
+module LibraBFT.ImplShared.Util.Dijkstra.Error.Syntax where
+
+private
+  variable
+    E     : Set
+    A B C : Set
+
+-- From this instance declaration, we get _<$>_, pure, and _<*>_ also.
+instance
+  Monad-Error : ∀ {E : Set} → Monad (Error E)
+  Monad.return Monad-Error = Error-return
+  Monad._>>=_  Monad-Error = Error-bind
+
+-- These instance declarations give us variant conditional operations that we
+-- can define to play nice with `Error-weakestPre`
+
+instance
+  Error-MonadIfD : MonadIfD{ℓ₃ = ℓ0} (Error E)
+  MonadIfD.monad Error-MonadIfD = Monad-Error
+  MonadIfD.ifD‖  Error-MonadIfD = Error-if
+
+  Error-MonadMaybeD : MonadMaybeD (Error E)
+  MonadMaybeD.monad   Error-MonadMaybeD = Monad-Error
+  MonadMaybeD.maybeSD Error-MonadMaybeD = Error-maybe

--- a/LibraBFT/ImplShared/Util/Dijkstra/RWST.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/RWST.agda
@@ -29,7 +29,7 @@ open import LibraBFT.Prelude
 -- TODO-2: this module is independent of any particular implementation
 -- and arguably belongs somewhere more general, such as next to Optics.
 
-module LibraBFT.ImplShared.Util.RWST where
+module LibraBFT.ImplShared.Util.Dijkstra.RWST where
 
 -- RWST, the AST of computations with state `St` reading from an environment
 -- `Ev` and producing a list of outputs of type `Wr`

--- a/LibraBFT/ImplShared/Util/Dijkstra/RWST.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/RWST.agda
@@ -157,6 +157,12 @@ RWST-weakestPre-ebindPost ev f Post (Right r) post outs =
 RWST-weakestPre-bindPost ev f Post x post outs =
   ∀ r → r ≡ x → RWST-weakestPre (f r) (RWST-Post++ Post outs) ev post
 
+-- The post condition `P` holds for `m` with environment `ev` and prestate `pre`
+RWST-Post-True : (P : RWST-Post Wr St A) (m : RWST Ev Wr St A) (ev : Ev) (pre : St) → Set
+RWST-Post-True P m ev pre =
+  let (x , post , outs) = RWST-run m ev pre in
+  P x post outs
+
 -- For every RWST computation `m`, `RWST-Contract m` is the type of proofs that,
 -- for all post conditions `P`, starting environments `ev` and prestates `pre`,
 -- to prove that `P` holds after running `m` in `ev` and `pre`, it suffices to
@@ -166,8 +172,7 @@ RWST-Contract : (m : RWST Ev Wr St A) → Set₁
 RWST-Contract{Ev}{Wr}{St}{A} m =
   (P : RWST-Post Wr St A)
   → (ev : Ev) (pre : St) → RWST-weakestPre m P ev pre
-  → let (x , post , outs) = RWST-run m ev pre in
-    P x post outs
+  → RWST-Post-True P m ev pre
 
 -- This proves that `RWST-weakestPre` gives a *sufficient* precondition for
 -- establishing a desired postcondition. Note thought that it does not prove

--- a/LibraBFT/ImplShared/Util/Dijkstra/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/Syntax.agda
@@ -5,7 +5,7 @@
 -}
 
 open import LibraBFT.ImplShared.Util.Dijkstra.RWST
-open import LibraBFT.ImplShared.Util.Dijkstra.Error
+open import LibraBFT.ImplShared.Util.Dijkstra.EitherD
 open import LibraBFT.Prelude
 open import Optics.All
 

--- a/LibraBFT/ImplShared/Util/Dijkstra/Syntax.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/Syntax.agda
@@ -1,0 +1,186 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.ImplShared.Util.Dijkstra.RWST
+open import LibraBFT.ImplShared.Util.Dijkstra.Error
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.ImplShared.Util.Dijkstra.Syntax where
+
+{-
+Within a "Dijkstra-fied" monad `M`, `if` and `ifD` are semantically interchangeable.
+
+The difference is in how proof obligations are generated
+- with the *D variants generating new weakestPre obligations for each case.
+
+In some cases, this is helpful for structuring proofs, while in other cases it is
+unnecessary and introduces more structure to the proof without adding any benefit.
+
+A rule of thumb is that, if the "scrutinee" (whatever we are doing case analysis on,
+i.e., the first argument) is the value provided via >>= (bind) by a previous code block,
+then we already have a weakestPre proof obligation, so introducing additional ones via the
+*D variants only creates more work and provides no additional benefit.
+-}
+
+record MonadIfD {ℓ₁ ℓ₂ ℓ₃ : Level} (M : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁ ℓ⊔ ℓ+1 ℓ₃) where
+  infix 1 ifD‖_
+  field
+    ⦃ monad ⦄ : Monad M
+    ifD‖_ : ∀ {A : Set ℓ₁} → Guards{ℓ₂}{ℓ₃} (M A) → M A
+
+open MonadIfD ⦃ ... ⦄ public
+
+module _ {ℓ₁ ℓ₂ ℓ₃} {M : Set ℓ₁ → Set ℓ₂} where
+
+  private
+    variable
+      A : Set ℓ₁
+      B : Set ℓ₃
+
+  infix 0 ifD_then_else_
+  ifD_then_else_ : ⦃ _ : MonadIfD{ℓ₃ = ℓ₃} M ⦄ ⦃ _ : ToBool B ⦄ → B → (c₁ c₂ : M A) → M A
+  ifD b then c₁ else c₂ =
+    ifD‖ b ≔ c₁
+       ‖ otherwise≔ c₂
+
+whenD : ∀ {ℓ₂ ℓ₃} {M : Set → Set ℓ₂} {B : Set ℓ₃} ⦃ _ : MonadIfD{ℓ0}{ℓ₂}{ℓ₃} M ⦄ ⦃ _ : ToBool B ⦄ → B → M Unit → M Unit
+whenD b f = ifD b then f else pure unit
+
+module _ {ℓ₁ ℓ₂} {M : Set ℓ₁ → Set ℓ₂} where
+  private
+    variable A B : Set ℓ₁
+
+  ifMD : ⦃ mi : MonadIfD{ℓ₃ = ℓ₁} M ⦄ ⦃ _ : ToBool B ⦄ → M B → (c₁ c₂ : M A) → M A
+  ifMD{B = B} ⦃ mi ⦄ m c₁ c₂ = do
+    x ← m
+    ifD x then c₁ else c₂
+
+record MonadMaybeD {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
+  field
+    ⦃ monad ⦄ : Monad M
+    maybeSD : ∀ {A B : Set ℓ₁} → Maybe A → M B → (A → M B) → M B
+
+open MonadMaybeD ⦃ ... ⦄ public
+
+infix 0 caseMD_of_
+caseMD_of_ : ∀ {ℓ₁ ℓ₂} {M : Set ℓ₁ → Set ℓ₂} ⦃ _ : MonadMaybeD M ⦄ {A B : Set ℓ₁} → Maybe A → (Maybe A → M B) → M B
+caseMD m of f = maybeSD m (f nothing) (f ∘ just)
+
+record MonadEitherD {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
+  field
+    ⦃ monad ⦄ : Monad M
+    eitherSD : ∀ {E A B : Set ℓ₁} → Either E A → (E → M B) → (A → M B) → M B
+
+open MonadEitherD ⦃ ... ⦄ public
+
+infix 0 case⊎D_of_
+case⊎D_of_ : ∀ {ℓ₁ ℓ₂} {M : Set ℓ₁ → Set ℓ₂} ⦃ _ : MonadEitherD M ⦄ {E A B : Set ℓ₁} → Either E A → (Either E A → M B) → M B
+case⊎D e of f = eitherSD e (f ∘ Left) (f ∘ Right)
+
+-- Conditionals
+
+
+-- infix 1 ifM‖_
+-- ifM‖_ : Guards (RWST Ev Wr St A) → RWST Ev Wr St A
+-- ifM‖_ = RWST-if
+
+-- infix 0 if-RWST_then_else_
+-- if-RWST_then_else_ : ⦃ _ : ToBool B ⦄ → B → (c₁ c₂ : RWST Ev Wr St A) → RWST Ev Wr St A
+-- if-RWST b then c₁ else c₂ =
+--   ifM‖ b ≔ c₁
+--      ‖ otherwise≔ c₂
+
+-- -- This is like the Haskell version, except Haskell's works for any monad (not just RWST).
+-- ifM : ⦃ _ : ToBool B ⦄ → RWST Ev Wr St B → (c₁ c₂ : RWST Ev Wr St A) → RWST Ev Wr St A
+-- ifM mb c₁ c₂ = do
+--   x ← mb
+--   if-RWST x then c₁ else c₂
+
+-- infix 0 caseM⊎_of_ caseMM_of_
+-- caseM⊎_of_ : Either B C → (Either B C → RWST Ev Wr St A) → RWST Ev Wr St A
+-- caseM⊎ e of f = RWST-either e (f ∘ Left) (f ∘ Right)
+
+-- caseMM_of_ : Maybe B → (Maybe B → RWST Ev Wr St A) → RWST Ev Wr St A
+-- caseMM m of f = RWST-maybe m (f nothing) (f ∘ just)
+
+-- eitherS-RWST : ∀ {A B C} → Either B C
+--                → (B → RWST Ev Wr St A) → (C → RWST Ev Wr St A)   → RWST Ev Wr St A
+-- eitherS-RWST = RWST-either
+
+-- when : ∀ {ℓ} {B : Set ℓ} ⦃ _ : ToBool B ⦄ → B → RWST Ev Wr St Unit → RWST Ev Wr St Unit
+-- when b f = if-RWST toBool b then f else pure unit
+
+-- when-RWST : ⦃ _ : ToBool B ⦄ → B → (c : RWST Ev Wr St Unit) → RWST Ev Wr St Unit
+-- when-RWST b c = if-RWST b then c else pure unit
+
+-- -- Composition with error monad
+-- ok : A → RWST Ev Wr St (B ⊎ A)
+-- ok = pure ∘ Right
+
+-- bail : B → RWST Ev Wr St (B ⊎ A)
+-- bail = pure ∘ Left
+
+-- infixl 4 _∙?∙_
+-- _∙?∙_ : RWST Ev Wr St (Either C A) → (A → RWST Ev Wr St (Either C B)) → RWST Ev Wr St (Either C B)
+-- _∙?∙_ = RWST-ebind
+
+-- -- Composition/use with partiality monad
+-- maybeS-RWST : Maybe A → (RWST Ev Wr St B) → (A → RWST Ev Wr St B) → RWST Ev Wr St B
+-- maybeS-RWST ma n j =
+--   caseMM ma of λ where
+--     nothing  → n
+--     (just x) → j x
+
+-- maybeSM : RWST Ev Wr St (Maybe A) → RWST Ev Wr St B → (A → RWST Ev Wr St B) → RWST Ev Wr St B
+-- maybeSM mma mb f = do
+--   x ← mma
+--   caseMM x of λ where
+--     nothing  → mb
+--     (just j) → f j
+--   where
+
+-- maybeSMP-RWST : RWST Ev Wr St (Maybe A) → B → (A → RWST Ev Wr St B)
+--               → RWST Ev Wr St B
+-- maybeSMP-RWST ma b f = do
+--   x ← ma
+--   caseMM x of λ where
+--     nothing  → pure b
+--     (just j) → f j
+
+-- infixl 4 _∙^∙_
+-- _∙^∙_ : RWST Ev Wr St (Either B A) → (B → B) → RWST Ev Wr St (Either B A)
+-- m ∙^∙ f = do
+--   x ← m
+--   either (bail ∘ f) ok x
+
+-- RWST-weakestPre-∙^∙Post : (ev : Ev) (e : C → C) → RWST-Post Wr St (C ⊎ A) → RWST-Post Wr St (C ⊎ A)
+-- RWST-weakestPre-∙^∙Post ev e Post =
+--   RWST-weakestPre-bindPost ev (either (bail ∘ e) ok) Post
+
+-- -- Lens functionality
+-- --
+-- -- If we make RWST work for different level State types, we will break use and
+-- -- modify because Lens does not support different levels, we define use and
+-- -- modify' here for RoundManager. We are ok as long as we can keep
+-- -- RoundManager in Set. If we ever need to make RoundManager at some higher
+-- -- Level, we will have to consider making Lens level-agnostic. Preliminary
+-- -- exploration by @cwjnkins showed this to be somewhat painful in particular
+-- -- around composition, so we are not pursuing it for now.
+-- use : Lens St A → RWST Ev Wr St A
+-- use f = gets (_^∙ f)
+
+-- modifyL : Lens St A → (A → A) → RWST Ev Wr St Unit
+-- modifyL l f = modify (over l f)
+-- syntax modifyL l f = l %= f
+
+-- setL : Lens St A → A → RWST Ev Wr St Unit
+-- setL l x = l %= const x
+-- syntax setL l x = l ∙= x
+
+-- setL? : Lens St (Maybe A) → A → RWST Ev Wr St Unit
+-- setL? l x = l ∙= just x
+-- syntax setL? l x = l ?= x

--- a/LibraBFT/ImplShared/Util/Error.agda
+++ b/LibraBFT/ImplShared/Util/Error.agda
@@ -1,0 +1,65 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Prelude
+
+module LibraBFT.ImplShared.Util.Error where
+
+
+data Error (E : Set) : Set → Set₁ where
+  Error-return : ∀ {A} → A → Error E A
+  Error-bind   : ∀ {A B} → Error E A → (A → Error E B) → Error E B
+  Error-bail   : ∀ {A} → E → Error E A
+
+private
+  variable
+    E : Set
+    A B C : Set
+
+Error-run : Error E A → Either E A
+Error-run (Error-return x) = Right x
+Error-run (Error-bind m f)
+  with Error-run m
+... | Left x = Left x
+... | Right y = Error-run (f y)
+Error-run (Error-bail x) = Left x
+
+Error-Pre : (E A : Set) → Set₁
+Error-Pre E A = Set
+
+Error-Post : (E A : Set) → Set₁
+Error-Post E A = Either E A → Set
+
+Error-PredTrans : (E A : Set) → Set₁
+Error-PredTrans E A = Error-Post E A → Error-Pre E A
+
+Error-weakestPre-bindPost : (f : A → Error E B) → Error-Post E B → Error-Post E A
+
+Error-weakestPre : (m : Error E A) → Error-PredTrans E A
+Error-weakestPre (Error-return x) P = P (Right x)
+Error-weakestPre (Error-bind m f) P =
+  Error-weakestPre m (Error-weakestPre-bindPost f P)
+Error-weakestPre (Error-bail x) P = P (Left x)
+
+Error-weakestPre-bindPost f P (Left x) =
+  P (Left x)
+Error-weakestPre-bindPost f P (Right y) =
+  ∀ c → c ≡ y → Error-weakestPre (f c) P
+
+Error-Contract : (m : Error E A) → Set₁
+Error-Contract{E}{A} m =
+  (P : Error-Post E A)
+  → Error-weakestPre m P → P (Error-run m)
+
+Error-contract : (m : Error E A) → Error-Contract m
+Error-contract (Error-return x) P wp = wp
+Error-contract (Error-bind m f) P wp
+   with Error-contract m _ wp
+...| wp'
+   with Error-run m
+... | Left x = wp'
+... | Right y = Error-contract (f y) P (wp' y refl)
+Error-contract (Error-bail x) P wp = wp

--- a/LibraBFT/ImplShared/Util/Util.agda
+++ b/LibraBFT/ImplShared/Util/Util.agda
@@ -16,8 +16,8 @@ module LibraBFT.ImplShared.Util.Util where
   open import LibraBFT.ImplShared.Util.Dijkstra.Syntax public
   open import LibraBFT.ImplShared.Util.Dijkstra.RWST public
   open import LibraBFT.ImplShared.Util.Dijkstra.RWST.Syntax public
-  open import LibraBFT.ImplShared.Util.Dijkstra.Error public
-  open import LibraBFT.ImplShared.Util.Dijkstra.Error.Syntax public
+  open import LibraBFT.ImplShared.Util.Dijkstra.EitherD public
+  open import LibraBFT.ImplShared.Util.Dijkstra.EitherD.Syntax public
   ----------------
   -- LBFT Monad --
   ----------------

--- a/LibraBFT/ImplShared/Util/Util.agda
+++ b/LibraBFT/ImplShared/Util/Util.agda
@@ -13,8 +13,11 @@ open import LibraBFT.ImplShared.Interface.Output
 
 module LibraBFT.ImplShared.Util.Util where
   open import Optics.All
-  open import LibraBFT.ImplShared.Util.RWST        public
-  open import LibraBFT.ImplShared.Util.RWST.Syntax public
+  open import LibraBFT.ImplShared.Util.Dijkstra.Syntax public
+  open import LibraBFT.ImplShared.Util.Dijkstra.RWST public
+  open import LibraBFT.ImplShared.Util.Dijkstra.RWST.Syntax public
+  open import LibraBFT.ImplShared.Util.Dijkstra.Error public
+  open import LibraBFT.ImplShared.Util.Dijkstra.Error.Syntax public
   ----------------
   -- LBFT Monad --
   ----------------

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -479,9 +479,9 @@ module LibraBFT.Prelude where
       return (f x)
 
   instance
-    Monad-Error : ∀ {ℓ}{C : Set ℓ} → Monad{ℓ}{ℓ} (Either C)
-    Monad.return (Monad-Error{ℓ}{C}) = inj₂
-    Monad._>>=_ (Monad-Error{ℓ}{C}) = either (const ∘ inj₁) _&_
+    Monad-Either : ∀ {ℓ}{C : Set ℓ} → Monad{ℓ}{ℓ} (Either C)
+    Monad.return (Monad-Either{ℓ}{C}) = inj₂
+    Monad._>>=_ (Monad-Either{ℓ}{C}) = either (const ∘ inj₁) _&_
 
     Monad-Maybe : ∀ {ℓ} → Monad {ℓ} {ℓ} Maybe
     Monad.return (Monad-Maybe{ℓ}) = just

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -357,6 +357,18 @@ module LibraBFT.Prelude where
     (Left  a) → fa a
     (Right b) → fb b
 
+
+  -- Utility to make passing between `Either` and `EitherD` more convenient
+  record EitherLike {ℓ₁ ℓ₂ ℓ₃} (E : Set ℓ₁ → Set ℓ₂ → Set ℓ₃) : Set (ℓ+1 (ℓ₁ ℓ⊔ ℓ₂ ℓ⊔ ℓ₃)) where
+    field
+      fromEither : ∀ {A : Set ℓ₁} {B : Set ℓ₂} → Either A B → E A B
+      toEither   : ∀ {A : Set ℓ₁} {B : Set ℓ₂} → E A B → Either A B
+  open EitherLike ⦃ ... ⦄ public
+  instance
+    EitherLike-Either : ∀ {ℓ₁ ℓ₂} → EitherLike{ℓ₁}{ℓ₂}{ℓ₁ ℓ⊔ ℓ₂} Either
+    EitherLike.fromEither EitherLike-Either = id
+    EitherLike.toEither   EitherLike-Either = id
+
   -- an approximation of Haskell's backtick notation for making infix operators; in Agda, must have
   -- spaces between f and backticks
   flip' : _     -- Avoids warning about definition and syntax declaration being in different scopes

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -43,6 +43,7 @@ module LibraBFT.Prelude where
     public
 
   max = _⊔_
+  min = _⊓_
 
   open import Data.Nat.Properties
     hiding (≡-irrelevant ; _≟_)
@@ -53,6 +54,8 @@ module LibraBFT.Prelude where
               tabulate to List-tabulate; foldl to List-foldl)
     hiding (fromMaybe; [_])
     public
+
+  foldl' = List-foldl
 
   open import Data.List.Properties
     renaming (≡-dec to List-≡-dec; length-map to List-length-map; map-compose to List-map-compose; filter-++ to List-filter-++)
@@ -238,6 +241,8 @@ module LibraBFT.Prelude where
     renaming (map to ×-map; map₂ to ×-map₂; map₁ to ×-map₁; <_,_> to split; swap to ×-swap)
     hiding (zip)
     public
+
+  fst = proj₁
 
   open import Data.Product.Properties
     public
@@ -533,6 +538,17 @@ module LibraBFT.Prelude where
   foldrM : ∀ {ℓ₁ ℓ₂} {A B : Set ℓ₁} {M : Set ℓ₁ → Set ℓ₂} ⦃ _ : Monad M ⦄ → (A → B → M B) → B → List A → M B
   foldrM _ b      []  = return b
   foldrM f b (a ∷ as) = foldrM f b as >>= f a
+
+  foldlM : ∀ {ℓ₁ ℓ₂} {A B : Set ℓ₁} {M : Set ℓ₁ → Set ℓ₂} ⦃ _ : Monad M ⦄ → (B → A → M B) → B → List A → M B
+  foldlM _ z      []  = pure z
+  foldlM f z (x ∷ xs) = do
+    z' ← f z x
+    foldlM f z' xs
+
+  foldM = foldlM
+
+  foldM_ : {A B : Set} {M : Set → Set} ⦃ _ : Monad M ⦄ → (B → A → M B) → B → List A → M Unit
+  foldM_ f a xs = foldlM f a xs >> pure unit
 
   open import LibraBFT.Base.Util public
 

--- a/PeerHandlerContracts.org
+++ b/PeerHandlerContracts.org
@@ -1,0 +1,174 @@
+#+TITLE: Formal verification of the LibraBFT consensus algorithm
+#+SUBTITLE: An overview of proving contracts for peer handlers
+#+AUTHOR: Chris Jenkins
+#+DATE: 2021 Aug 11
+
+* Metadata
+
+  This file was written with respect to the following commit hash of the repository:
+  - 9da2d65e4592395aa3ebc6e1313f307a55393f22
+
+* Structure of peer handler proofs
+
+  In both the Haskell prototype and Agda model, peer handler code is written in
+  the =RWST= monad --- /reader, writer, state/. Unlike the Haskell code, however,
+  in Agda this monad is [[file:LibraBFT/ImplShared/Util/RWST.agda::data RWST (Ev Wr St : Set) : Set → Set₁ where][defined as a datatype]]. This allows proofs to inspect the
+  AST of peer handler code directly.
+
+  The primary way that this is used is to compute, for any postcondition =Q :
+  (Wr St A : Set) -> Set= and peer handler =h : RWST Wr St A=, the weakest
+  precondition =RWST-weakestPre m Q= which can be used to prove =Q=. This is
+  based on Dijsktra's weakest precondition calculus and the work by Swamy et al.
+  on the [[file:LibraBFT/ImplShared/Util/RWST.agda::{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.][Dijkstra monad]]. Phrasing properties about peer handlers as
+  preconditions has a number of benefits, described below.
+
+  
+** Dijkstra's weakest precondition calculus
+
+   [[file:LibraBFT/ImplShared/Util/RWST.agda]] 
+
+   There are two kinds of constructors of the Agda =RWST= monad: primitives
+   needed to support the desired functionality, and conveniences that allow us
+   to define custom proof obligations for branching code.
+
+   #+begin_src agda
+-- RWST, the AST of computations with state `St` reading from an environment
+-- `Ev` and producing a list of outputs of type `Wr`
+data RWST (Ev Wr St : Set) : Set → Set₁ where
+  -- Primitive combinators
+  RWST-return : ∀ {A}   → A                                     → RWST Ev Wr St A
+  RWST-bind   : ∀ {A B} → RWST Ev Wr St A → (A → RWST Ev Wr St B) → RWST Ev Wr St B
+  RWST-gets   : ∀ {A} → (St → A)                                → RWST Ev Wr St A
+  RWST-put    : St                                              → RWST Ev Wr St Unit
+  RWST-ask    :                                                   RWST Ev Wr St Ev
+  RWST-tell   : List Wr                                         → RWST Ev Wr St Unit
+
+  -- Branching combinators (used for creating more convenient contracts)
+  RWST-if     : ∀ {A} → Guards (RWST Ev Wr St A)                → RWST Ev Wr St A
+  RWST-either : ∀ {A B C} → Either B C
+               → (B → RWST Ev Wr St A) → (C → RWST Ev Wr St A)   → RWST Ev Wr St A
+  RWST-ebind  : ∀ {A B C}
+               → RWST Ev Wr St (Either C A)
+               → (A → RWST Ev Wr St (Either C B))               → RWST Ev Wr St (Either C B)
+  RWST-maybe  : ∀ {A B} → Maybe B
+               → (RWST Ev Wr St A) → (B → RWST Ev Wr St A)       → RWST Ev Wr St A
+   #+end_src
+
+   There are two steps in the development for the weakest precondition calculus.
+
+*** Computing the weakest precondition
+
+    From a peer handler =m= and postcondition =P= we compute (using a large
+    elimination) a precondition =RWST-weakestPre m P=.
+
+    - This is easy to see for =RWST-pure=
+
+        #+begin_src agda
+RWST-weakestPre (RWST-return x) P ev pre = P x pre []
+        #+end_src
+
+      That is, the post condition must already hold for the returned value and
+      prestate with no outputs. Here, =ev= is the environment we read from and
+      =pre= is the prestate.
+
+    - The case for =RWST-bind= is trickier
+
+        #+begin_src agda
+RWST-weakestPre (RWST-bind m f) P ev pre =
+  RWST-weakestPre m (RWST-weakestPre-bindPost ev f P) ev pre
+{- ... -}
+
+RWST-Post++ P outs x post outs₁ = P x post (outs ++ outs₁)
+
+RWST-weakestPre-bindPost ev f P x post outs =
+  ∀ r → r ≡ x → RWST-weakestPre (f r) (RWST-Post++ P outs) ev post
+        #+end_src
+
+      - We want a weakest precondition for =m= of a postcondition for =m= that
+        will guarantee that running =f= on the result of =m= gives us the
+        desired final postcondition =P= of =RWST-bind m f=.
+
+        The postcondition of =m= which is also the precondition for running
+        =f= on the result of =m= is =RWST-weakestPre-bindPost ev f P=
+
+      - In =RWST-weakestPre-bindPost=, =x= is the result of running =m=, =post=
+        is the poststate, and =outs= is the list of outputs =m= generated.
+
+      - We introduce a new variable =r= to serve as an alias for the result
+        =x=.
+
+        In proofs, the variable =x= may be instantiated with some very large
+        and complicated expression, and substituting it directly into the
+        desired precondition could cause the proof state to become quite
+        unreadable. Introducing an alias allows the prover (e.g., you!) to use
+        the same name as used in the peer handler code itself, and only reveal
+        what it actually computes to where that information is needed.
+
+      - Finally, we want the weakest precondition of =P= for =f r=, but now
+        =P= must hold not only for the outputs of =f r= but also the
+        previously generated outputs, =outs=.
+
+        We therefore use the helper function =RWST-Post++=.
+
+    - Now we look at a case for one of the "convenience" constructors ---
+      =RWST-maybe=
+
+      #+begin_src agda
+RWST-weakestPre (RWST-maybe m f₁ f₂) P ev pre =
+  (m ≡ nothing → RWST-weakestPre f₁ P ev pre)
+  × (∀ j → m ≡ just j → RWST-weakestPre (f₂ j) P ev pre)
+      #+end_src
+
+      - Here, we decompose the precondition into two subgoals: one where
+        =m : Maybe A= is =nothing= (and so we need that the weakest precondition
+        of =P= holds for =f₁=) and one where there is a =j= such that =m ≡ just
+        j=.
+
+      - By phrasing it this way, we get help from Agda: in proofs, instead of
+        having to do case analysis on =m= ourselves (which might be quite a
+        complicated expression), Agda can automatically refine (using =C-c C-r=,
+        or =C-c C-c= for copattern matching) the goal to these two subgoals when
+        the expression we are considering is formed by =RWST-maybe=
+    
+        
+*** Proving a contract
+
+    For the top-level peer handlers (process proposal, process vote), once we
+    have proven the weakest precondition for the desired postcondition, the next
+    step is to use this to extract that post condition. This is done with
+    =RWST-contract= below
+
+    #+begin_src agda
+RWST-Post-True : (P : RWST-Post Wr St A) (m : RWST Ev Wr St A) (ev : Ev) (pre : St) → Set
+RWST-Post-True P m ev pre =
+  let (x , post , outs) = RWST-run m ev pre in
+  P x post outs
+
+RWST-Contract : (m : RWST Ev Wr St A) → Set₁
+RWST-Contract{Ev}{Wr}{St}{A} m =
+  (P : RWST-Post Wr St A)
+  → (ev : Ev) (pre : St) → RWST-weakestPre m P ev pre
+  → RWST-Post-True P m ev pre
+
+
+RWST-Contract : (m : RWST Ev Wr St A) → Set₁
+RWST-Contract{Ev}{Wr}{St}{A} m =
+  (P : RWST-Post Wr St A)
+  → (ev : Ev) (pre : St) → RWST-weakestPre m P ev pre
+  → let (x , post , outs) = RWST-run m ev pre in
+    P x post outs
+
+RWST-contract : (m : RWST Ev Wr St A) → RWST-Contract m
+    #+end_src
+
+    1. =RWST-Post-True= says what it means for a post condition =P= to be
+       true of a peer handler =m= running in environment =ev= with prestate =pre=
+
+    2. =RWST-Contract= is the statement that it suffices to show the weakest
+       precondition of =P= for =m= if you want that the =P= holds for =m=
+
+    3. =RWST-contract= is the proof of the above statement
+
+
+    You can find =RWST-contract= (in the form of =LBFT-contract=) used in
+    [[file:LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda]]

--- a/PeerHandlerContracts.org
+++ b/PeerHandlerContracts.org
@@ -5,27 +5,28 @@
 
 * Metadata
 
-  This file was written with respect to the following commit hash of the repository:
-  - 9da2d65e4592395aa3ebc6e1313f307a55393f22
+  This file was written with respect to the following commit hash of the
+  repository:
+  - 2697125876ba4f02a7904867db50be8ddb331f80
 
 * Structure of peer handler proofs
 
   In both the Haskell prototype and Agda model, peer handler code is written in
-  the =RWST= monad --- /reader, writer, state/. Unlike the Haskell code, however,
-  in Agda this monad is [[file:LibraBFT/ImplShared/Util/RWST.agda::data RWST (Ev Wr St : Set) : Set → Set₁ where][defined as a datatype]]. This allows proofs to inspect the
-  AST of peer handler code directly.
+  the =RWST= --- /reader, writer, state/ --- and =EitherD= monads. Unlike the
+  Haskell code, in Agda these monads are [[file:LibraBFT/ImplShared/Util/RWST.agda::data RWST (Ev Wr St : Set) : Set → Set₁ where][defined as a special-purpose datatypes]].
+  This allows proofs to inspect the AST of peer handler code directly.
 
-  The primary way that this is used is to compute, for any postcondition =Q :
-  (Wr St A : Set) -> Set= and peer handler =h : RWST Wr St A=, the weakest
-  precondition =RWST-weakestPre m Q= which can be used to prove =Q=. This is
-  based on Dijsktra's weakest precondition calculus and the work by Swamy et al.
-  on the [[file:LibraBFT/ImplShared/Util/RWST.agda::{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.][Dijkstra monad]]. Phrasing properties about peer handlers as
+  For =RWST=, the primary way that this is used is to compute, for any
+  postcondition =Q : (Wr St A : Set) -> Set= and peer handler =h : RWST Wr St
+  A=, the weakest precondition =RWST-weakestPre m Q= which can be used to prove
+  =Q=. This is based on Dijsktra's weakest precondition calculus and the work by
+  Swamy et al. on the [[file:LibraBFT/ImplShared/Util/RWST.agda::{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.][Dijkstra monad]]. Phrasing properties about peer handlers as
   preconditions has a number of benefits, described below.
 
   
 ** Dijkstra's weakest precondition calculus
 
-   [[file:LibraBFT/ImplShared/Util/RWST.agda]] 
+   [[file:LibraBFT/ImplShared/Util/Dijkstra/RWST.agda]] 
 
    There are two kinds of constructors of the Agda =RWST= monad: primitives
    needed to support the desired functionality, and conveniences that allow us
@@ -84,7 +85,7 @@ RWST-weakestPre-bindPost ev f P x post outs =
   ∀ r → r ≡ x → RWST-weakestPre (f r) (RWST-Post++ P outs) ev post
         #+end_src
 
-      - We want a weakest precondition for =m= of a postcondition for =m= that
+      - We want the weakest precondition for =m= of a postcondition for =m= that
         will guarantee that running =f= on the result of =m= gives us the
         desired final postcondition =P= of =RWST-bind m f=.
 
@@ -130,13 +131,12 @@ RWST-weakestPre (RWST-maybe m f₁ f₂) P ev pre =
         or =C-c C-c= for copattern matching) the goal to these two subgoals when
         the expression we are considering is formed by =RWST-maybe=
     
-        
-*** Proving a contract
+*** Proving a contract from its weakest precondition
 
     For the top-level peer handlers (process proposal, process vote), once we
     have proven the weakest precondition for the desired postcondition, the next
     step is to use this to extract that post condition. This is done with
-    =RWST-contract= below
+    =RWST-contract= below:
 
     #+begin_src agda
 RWST-Post-True : (P : RWST-Post Wr St A) (m : RWST Ev Wr St A) (ev : Ev) (pre : St) → Set
@@ -172,3 +172,180 @@ RWST-contract : (m : RWST Ev Wr St A) → RWST-Contract m
 
     You can find =RWST-contract= (in the form of =LBFT-contract=) used in
     [[file:LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda]]
+    
+*** Postcondition implication
+
+    Sometimes when proving a precondition, it is convenient to show
+    directly that one postcondition implies another. For example, let us say we
+    have peer handlers =foo=, =bar=, and =baz=, we have prooven =ContractFoo=
+    and =ContractBar=, and we are trying to prove =ContractBaz= when =baz= looks
+    like:
+
+    #+begin_src haskell
+      baz = do
+        x <- foo
+        bar x
+    #+end_src
+
+    So, we may wish to show that =ContractFoo= implies the postcondition
+    =RWST-weakestPre-bindPost ev bar ContractBaz=. The lemma =RWST-⇒= serves
+    just this purpose.
+
+    #+begin_src agda
+RWST-Post-⇒ : (P Q : RWST-Post Wr St A) → Set
+RWST-Post-⇒ P Q = ∀ r st outs → P r st outs → Q r st outs
+
+-- This helper function is primarily used to take a proof concerning one
+-- computation `m` and show that that proof implies a property concerning a
+-- larger computation which contains `m`.
+RWST-⇒
+  : (P Q : RWST-Post Wr St A) → (RWST-Post-⇒ P Q)
+    → ∀ m (ev : Ev) st → RWST-weakestPre m P ev st → RWST-weakestPre m Q ev st
+    #+end_src
+
+    In fact, this need comes up so frequently that I recommend contracts for
+    non-toplevel handlers always be formulated so that they speak about
+    arbitrary postconditions. (Below, =pre= is a module parameter)
+
+    #+begin_src agda
+    contract' : LBFT-weakestPre baz ContractBaz pre
+
+    contract : ∀ Post → (RWST-Post-⇒ ContractBaz Post) → LBFT-weakestPre baz Post pre
+    contract Post pf = LBFT-⇒ ContractBaz Post pf baz pre contract'
+    #+end_src
+    
+** Peer handler proofs
+   
+*** Breaking the peer handler down into smaller "steps"
+
+    When beginning to prove a contract for a peer handler, it is extremely
+    useful to (re)write than handler into smaller steps, for two reasons:
+    1. It helps to declutter the proof state, so you can orient yourself on what
+       you still need to show.
+
+    2. It allows you to break the proof down into smaller pieces as well, making
+       it more readable. The types of these smaller proofs will mention the code
+       that remains to execute, so save yourself some typing by having this be
+       something short like =step3 <args>=
+
+
+    Let's look at =ensureRoundAndSyncUpM= as an example
+
+    #+begin_src agda
+module ensureRoundAndSyncUpM
+  (now : Instant) (messageRound : Round) (syncInfo : SyncInfo) (author : Author) (helpRemote : Bool) where
+  step₀ : LBFT (Either ErrLog Bool)
+  step₁ : LBFT (Either ErrLog Bool)
+  step₂ : LBFT (Either ErrLog Bool)
+
+  step₀ = do
+    currentRound ← use (lRoundState ∙ rsCurrentRound)
+    ifD messageRound <? currentRound
+      then ok false
+      else step₁
+
+  step₁ =
+        syncUpM now syncInfo author helpRemote ∙?∙ λ _ → step₂
+
+  step₂ = do
+          currentRound' ← use (lRoundState ∙ rsCurrentRound)
+          ifD messageRound /= currentRound'
+            then bail fakeErr -- error: after sync, round does not match local
+            else ok true
+
+ensureRoundAndSyncUpM = ensureRoundAndSyncUpM.step₀
+    #+end_src
+
+    Generally speaking, it's good to choose the boundaries of these steps around
+    any point that branches, and at any point where another function is called
+    (such as =syncUpM=) so you can use the contract for that function to "move"
+    to the next step. This is shown below for a part of the proof of the
+    contract for =ensureRoundAndSyncUpM= (found in [[file:LibraBFT/Impl/Consensus/RoundManager/Properties.agda]])
+
+    #+begin_src agda
+      contract-step₁
+        : RWST-weakestPre (syncUpM now syncInfo author helpRemote)
+            (RWST-weakestPre-ebindPost unit (const step₂) Contract)
+            unit pre
+      contract-step₁ = syncUpMSpec.contract now syncInfo author helpRemote pre Post contract-step₁'
+        where
+        Post = RWST-weakestPre-ebindPost unit (const step₂) Contract
+    #+end_src
+
+    Here =Contract= is the contract we want to show. =Post= is the postcondition
+    we want for =syncUpM= --- which is the weakest precondition for =const
+    step₂= that gives us =Contract=.
+
+    
+*** Using =abstract= blocks
+
+    When completely normalized (i.e., evaluated as much as they can be by Agda's
+    typechecker), many peer handler functions are *quite* large. That means
+    there can be quite a lot of clutter to read through while proving. One way
+    to reduce this is by using Agda's =abstract= blocks, which prevent Agda from
+    unrolling a definition outside that block.
+
+    =processProposalMsgM= (an external entry point to =RoundManager.agda=) is an
+    example of this.
+
+    #+begin_src agda
+abstract
+  processProposalMsgM = processProposalMsgM.step₀
+
+  processProposalMsgM≡ : processProposalMsgM ≡ processProposalMsgM.step₀
+  processProposalMsgM≡ = refl
+    #+end_src
+
+    The defintion of =processProposalMsgM.step₀= /is/ visible in other contexts,
+    so =processProposalMsgM≡= is used by the proof of the contract for
+    =processProposalMsgM= to transfer a property about
+    =processProposalMsgM.step₀= to =processProposalMsgM=.
+
+    At the time of writing, there is no set discipline for when to use
+    =abstract= blocks. Conceivably, they could be used for *every* function,
+    since this would greatly improve the readability of the proof state for any
+    peer handler contract proof.
+
+    
+*** =EitherLike=
+
+    To take advantage of the weakest precondition infrastructure, peer handler
+    code written in the =Either ErrLog= monad in Haskell is (or will be) written
+    in the =EitherD ErrLog= monad. To facilitate writing code to operate on both
+    =Either= or =EitherD=, the prelude defines a typeclass =EitherLike=.
+
+    #+begin_src agda
+  -- Utility to make passing between `Either` and `EitherD` more convenient
+  record EitherLike {ℓ₁ ℓ₂ ℓ₃} (E : Set ℓ₁ → Set ℓ₂ → Set ℓ₃) : Set (ℓ+1 (ℓ₁ ℓ⊔ ℓ₂ ℓ⊔ ℓ₃)) where
+    field
+      fromEither : ∀ {A : Set ℓ₁} {B : Set ℓ₂} → Either A B → E A B
+      toEither   : ∀ {A : Set ℓ₁} {B : Set ℓ₂} → E A B → Either A B
+  open EitherLike ⦃ ... ⦄ public
+    #+end_src
+
+    With this, operations for branching (such as =case⊎D_of_=) can be defined to
+    operate over anything that is =EitherLike=.
+
+    The one wrinkle in this story is the monadic bind operation. When writing
+    "m >>= f" in the =EitherD ErrLog= monad, =f= must return something of the form
+    =EitherD ErrLog B=, and similarly for the =Either ErrLog= monad.
+
+    At the time of writing, the recommendation for =EitherD= peer handler code
+    is:
+    - write the steps in =EitherD=
+      e.g., =executeAndInsertBlockE.step₀ : BlockStore → Block → EitherD ErrLog (BlockStore × Block)=
+    - write the function itself in =Either=, which will be used by =LBFT= peer handlers
+      e.g., =executeAndInsertBlockE bs block = toEither $ executeAndInsertBlockE.step₀ bs block=
+
+    - write a variant in =EitherD= again, to be used by other =EitherD=
+      handlers
+
+      e.g. =executeAndInsertBlockE₀ bs block = fromEither executeAndInsertBlockE bs block=
+
+
+    Note that this third version is not the same as the first, even though it
+    has the same type signature. While =step₀= may have many uses of binds and
+    branching, =executeAndInsertBlockE₀= will only ever be an =EitherD-return=
+    or =EitherD-bail=. This has the side effect of reducing clutter in the proof
+    state for any contract of an =EitherD= handler that calls
+    =executeAndInsertBlockE₀=.

--- a/docs/PeerHandlerContracts.org
+++ b/docs/PeerHandlerContracts.org
@@ -200,7 +200,7 @@ RWST-⇒
     #+end_src
 
     This is such a common pattern that contracts for
-    non-toplevel handlers should generally formulated for
+    non-toplevel handlers should generally be formulated for
     arbitrary postconditions (=pre= is a module parameter):
 
     #+begin_src agda
@@ -370,9 +370,9 @@ module ensureRoundAndSyncUpMSpec
 
      With the local definition of =Post= as =RWST-weakestPre-ebindPost unit
      (const step₂) Contract= (because the call to =syncUpM= is followed by =∙?∙
-     λ _ → step₂=, where =∙?∙= is an alias for =RWST-ebind=), we now know the
-     what the type of ~contract-step₁'~ should be --- and so below, we can
-     choose to omit it using an underscore, shown below in the definition of
+     λ _ → step₂=, where =∙?∙= is an alias for =RWST-ebind=), we now know what
+     the type of ~contract-step₁'~ should be --- and so below, we can choose to
+     omit it using an underscore, shown below in the definition of
      ~contract-step₁'~.
      
      #+begin_src agda
@@ -524,7 +524,7 @@ record MonadEitherD {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) : Se
 open MonadEitherD ⦃ ... ⦄ public hiding (eitherSD)
 #+end_src
 
-     The Agda typeclass =MonadEitherD= allows us to gives a single name for an
+     The Agda typeclass =MonadEitherD= allows us to give a single name for an
      operation that acts the same as =eitherS= in the Haskell prototype.
      When we open =MonadEitherD=, we hide =eitherSD= so that we can define a
      version in which the first (non-implicit) argument is anything that is

--- a/docs/PeerHandlerContracts.org
+++ b/docs/PeerHandlerContracts.org
@@ -13,10 +13,12 @@
 
   In both the Haskell prototype and Agda model, peer handler code is written in
   the =RWST= --- /reader, writer, state/ --- and =EitherD= monads. Unlike the
-  Haskell code, in Agda these monads are [[file:LibraBFT/ImplShared/Util/RWST.agda::data RWST (Ev Wr St : Set) : Set → Set₁ where][defined as a special-purpose datatypes]].
+  Haskell code, in Agda, these monads are [[file:LibraBFT/ImplShared/Util/RWST.agda::data RWST (Ev Wr St : Set) : Set → Set₁ where][defined as a special-purpose datatypes]]
+  (in , defined in
+  ~LibraBFT.ImplShared.Util.Dijkstra.RWST~ and ~LibraBFT.ImplShared.Util.Dijkstra.EitherD~, respectively).
   This allows proofs to inspect the AST of peer handler code directly.
 
-  For =RWST=, the primary way that this is used is to compute, for any
+  For =RWST=, this is primarily used to compute, for any
   postcondition =Q : (Wr St A : Set) -> Set= and peer handler =h : RWST Wr St
   A=, the weakest precondition =RWST-weakestPre m Q= which can be used to prove
   =Q=. This is based on Dijsktra's weakest precondition calculus and the work by
@@ -150,14 +152,6 @@ RWST-Contract{Ev}{Wr}{St}{A} m =
   → (ev : Ev) (pre : St) → RWST-weakestPre m P ev pre
   → RWST-Post-True P m ev pre
 
-
-RWST-Contract : (m : RWST Ev Wr St A) → Set₁
-RWST-Contract{Ev}{Wr}{St}{A} m =
-  (P : RWST-Post Wr St A)
-  → (ev : Ev) (pre : St) → RWST-weakestPre m P ev pre
-  → let (x , post , outs) = RWST-run m ev pre in
-    P x post outs
-
 RWST-contract : (m : RWST Ev Wr St A) → RWST-Contract m
     #+end_src
 
@@ -170,16 +164,18 @@ RWST-contract : (m : RWST Ev Wr St A) → RWST-Contract m
     3. =RWST-contract= is the proof of the above statement
 
 
-    You can find =RWST-contract= (in the form of =LBFT-contract=) used in
-    [[file:LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda]]
+    There is an example of using =RWST-contract= in
+    [[file:LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda]].  (Note that `LBFT`, defined in
+    ~LibraBFT.ImplShared.Util.Util~ is `RWST` instantiated with the types used to express our Agda
+    implementation of `LibraBFT`; for convenience, we often have `LBFT` variants of `RWST`
+    definitions and proofs.)
     
 *** Postcondition implication
 
     Sometimes when proving a precondition, it is convenient to show
-    directly that one postcondition implies another. For example, let us say we
-    have peer handlers =foo=, =bar=, and =baz=, we have prooven =ContractFoo=
-    and =ContractBar=, and we are trying to prove =ContractBaz= when =baz= looks
-    like:
+    directly that one postcondition implies another. For example, suppose we
+    have peer handlers =foo=, =bar=, and =baz=, we have proved =ContractFoo=
+    and =ContractBar=, and we are trying to prove =ContractBaz= where =baz= is:
 
     #+begin_src haskell
       baz = do
@@ -187,7 +183,7 @@ RWST-contract : (m : RWST Ev Wr St A) → RWST-Contract m
         bar x
     #+end_src
 
-    So, we may wish to show that =ContractFoo= implies the postcondition
+    We may wish to show that =ContractFoo= implies the postcondition
     =RWST-weakestPre-bindPost ev bar ContractBaz=. The lemma =RWST-⇒= serves
     just this purpose.
 
@@ -197,15 +193,15 @@ RWST-Post-⇒ P Q = ∀ r st outs → P r st outs → Q r st outs
 
 -- This helper function is primarily used to take a proof concerning one
 -- computation `m` and show that that proof implies a property concerning a
--- larger computation which contains `m`.
+-- larger computation that contains `m`.
 RWST-⇒
   : (P Q : RWST-Post Wr St A) → (RWST-Post-⇒ P Q)
     → ∀ m (ev : Ev) st → RWST-weakestPre m P ev st → RWST-weakestPre m Q ev st
     #+end_src
 
-    In fact, this need comes up so frequently that I recommend contracts for
-    non-toplevel handlers always be formulated so that they speak about
-    arbitrary postconditions. (Below, =pre= is a module parameter)
+    This is such a common pattern that contracts for
+    non-toplevel handlers should generally formulated for
+    arbitrary postconditions (=pre= is a module parameter):
 
     #+begin_src agda
     contract' : LBFT-weakestPre baz ContractBaz pre
@@ -218,18 +214,18 @@ RWST-⇒
    
 *** Breaking the peer handler down into smaller "steps"
 
-    When beginning to prove a contract for a peer handler, it is extremely
-    useful to (re)write than handler into smaller steps, for two reasons:
+    When beginning to prove a contract for a peer handler, it is often
+    useful to break the handler into smaller steps, for two reasons:
     1. It helps to declutter the proof state, so you can orient yourself on what
        you still need to show.
 
     2. It allows you to break the proof down into smaller pieces as well, making
        it more readable. The types of these smaller proofs will mention the code
-       that remains to execute, so save yourself some typing by having this be
-       something short like =step3 <args>=
+       that remains to execute, so save yourself some typing by using
+       short names like =step3 <args>=.
 
 
-    Let's look at =ensureRoundAndSyncUpM= as an example
+    Let's look at =ensureRoundAndSyncUpM= as an example.
 
     #+begin_src agda
 module ensureRoundAndSyncUpM
@@ -260,7 +256,7 @@ ensureRoundAndSyncUpM = ensureRoundAndSyncUpM.step₀
     any point that branches, and at any point where another function is called
     (such as =syncUpM=) so you can use the contract for that function to "move"
     to the next step. This is shown below for a part of the proof of the
-    contract for =ensureRoundAndSyncUpM= (found in [[file:LibraBFT/Impl/Consensus/RoundManager/Properties.agda]])
+    contract for =ensureRoundAndSyncUpM= (found in [[file:LibraBFT/Impl/Consensus/RoundManager/Properties.agda]]):
 
     #+begin_src agda
       contract-step₁
@@ -272,7 +268,7 @@ ensureRoundAndSyncUpM = ensureRoundAndSyncUpM.step₀
         Post = RWST-weakestPre-ebindPost unit (const step₂) Contract
     #+end_src
 
-    Here =Contract= is the contract we want to show. =Post= is the postcondition
+    Here, =Contract= is the contract we want to show. =Post= is the postcondition
     we want for =syncUpM= --- which is the weakest precondition for =const
     step₂= that gives us =Contract=.
 
@@ -283,7 +279,7 @@ ensureRoundAndSyncUpM = ensureRoundAndSyncUpM.step₀
     typechecker), many peer handler functions are *quite* large. That means
     there can be quite a lot of clutter to read through while proving. One way
     to reduce this is by using Agda's =abstract= blocks, which prevent Agda from
-    unrolling a definition outside that block.
+    unrolling a definition beyond that block.
 
     =processProposalMsgM= (an external entry point to =RoundManager.agda=) is an
     example of this.
@@ -312,7 +308,7 @@ abstract
     To take advantage of the weakest precondition infrastructure, peer handler
     code written in the =Either ErrLog= monad in Haskell is (or will be) written
     in the =EitherD ErrLog= monad. To facilitate writing code to operate on both
-    =Either= or =EitherD=, the prelude defines a typeclass =EitherLike=.
+    =Either= or =EitherD=, ~LibraBFT.Prelude~ defines a typeclass =EitherLike=.
 
     #+begin_src agda
   -- Utility to make passing between `Either` and `EitherD` more convenient
@@ -334,13 +330,13 @@ abstract
     is:
     - write the steps in =EitherD=
       e.g., =executeAndInsertBlockE.step₀ : BlockStore → Block → EitherD ErrLog (BlockStore × Block)=
-    - write the function itself in =Either=, which will be used by =LBFT= peer handlers
+    - use ~toEither~ to create a version of the function in =Either=, which will be used by =LBFT= peer handlers
       e.g., =executeAndInsertBlockE bs block = toEither $ executeAndInsertBlockE.step₀ bs block=
 
     - write a variant in =EitherD= again, to be used by other =EitherD=
       handlers
 
-      e.g. =executeAndInsertBlockE₀ bs block = fromEither executeAndInsertBlockE bs block=
+      e.g. =executeAndInsertBlockE₀ bs block = fromEither $ executeAndInsertBlockE bs block=
 
 
     Note that this third version is not the same as the first, even though it

--- a/docs/PeerHandlerContracts.org
+++ b/docs/PeerHandlerContracts.org
@@ -7,7 +7,7 @@
 
   This file was written with respect to the following commit hash of the
   repository:
-  - 7bdbde02b220a20b2e7cde98154a0fbdb75c5051
+  - bf83f206aec53b2f7abd3a92293ca1ac722bf6eb
 
 * Structure of peer handler proofs
 

--- a/docs/PeerHandlerContracts.org
+++ b/docs/PeerHandlerContracts.org
@@ -7,7 +7,7 @@
 
   This file was written with respect to the following commit hash of the
   repository:
-  - 2697125876ba4f02a7904867db50be8ddb331f80
+  - 7bdbde02b220a20b2e7cde98154a0fbdb75c5051
 
 * Structure of peer handler proofs
 

--- a/docs/PeerHandlerContracts.org
+++ b/docs/PeerHandlerContracts.org
@@ -13,7 +13,7 @@
 
   In both the Haskell prototype and Agda model, peer handler code is written in
   the =RWST= --- /reader, writer, state/ --- and =EitherD= monads. Unlike the
-  Haskell code, in Agda, these monads are [[file:LibraBFT/ImplShared/Util/RWST.agda::data RWST (Ev Wr St : Set) : Set → Set₁ where][defined as a special-purpose datatypes]]
+  Haskell code, in Agda, these monads are [[file:../LibraBFT/ImplShared/Util/RWST.agda::data RWST (Ev Wr St : Set) : Set → Set₁ where][defined as a special-purpose datatypes]]
   (in , defined in
   ~LibraBFT.ImplShared.Util.Dijkstra.RWST~ and ~LibraBFT.ImplShared.Util.Dijkstra.EitherD~, respectively).
   This allows proofs to inspect the AST of peer handler code directly.
@@ -22,13 +22,13 @@
   postcondition =Q : (Wr St A : Set) -> Set= and peer handler =h : RWST Wr St
   A=, the weakest precondition =RWST-weakestPre m Q= which can be used to prove
   =Q=. This is based on Dijsktra's weakest precondition calculus and the work by
-  Swamy et al. on the [[file:LibraBFT/ImplShared/Util/RWST.agda::{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.][Dijkstra monad]]. Phrasing properties about peer handlers as
+  Swamy et al. on the [[file:../LibraBFT/ImplShared/Util/RWST.agda::{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.][Dijkstra monad]]. Phrasing properties about peer handlers as
   preconditions has a number of benefits, described below.
 
   
 ** Dijkstra's weakest precondition calculus
 
-   [[file:LibraBFT/ImplShared/Util/Dijkstra/RWST.agda]] 
+   [[file:../LibraBFT/ImplShared/Util/Dijkstra/RWST.agda]] 
 
    There are two kinds of constructors of the Agda =RWST= monad: primitives
    needed to support the desired functionality, and conveniences that allow us
@@ -165,7 +165,7 @@ RWST-contract : (m : RWST Ev Wr St A) → RWST-Contract m
 
 
     There is an example of using =RWST-contract= in
-    [[file:LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda]].  (Note that `LBFT`, defined in
+    [[file:../LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda]].  (Note that `LBFT`, defined in
     ~LibraBFT.ImplShared.Util.Util~ is `RWST` instantiated with the types used to express our Agda
     implementation of `LibraBFT`; for convenience, we often have `LBFT` variants of `RWST`
     definitions and proofs.)
@@ -256,22 +256,185 @@ ensureRoundAndSyncUpM = ensureRoundAndSyncUpM.step₀
     any point that branches, and at any point where another function is called
     (such as =syncUpM=) so you can use the contract for that function to "move"
     to the next step. This is shown below for a part of the proof of the
-    contract for =ensureRoundAndSyncUpM= (found in [[file:LibraBFT/Impl/Consensus/RoundManager/Properties.agda]]):
+    contract for =ensureRoundAndSyncUpM= (found in [[file:../LibraBFT/Impl/Consensus/RoundManager/Properties.agda]]):
+
+**** Standard setup for contracts
+
+     For formulating and proving peer handler contracts, the preferred style is
+     to create a module specifically for that peer handler (in a separate
+     =Properties.agda= file) with the suffix =Spec=, e.g., =ensureRoundAndSyncUpMSpec=
+     
+     #+begin_src agda
+module ensureRoundAndSyncUpMSpec
+  (now : Instant) (messageRound : Round) (syncInfo : SyncInfo)
+  (author : Author) (helpRemote : Bool) where
+
+  open ensureRoundAndSyncUpM now messageRound syncInfo author helpRemote
+
+  module _ (pre : RoundManager) where
+
+    record Contract (r : Either ErrLog Bool) (post : RoundManager) (outs : List Output) : Set where
+      constructor mkContract
+      field
+        -- General invariants / properties
+        rmInv         : Preserves RoundManagerInv pre post
+        noEpochChange : NoEpochChange pre post
+        noVoteOuts    : OutputProps.NoVotes outs
+        -- Voting
+        noVote        : VoteNotGenerated pre post true
+        -- Signatures
+        outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
+        qcPost   : QCProps.∈Post⇒∈PreOr (_QC∈SyncInfo syncInfo) pre post
+     #+end_src
+
+     From within this module, open the =ensureRoundAndSyncUpM= module and call
+     the property that we want to prove =Contract= --- from outside the module,
+     this is called =ensureRoundAndSyncUpMSpec.Contract=.
+
+     The main proof effort is in showing the weakest precondition of =Contract=
+     for =ensureRoundAndSyncUpM=. This is =contract'= below, which we break up
+     into smaller pieces to discuss.
 
     #+begin_src agda
-      contract-step₁
-        : RWST-weakestPre (syncUpM now syncInfo author helpRemote)
-            (RWST-weakestPre-ebindPost unit (const step₂) Contract)
-            unit pre
+    contract'
+      : LBFT-weakestPre (ensureRoundAndSyncUpM now messageRound syncInfo author helpRemote) Contract pre
+    proj₁ (contract' ._ refl) _         =
+      mkContract id refl refl vng outqcs qcPost
+      where
+        vng : VoteNotGenerated pre pre true
+        vng = mkVoteNotGenerated refl refl
+
+        outqcs : QCProps.OutputQc∈RoundManager [] pre
+        outqcs = QCProps.NoMsgs⇒OutputQc∈RoundManager [] pre refl
+
+        qcPost : QCProps.∈Post⇒∈PreOr _ pre pre
+        qcPost qc = Left
+
+     #+end_src
+
+     The first two arguments to =contract'= come from the bind operation
+     (=currentRound ← use (lRoundState ∙ rsCurrentRound)=). The first argument
+     (unnamed, given as an underscore) has type =Round= and the second argument
+     is a proof that it is equal to =pre ^∙ lRoundState ∙ rsCurrentRound=.
+
+     - NOTE: By pattern matching on the equality, we reveal the relationship
+       between the "alias" variables that =RWST-weakestPre= gives us and the
+       preceding computation that generated it (here, =use (lRoundState ∙
+       rsCurrentRound)=). This is fine in this case; however, for alias
+       variables generated from complex computations it is usually desirable to
+       hold off on using case analysis on the equality proof, since this results
+       in substituting the entire expression into the goal.
+
+       You can see the private module =Tutorial= in
+       [[file:../LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda]]
+       for more details about reading and managing the proof state when using
+       the weakest precondition infrastructure.
+
+
+     After the bind, we have a conditional operation, so the goal becomes
+     showing a product of proofs --- one each for the ~then~ and ~else~
+     branches. The code listing above is for the ~then~ branch, which is a
+     non-error early exit. The second underscore is an anonymous proof that the
+     conditional evaluated to true (for safety, we do not need this evidence).
+
+     In the local proof =outqcs=, we use one of the many utility lemmas defined
+     in [[file:../LibraBFT/Impl/Properties/Util.agda]] designed to help glue
+     contracts of different peer handlers together and deal with many common
+     cases. For =outqcs=, we are in a situation where we have generated *no*
+     messages. One of the properties in the contract is that any quorum
+     certificate found in the output came from the round manager, and the lemma
+     =QCProps.NoMsgs⇒OutputQc∈RoundManager= proves that if there are no output
+     messages (but maybe some logging messages), then this universal statement
+     holds vacuously.
+     
+     #+begin_src agda
+    proj₂ (contract' ._ refl) mrnd≥crnd = contract-step₁
+      where
+      contract-step₁ : LBFT-weakestPre step₁ Contract pre
       contract-step₁ = syncUpMSpec.contract now syncInfo author helpRemote pre Post contract-step₁'
         where
         Post = RWST-weakestPre-ebindPost unit (const step₂) Contract
+     #+end_src
+
+     For the =else= branch, we are given evidence that the condition evaluated
+     to =false=. The code then proceeds to =step₁=, so the proof now must show
+     the weakest precondition of =Contract= for =step₁=.
+
+     At this point, the code calls =syncUpM=; similarly, the proof of the
+     contract for =ensureRoundAndSyncUpM= invokes the contract for =syncUpM=.
+     The type of =syncUpMSpec.contract now syncInfo author helpRemote pre= is:
+
+     #+begin_src agda
+     ∀ Post → RWST-Post-⇒ (syncUpMSpec.Contract now syncInfo author helpRemote) Post
+     → LBFT-weakestPre (syncUpM now syncInfo author helpRemote) Post pre
+     #+end_src
+
+     With the local definition of =Post= as =RWST-weakestPre-ebindPost unit
+     (const step₂) Contract= (because the call to =syncUpM= is followed by =∙?∙
+     λ _ → step₂=, where =∙?∙= is an alias for =RWST-ebind=), we now know the
+     what the type of ~contract-step₁'~ should be --- and so below, we can
+     choose to omit it using an underscore, shown below in the definition of
+     ~contract-step₁'~.
+     
+     #+begin_src agda
+        contract-step₁' : _
+        contract-step₁' (Left  _   ) st outs con =
+          mkContract SU.rmInv SU.noEpochChange SU.noVoteOuts SU.noVote SU.outQcs∈RM SU.qcPost
+          where
+          module SU = syncUpMSpec.Contract con
+        contract-step₁' (Right unit) st outs con = contract-step₂
+          where
+          module SU = syncUpMSpec.Contract con
+
+          noVoteOuts' : NoVotes (outs ++ [])
+          noVoteOuts' = ++-NoVotes outs [] SU.noVoteOuts refl
+
+          outqcs : QCProps.OutputQc∈RoundManager (outs ++ []) st
+          outqcs = QCProps.++-OutputQc∈RoundManager{rm = st} SU.outQcs∈RM
+                     (QCProps.NoMsgs⇒OutputQc∈RoundManager [] st refl)
+
+          contract-step₂ : Post (Right unit) st outs
+          proj₁ (contract-step₂ ._ refl ._ refl) _ =
+            mkContract SU.rmInv SU.noEpochChange noVoteOuts' SU.noVote
+              outqcs SU.qcPost
+          proj₂ (contract-step₂ ._ refl ._ refl) _ =
+            mkContract SU.rmInv SU.noEpochChange noVoteOuts' SU.noVote
+              outqcs SU.qcPost
     #+end_src
+    
+    ~contract-step₁'~ proceeds by inspecting the result returned by =syncUpM=.
+    Focusing on the success case (=Right unit=), the code continues on to
+    =step₂=, and the proof follows by defining =contract-step₂=. Note the
+    following local bindings and definitions.
 
-    Here, =Contract= is the contract we want to show. =Post= is the postcondition
-    we want for =syncUpM= --- which is the weakest precondition for =const
-    step₂= that gives us =Contract=.
+    - =st= and outs are resp. the post-state and outputs of executing =syncUpM=
+      with state =pre=
+    - =con= is the proof of the contract for =syncUpM=. To make accessing the
+      individual fields of =con= more convenient, we make a local module
+      definition =SU=.
 
+    - =SU.noVoteOuts= tells us there are not vote messages in =outs=, but our
+      obligation is to show there are no vote messages in =outs ++ []=.
+
+      Here we could prove =noVoteOuts'= by rewriting with =++-identiyʳ=. In
+      general, if we have two lists which have been proven to not contain a
+      certain type of message (e.g., a vote), then you can use the lemma
+      =++-NoneOfKind= in [[file:../LibraBFT/Impl/Properties/Util.agda]]. For
+      readability, several instances of this lemma (such as =++-NoVotes=) are
+      also defined.
+
+    - Similarly, =SU.outQcs∈RM= tells us that all quorum certificates appearing
+      in =outs= come from the round manager =st=, but our obligation is to show
+      that this property holds for =outs ++ []=. The lemma
+      =QCProps.++-OutputQc∈RoundManager= lets us conclude that if this property
+      holds for two lists, then it holds for their concatenation.
+    
+
+    Finally, in =contract-step₂=, the first =._ refl= pair corresponds to the
+    =Unit= returned =syncUpM=, and the second pair corresponds to the variable
+    =currentRound'= in the peer handler code. When we reach the conditional, we
+    prove the two obligations the weakest precondition infrastructure generates
+    for us --- which finishes the proof.
     
 *** Using =abstract= blocks
 

--- a/docs/PeerHandlerContracts.org
+++ b/docs/PeerHandlerContracts.org
@@ -211,7 +211,6 @@ RWST-⇒
     #+end_src
     
 ** Peer handler proofs
-   
 *** Breaking the peer handler down into smaller "steps"
 
     When beginning to prove a contract for a peer handler, it is often
@@ -457,54 +456,126 @@ abstract
 
     The defintion of =processProposalMsgM.step₀= /is/ visible in other contexts,
     so =processProposalMsgM≡= is used by the proof of the contract for
-    =processProposalMsgM= to transfer a property about
-    =processProposalMsgM.step₀= to =processProposalMsgM=.
+    =processProposalMsgM= (see
+    [[file:../LibraBFT/Impl/Consensus/RoundManager/Properties.agda]]) to transfer a
+    property about =processProposalMsgM.step₀= to =processProposalMsgM=.
+
+    #+begin_src agda
+    contract' : LBFT-weakestPre (processProposalMsgM now pm) Contract pre
+    contract' rewrite processProposalMsgM≡ = contract
+      where
+      contract : LBFT-weakestPre step₀ Contract pre
+    #+end_src
+
+    Note that after the rewrite, the expected type for the right-hand side of
+    =contract'= is not =LBFT-weakestPre step₀ Contract pre= but unrolls the
+    full definition of =step₀=. This is a quirk of how =rewrite= (and =with= in
+    general) behaves in Agda.
 
     At the time of writing, there is no set discipline for when to use
     =abstract= blocks. Conceivably, they could be used for *every* function,
     since this would greatly improve the readability of the proof state for any
-    peer handler contract proof.
+    peer handler contract proof. This is especially in the instances where
+    =with= or =rewrite= are used, which irrevocably normalize the proof state in
+    an attempt to abstract over the given expression in both the goal type and
+    the type of (non-parameter) variables in context.
+    
 
+* Peer handler code
+** Type classes for branching operations
+
+   Peer handler code written in both the =LBFT= and =Either ErrLog= monads use
+   branching operations on booleans, =Maybe='s, and =Either='s. To take
+   advantage of the weakest precondition machinery, we want to use the
+   constructors for the datatype (=RWST= or =EitherD=). However, for
+   readability it is desirable to use the same name for the operation that
+   performs e.g. case analysis on a boolean value.
+
+   To that end, [[file:../LibraBFT/ImplShared/Util/Dijkstra/Syntax.agda]] defines
+   three Agda "typeclasses" --- =MonadIfD=, =MonadMaybeD=, and =MonadEitherD=.
+   Of these, =MonadEitherD= deserves some elaboration.
     
 *** =EitherLike=
 
-    To take advantage of the weakest precondition infrastructure, peer handler
-    code written in the =Either ErrLog= monad in Haskell is (or will be) written
-    in the =EitherD ErrLog= monad. To facilitate writing code to operate on both
-    =Either= or =EitherD=, ~LibraBFT.Prelude~ defines a typeclass =EitherLike=.
+   Peer handler code written in the =Either ErrLog= monad in Haskell is (or
+   will be) written in the =EitherD ErrLog= monad. To facilitate writing code
+   to operate on both =Either= or =EitherD=, ~LibraBFT.Prelude~ defines a
+   typeclass =EitherLike=.
 
-    #+begin_src agda
-  -- Utility to make passing between `Either` and `EitherD` more convenient
-  record EitherLike {ℓ₁ ℓ₂ ℓ₃} (E : Set ℓ₁ → Set ℓ₂ → Set ℓ₃) : Set (ℓ+1 (ℓ₁ ℓ⊔ ℓ₂ ℓ⊔ ℓ₃)) where
-    field
-      fromEither : ∀ {A : Set ℓ₁} {B : Set ℓ₂} → Either A B → E A B
-      toEither   : ∀ {A : Set ℓ₁} {B : Set ℓ₂} → E A B → Either A B
-  open EitherLike ⦃ ... ⦄ public
-    #+end_src
+   #+begin_src agda
+ -- Utility to make passing between `Either` and `EitherD` more convenient
+ record EitherLike {ℓ₁ ℓ₂ ℓ₃} (E : Set ℓ₁ → Set ℓ₂ → Set ℓ₃) : Set (ℓ+1 (ℓ₁ ℓ⊔ ℓ₂ ℓ⊔ ℓ₃)) where
+   field
+     fromEither : ∀ {A : Set ℓ₁} {B : Set ℓ₂} → Either A B → E A B
+     toEither   : ∀ {A : Set ℓ₁} {B : Set ℓ₂} → E A B → Either A B
+ open EitherLike ⦃ ... ⦄ public
+   #+end_src
 
-    With this, operations for branching (such as =case⊎D_of_=) can be defined to
-    operate over anything that is =EitherLike=.
+   With this and =MonadEitherD=, we can define operations for branching over
+   anything that is =EitherLike=.
 
-    The one wrinkle in this story is the monadic bind operation. When writing
-    "m >>= f" in the =EitherD ErrLog= monad, =f= must return something of the form
-    =EitherD ErrLog B=, and similarly for the =Either ErrLog= monad.
+**** =MonadEitherD= and =eitherSD=
+#+begin_src agda
+record MonadEitherD {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
+  field
+    ⦃ monad ⦄ : Monad M
+    eitherSD : ∀ {E A B : Set ℓ₁} → Either E A → (E → M B) → (A → M B) → M B
 
-    At the time of writing, the recommendation for =EitherD= peer handler code
-    is:
-    - write the steps in =EitherD=
-      e.g., =executeAndInsertBlockE.step₀ : BlockStore → Block → EitherD ErrLog (BlockStore × Block)=
-    - use ~toEither~ to create a version of the function in =Either=, which will be used by =LBFT= peer handlers
-      e.g., =executeAndInsertBlockE bs block = toEither $ executeAndInsertBlockE.step₀ bs block=
+open MonadEitherD ⦃ ... ⦄ public hiding (eitherSD)
+#+end_src
 
-    - write a variant in =EitherD= again, to be used by other =EitherD=
-      handlers
+     The Agda typeclass =MonadEitherD= allows us to gives a single name for an
+     operation that acts the same as =eitherS= in the Haskell prototype.
+     When we open =MonadEitherD=, we hide =eitherSD= so that we can define a
+     version in which the first (non-implicit) argument is anything that is
+     =EitherLike=.
 
-      e.g. =executeAndInsertBlockE₀ bs block = fromEither $ executeAndInsertBlockE bs block=
+#+begin_src agda
+eitherSD
+  : ∀ {ℓ₁ ℓ₂ ℓ₃} {M : Set ℓ₁ → Set ℓ₂} ⦃ med : MonadEitherD M ⦄ →
+    ∀ {EL : Set ℓ₁ → Set ℓ₁ → Set ℓ₃} ⦃ _ : EitherLike EL ⦄ →
+    ∀ {E A B : Set ℓ₁} → EL E A → (E → M B) → (A → M B) → M B
+eitherSD ⦃ med = med ⦄ e f₁ f₂ = MonadEitherD.eitherSD med (toEither e) f₁ f₂
+#+end_src
+
+**** =EitherD= and monadic bind
+
+      A wrinkle in this story is the monadic bind operation. When writing "m >>=
+      f" in the =EitherD ErrLog= monad, =f= must return something of the form
+      =EitherD ErrLog B=, and similarly for the =Either ErrLog= monad.
+
+      At the time of writing, the recommended approach is to have different
+      variants for different contexts an error-throwing peer handler might be
+      used.
+      
+      - write the steps in =EitherD=
+        e.g.,
+        =insertQuorumCertE.step₀ : QuorumCert → BlockTree → EitherD ErrLog (BlockTree × List InfoLog)=
+      - use ~toEither~ to create a version of the function in =Either=, which
+        will be used by =LBFT= peer handlers e.g.,
+        =insertQuorumCertE qc bt0 = toEither $ insertQuorumCertE.step₀ qc bt0=
+
+        This runs the =EitherD= (for =EitherD=, =toEither= is implemented with
+        =EitherD-run=).
+
+      - write a variant in =EitherD= again, to be used by other =EitherD=
+        handlers
+
+        e.g. =insertQuorumCertE-D qc bt0 = fromEither $ insertQuorumCertE qc bt0=
 
 
-    Note that this third version is not the same as the first, even though it
-    has the same type signature. While =step₀= may have many uses of binds and
-    branching, =executeAndInsertBlockE₀= will only ever be an =EitherD-return=
-    or =EitherD-bail=. This has the side effect of reducing clutter in the proof
-    state for any contract of an =EitherD= handler that calls
-    =executeAndInsertBlockE₀=.
+      Note that this third version is not the same as the first, even though it
+      has the same type. While =step₀= may have many uses of binds and
+      branching, the closed normal form of =insertQuorumCertE-D= will only ever
+      be an =EitherD-return= or =EitherD-bail=.
+
+
+      Another alternative is to define special syntax for =EitherD ErrLog= peer
+      handlers that can bind variables from both =Either ErrLog= and =EitherD
+      ErrLog= operations. This would look like:
+
+      #+begin_src agda
+syntax EitherD-bindEitherLike m₁ (λ x → m₂) = x ←E m₁ ； m₂
+      #+end_src
+
+      This would replace =do=-notation for =EitherD ErrLog= peer handlers.


### PR DESCRIPTION
- example proof in `LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda`
- `LibraBFT/ImplShared/Util/` has been re-arranged so that common definitions for conditionals can be shared between `RWST` and `Error`

There are still some things that could be cleaned up, in particular the current need for `fromEither` -- we can discuss how to deal with this at a higher bandwidth.