### PR TITLE
functions needed by epoch change

### DIFF
--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
@@ -33,8 +33,10 @@ isGenesisBlock b = BlockData.isGenesisBlock (b ^∙ bBlockData)
 isNilBlock : Block → Bool
 isNilBlock b = BlockData.isNilBlock (b ^∙ bBlockData)
 
-postulate -- NOTE: This is not needed until epoch change is implements/supported.
-  makeGenesisBlockFromLedgerInfo : LedgerInfo → Block
+makeGenesisBlockFromLedgerInfo : LedgerInfo → Either ErrLog Block
+makeGenesisBlockFromLedgerInfo li = do
+  blockData <- BlockData.newGenesisFromLedgerInfo li
+  pure (Block∙new (hashBD blockData) blockData nothing)
 
 newProposalFromBlockDataAndSignature : BlockData → Signature → Block
 newProposalFromBlockDataAndSignature blockData signature =

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
@@ -38,6 +38,10 @@ makeGenesisBlockFromLedgerInfo li = do
   blockData <- BlockData.newGenesisFromLedgerInfo li
   pure (Block∙new (hashBD blockData) blockData nothing)
 
+newNil : Round → QuorumCert → Block
+newNil r qc = Block∙new (hashBD blockData) blockData nothing
+ where blockData = BlockData.newNil r qc
+
 newProposalFromBlockDataAndSignature : BlockData → Signature → Block
 newProposalFromBlockDataAndSignature blockData signature =
   Block∙new (hashBD blockData) blockData (just signature)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/BlockData.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/BlockData.agda
@@ -46,6 +46,14 @@ newGenesis {-timestamp-} qc = BlockData∙new
   qc
   Genesis
 
+newNil : Round → QuorumCert → BlockData
+newNil r qc = BlockData∙new
+  (qc ^∙ qcCertifiedBlock ∙ biEpoch)
+  r
+--(qc ^∙ qcCertifiedBlock ∙ biTimestamp)
+  qc
+  NilBlock
+
 newProposal : TX → Author → Round → {-Instant →-} QuorumCert → BlockData
 newProposal payload author round {-timestamp-} quorumCert = BlockData∙new
   (quorumCert ^∙ qcCertifiedBlock ∙ biEpoch) round {-timestamp-} quorumCert (Proposal payload author)

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/BlockData.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/BlockData.agda
@@ -4,13 +4,47 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import LibraBFT.Base.KVMap                 as Map
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
+import      LibraBFT.Impl.Crypto.Crypto.Hash    as Hash
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.BlockData where
+
+------------------------------------------------------------------------------
+
+newGenesis : {-Instant →-} QuorumCert → BlockData
+
+------------------------------------------------------------------------------
+
+newGenesisFromLedgerInfo : LedgerInfo → Either ErrLog BlockData
+newGenesisFromLedgerInfo li =
+  if not (li ^∙ liEndsEpoch)
+  then Left fakeErr -- ["BlockData", "newGenesisFromLedgerInfo", "liNextEpochState == Nothing"]
+  else
+    let ancestor          = BlockInfo∙new
+                              (li ^∙ liEpoch)
+                              {-Round-} 0
+                              Hash.valueZero
+                              (li ^∙ liTransactionAccumulatorHash)
+                              (li ^∙ liVersion)
+                            --(li ^∙ liTimestamp)
+                              nothing
+        genesisQuorumCert = QuorumCert∙new
+                              (VoteData∙new ancestor ancestor)
+                              (LedgerInfoWithSignatures∙new
+                               (LedgerInfo∙new ancestor Hash.valueZero) Map.empty)
+     in pure $ newGenesis {-(li ^∙ liTimestamp)-} genesisQuorumCert
+
+newGenesis {-timestamp-} qc = BlockData∙new
+  (qc ^∙ qcCertifiedBlock ∙ biEpoch + 1)
+  {-Round-} 0
+--timestamp
+  qc
+  Genesis
 
 newProposal : TX → Author → Round → {-Instant →-} QuorumCert → BlockData
 newProposal payload author round {-timestamp-} quorumCert = BlockData∙new

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
@@ -21,8 +21,21 @@ import      Data.String                                     as String
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert where
 
-postulate -- NOTE: not needed until epoch change is supported
-  certificateForGenesisFromLedgerInfo : LedgerInfo → HashValue → QuorumCert
+certificateForGenesisFromLedgerInfo : LedgerInfo → HashValue → QuorumCert
+certificateForGenesisFromLedgerInfo ledgerInfo genesisId =
+  let ancestor = BlockInfo∙new
+                 (ledgerInfo ^∙ liEpoch + 1)
+                 0
+                 genesisId
+                 (ledgerInfo ^∙ liTransactionAccumulatorHash)
+                 (ledgerInfo ^∙ liVersion)
+               --(ledgerInfo ^∙ liTimestamp)
+                 nothing
+      voteData = VoteData.new ancestor ancestor
+      li       = LedgerInfo∙new ancestor (hashVD voteData)
+   in QuorumCert∙new
+      voteData
+      (LedgerInfoWithSignatures∙new li Map.empty)
 
 verify : QuorumCert → ValidatorVerifier → Either ErrLog Unit
 verify self validator = do

--- a/LibraBFT/Impl/Consensus/EpochManagerTypes.agda
+++ b/LibraBFT/Impl/Consensus/EpochManagerTypes.agda
@@ -59,6 +59,16 @@ unquoteDecl ecpLedgerInfoWithSigs   ecpMore = mkLens (quote EpochChangeProof)
            (ecpLedgerInfoWithSigs ∷ ecpMore ∷ [])
 -- instance S.Serialize EpochChangeProof
 
+record ConsensusState : Set where
+  constructor ConsensusState∙new
+  field
+    _csSafetyData     : SafetyData
+    _csWaypoint       : Waypoint
+    _csInValidatorSet : Bool
+open ConsensusState public
+unquoteDecl csSafetyData   csWaypoint   csInValidatorSet = mkLens (quote ConsensusState)
+           (csSafetyData ∷ csWaypoint ∷ csInValidatorSet ∷ [])
+
 data SafetyRulesWrapper : Set where
   SRWLocal : SafetyRules → SafetyRulesWrapper
 

--- a/LibraBFT/Impl/Consensus/EpochManagerTypes.agda
+++ b/LibraBFT/Impl/Consensus/EpochManagerTypes.agda
@@ -64,10 +64,10 @@ record ConsensusState : Set where
   field
     _csSafetyData     : SafetyData
     _csWaypoint       : Waypoint
-    _csInValidatorSet : Bool
+  --_csInValidatorSet : Bool -- LBFT-OBM-DIFF: only used in tests in Rust
 open ConsensusState public
-unquoteDecl csSafetyData   csWaypoint   csInValidatorSet = mkLens (quote ConsensusState)
-           (csSafetyData ∷ csWaypoint ∷ csInValidatorSet ∷ [])
+unquoteDecl csSafetyData   csWaypoint   {-csInValidatorSet-} = mkLens (quote ConsensusState)
+           (csSafetyData ∷ csWaypoint {-∷ csInValidatorSet-} ∷ [])
 
 data SafetyRulesWrapper : Set where
   SRWLocal : SafetyRules → SafetyRulesWrapper

--- a/LibraBFT/Impl/Consensus/LedgerRecoveryData.agda
+++ b/LibraBFT/Impl/Consensus/LedgerRecoveryData.agda
@@ -26,15 +26,15 @@ postulate -- TODO-2: Implement
 findRoot : List Block → List QuorumCert → LedgerRecoveryData
          → Either ErrLog (RootInfo × List Block × List QuorumCert)
 findRoot blocks0 quorumCerts0 (LedgerRecoveryData∙new storageLedger) = do
-  let (rootId , (blocks1 , quorumCerts)) =
+  (rootId , (blocks1 , quorumCerts)) ←
         if storageLedger ^∙ liEndsEpoch
-        then
-          (let genesis   = Block.makeGenesisBlockFromLedgerInfo storageLedger
-               genesisQC = QuorumCert.certificateForGenesisFromLedgerInfo storageLedger (genesis ^∙ bId)
-           in (genesis ^∙ bId , (genesis ∷ blocks0 , genesisQC ∷ quorumCerts0)))
+        then (do
+          genesis       ← Block.makeGenesisBlockFromLedgerInfo storageLedger
+          let genesisQC = QuorumCert.certificateForGenesisFromLedgerInfo storageLedger (genesis ^∙ bId)
+          pure (genesis ^∙ bId , (genesis ∷ blocks0 , genesisQC ∷ quorumCerts0)))
         else
-           (storageLedger ^∙ liConsensusBlockId , (blocks0 , quorumCerts0))
-      sorter : Block → Block → Ordering
+          pure (storageLedger ^∙ liConsensusBlockId , (blocks0 , quorumCerts0))
+  let sorter : Block → Block → Ordering
       sorter = λ bl br → compareX (bl ^∙ bEpoch , bl ^∙ bRound) (br ^∙ bEpoch , br ^∙ bRound)
       sortedBlocks = sortBy sorter blocks1
   rootIdx          ← maybeS

--- a/LibraBFT/Impl/Consensus/LedgerRecoveryData.agda
+++ b/LibraBFT/Impl/Consensus/LedgerRecoveryData.agda
@@ -35,7 +35,7 @@ findRoot blocks0 quorumCerts0 (LedgerRecoveryData∙new storageLedger) = do
         else
           pure (storageLedger ^∙ liConsensusBlockId , (blocks0 , quorumCerts0))
   let sorter : Block → Block → Ordering
-      sorter = λ bl br → compareX (bl ^∙ bEpoch , bl ^∙ bRound) (br ^∙ bEpoch , br ^∙ bRound)
+      sorter bl br = compareX (bl ^∙ bEpoch , bl ^∙ bRound) (br ^∙ bEpoch , br ^∙ bRound)
       sortedBlocks = sortBy sorter blocks1
   rootIdx          ← maybeS
         (findIndex (λ x → x ^∙ bId == rootId) sortedBlocks)

--- a/LibraBFT/Impl/Consensus/Liveness/ProposalGenerator.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposalGenerator.agda
@@ -21,7 +21,7 @@ ensureHighestQuorumCertM : Round → LBFT (Either ErrLog QuorumCert)
 
 generateNilBlockM : Round → LBFT (Either ErrLog Block)
 generateNilBlockM round =
-  ensureHighestQuorumCertM round ∙?∙ (ok ∙ Block.newNil round)
+  ensureHighestQuorumCertM round ∙?∙ (ok ∘ Block.newNil round)
 
 generateProposalM : Instant → Round → LBFT (Either ErrLog BlockData)
 generateProposalM _now round = do

--- a/LibraBFT/Impl/Consensus/Liveness/ProposalGenerator.agda
+++ b/LibraBFT/Impl/Consensus/Liveness/ProposalGenerator.agda
@@ -6,8 +6,9 @@
 
 open import LibraBFT.Base.Encode                             as Encode
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.ConsensusTypes.BlockData as BlockData
-open import LibraBFT.Impl.Types.BlockInfo                    as BlockInfo
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Block     as Block
+import      LibraBFT.Impl.Consensus.ConsensusTypes.BlockData as BlockData
+import      LibraBFT.Impl.Types.BlockInfo                    as BlockInfo
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util
@@ -18,8 +19,9 @@ module LibraBFT.Impl.Consensus.Liveness.ProposalGenerator where
 
 ensureHighestQuorumCertM : Round → LBFT (Either ErrLog QuorumCert)
 
-postulate -- TODO-1: Implement
-  generateNilBlockM : Round → LBFT (Either ErrLog Block)
+generateNilBlockM : Round → LBFT (Either ErrLog Block)
+generateNilBlockM round =
+  ensureHighestQuorumCertM round ∙?∙ (ok ∙ Block.newNil round)
 
 generateProposalM : Instant → Round → LBFT (Either ErrLog BlockData)
 generateProposalM _now round = do

--- a/LibraBFT/Impl/Consensus/MetricsSafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/MetricsSafetyRules.agda
@@ -5,7 +5,9 @@
 -}
 
 open import LibraBFT.Base.Types
-import      LibraBFT.Impl.Consensus.TestUtils.MockStorage as MockStorage
+open import LibraBFT.Impl.Consensus.EpochManagerTypes
+import      LibraBFT.Impl.Consensus.SafetyRules.SafetyRules as SafetyRules
+import      LibraBFT.Impl.Consensus.TestUtils.MockStorage   as MockStorage
 open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
@@ -17,5 +19,10 @@ import      Data.String                                   as String
 
 module LibraBFT.Impl.Consensus.MetricsSafetyRules where
 
-postulate
-  performInitialize : SafetyRules → PersistentLivenessStorage → Either ErrLog SafetyRules
+performInitialize : SafetyRules → PersistentLivenessStorage → Either ErrLog SafetyRules
+performInitialize self obmPersistentLivenessStorage = do
+  let consensusState = SafetyRules.consensusState self
+      srWaypoint     = consensusState ^∙ csWaypoint
+  proofs            <- MockStorage.retrieveEpochChangeProofE
+                         (srWaypoint ^∙ wVersion) obmPersistentLivenessStorage
+  SafetyRules.initialize self proofs

--- a/LibraBFT/Impl/Consensus/SafetyRules/PersistentSafetyStorage.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/PersistentSafetyStorage.agda
@@ -6,25 +6,13 @@
 
 ------------------------------------------------------------------------------
 open import LibraBFT.Base.PKCS
-open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
-import      LibraBFT.Impl.Consensus.ConsensusTypes.Block      as Block
-import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert as QuorumCert
-import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote       as Vote
-import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData   as VoteData
-import      LibraBFT.Impl.OBM.Crypto                          as Crypto
+import      LibraBFT.Impl.OBM.Crypto            as TODO
 open import LibraBFT.Impl.OBM.Logging.Logging
-open import LibraBFT.Impl.Types.BlockInfo                     as BlockInfo
-open import LibraBFT.Impl.Types.ValidatorSigner               as ValidatorSigner
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
-import      LibraBFT.ImplShared.Util.Crypto                   as Crypto
-open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                       as String
+import      Data.String                         as String
 ------------------------------------------------------------------------------
 
 module LibraBFT.Impl.Consensus.SafetyRules.PersistentSafetyStorage where
@@ -39,3 +27,14 @@ new author waypoint sk = mkPersistentSafetyStorage
      {-, _pssAuthor    =-} author
      {-, _pssWaypoint  =-} waypoint
      {-, _pssObmSK     =-} (just sk)
+
+consensusKeyForVersion : PersistentSafetyStorage → PK → Either ErrLog SK
+consensusKeyForVersion self pk =
+  -- LBFT-OBM-DIFF
+  maybeS (self ^∙ pssObmSK) (Left fakeErr {-"pssObmSK Nothing"-}) $ λ sk →
+    if TODO.makePK sk /= pk
+    then Left fakeErr -- ["sk /= pk"]
+    else pure sk
+ where
+  here' : List String.String → List String.String
+  here' t = "PersistentSafetyStorage" ∷ "consensusKeyForVersion" ∷ t

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -155,11 +155,12 @@ consensusState : SafetyRules → ConsensusState
 consensusState self =
   ConsensusState∙new (self ^∙ srPersistentStorage ∙ pssSafetyData)
                      (self ^∙ srPersistentStorage ∙ pssWaypoint)
-                     true -- TODO
 
 ------------------------------------------------------------------------------
 
 -- ** NOTE: PAY PARTICULAR ATTENTION TO THIS FUNCTION **
+-- ** Because : it is long with lots of branches, so easy to transcribe wrong. **
+-- ** And if initialization is wrong, everything is wrong. **
 initialize : SafetyRules → EpochChangeProof → Either ErrLog SafetyRules
 initialize self proof = do
   let waypoint   = self ^∙ srPersistentStorage ∙ pssWaypoint
@@ -180,10 +181,10 @@ initialize self proof = do
                 epochState)
     else continue1 self epochState
  where
-  here'     : List String.String → List String.String
   continue2 : SafetyRules → EpochState → Either ErrLog SafetyRules
-  continue1 : SafetyRules → EpochState → Either ErrLog SafetyRules
+  here'     : List String.String → List String.String
 
+  continue1 : SafetyRules → EpochState → Either ErrLog SafetyRules
   continue1 self1 epochState =
     continue2 (self1 & srEpochState ?~ epochState) epochState
 
@@ -194,7 +195,7 @@ initialize self proof = do
       λ expectedKey → do
         let currKey = eitherS (signer self2)
                       (const nothing)
-                      (just ∘ ValidatorSigner.publicKey_ONLY_USE_AT_INIT)
+                      (just ∘ ValidatorSigner.publicKey_USE_ONLY_AT_INIT)
         grd‖ currKey == just expectedKey ≔
              Right self2
 

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -7,17 +7,23 @@
 ------------------------------------------------------------------------------
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
-import      LibraBFT.Impl.Consensus.ConsensusTypes.Block      as Block
-import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert as QuorumCert
-import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote       as Vote
-import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData   as VoteData
-import      LibraBFT.Impl.OBM.Crypto                          as Crypto
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Block                as Block
+import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert           as QuorumCert
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote                 as Vote
+import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData             as VoteData
+open import LibraBFT.Impl.Consensus.EpochManagerTypes
+import      LibraBFT.Impl.Consensus.SafetyRules.PersistentSafetyStorage as PersistentSafetyStorage
+import      LibraBFT.Impl.OBM.Crypto                                    as Crypto
 open import LibraBFT.Impl.OBM.Logging.Logging
-open import LibraBFT.Impl.Types.BlockInfo                     as BlockInfo
-open import LibraBFT.Impl.Types.ValidatorSigner               as ValidatorSigner
+import      LibraBFT.Impl.Types.BlockInfo                               as BlockInfo
+import      LibraBFT.Impl.Types.EpochChangeProof                        as EpochChangeProof
+import      LibraBFT.Impl.Types.ValidatorSigner                         as ValidatorSigner
+import      LibraBFT.Impl.Types.ValidatorVerifier                       as ValidatorVerifier
+open import LibraBFT.Impl.Types.Verifier
+import      LibraBFT.Impl.Types.Waypoint                                as Waypoint
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
-import      LibraBFT.ImplShared.Util.Crypto                   as Crypto
+import      LibraBFT.ImplShared.Util.Crypto                             as Crypto
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
@@ -145,6 +151,65 @@ verifyQcM qc = do
 
 ------------------------------------------------------------------------------
 
+consensusState : SafetyRules → ConsensusState
+consensusState self =
+  ConsensusState∙new (self ^∙ srPersistentStorage ∙ pssSafetyData)
+                     (self ^∙ srPersistentStorage ∙ pssWaypoint)
+                     true -- TODO
+
+------------------------------------------------------------------------------
+
+-- ** NOTE: PAY PARTICULAR ATTENTION TO THIS FUNCTION **
+initialize : SafetyRules → EpochChangeProof → Either ErrLog SafetyRules
+initialize self proof = do
+  let waypoint   = self ^∙ srPersistentStorage ∙ pssWaypoint
+  lastLi         ← withErrCtx' (here' ("EpochChangeProof.verify" ∷ []))
+                               (        EpochChangeProof.verify proof waypoint)
+  let ledgerInfo = lastLi ^∙ liwsLedgerInfo
+  epochState     ← maybeS (ledgerInfo ^∙ liNextEpochState)
+                          (Left fakeErr) -- ["last ledger info has no epoch state"]
+                          pure
+  let currentEpoch = self ^∙ srPersistentStorage ∙ pssSafetyData ∙ sdEpoch
+  if-dec currentEpoch <? epochState ^∙ esEpoch
+    then (do
+      waypoint'  ← withErrCtx' (here' ("Waypoint.newEpochBoundary" ∷ []))
+                               (        Waypoint.newEpochBoundary ledgerInfo)
+      continue1 (self & srPersistentStorage ∙ pssWaypoint    ∙~ waypoint'
+                      & srPersistentStorage ∙ pssSafetyData  ∙~
+                          SafetyData∙new (epochState ^∙ esEpoch) {-Round-} 0 {-Round-} 0 nothing)
+                epochState)
+    else continue1 self epochState
+ where
+  here'     : List String.String → List String.String
+  continue2 : SafetyRules → EpochState → Either ErrLog SafetyRules
+  continue1 : SafetyRules → EpochState → Either ErrLog SafetyRules
+
+  continue1 self1 epochState =
+    continue2 (self1 & srEpochState ?~ epochState) epochState
+
+  continue2 self2 epochState = do
+    let author = self2 ^∙ srPersistentStorage ∙ pssAuthor
+    maybeS (ValidatorVerifier.getPublicKey (epochState ^∙ esVerifier) author)
+      (Left fakeErr) -- ["ValidatorNotInSet", lsA author] $
+      λ expectedKey → do
+        let currKey = eitherS (signer self2)
+                      (const nothing)
+                      (just ∘ ValidatorSigner.publicKey_ONLY_USE_AT_INIT)
+        grd‖ currKey == just expectedKey ≔
+             Right self2
+
+           ‖ self2 ^∙ srExportConsensusKey ≔ (do
+              consensusKey ← withErrCtx' (here' ("ValidatorKeyNotFound" ∷ []))
+                (PersistentSafetyStorage.consensusKeyForVersion
+                  (self2 ^∙ srPersistentStorage) expectedKey)
+              Right (self2 & srValidatorSigner ?~ ValidatorSigner∙new author consensusKey))
+
+           ‖ otherwise≔
+             Left fakeErr -- ["srExportConsensusKey", "False", "NOT IMPLEMENTED"]
+  here' t = "SafetyRules" ∷ "initialize" ∷ t
+
+------------------------------------------------------------------------------
+
 constructAndSignVoteM-continue0 : VoteProposal → ValidatorSigner                       → LBFT (Either ErrLog Vote)
 constructAndSignVoteM-continue1 : VoteProposal → ValidatorSigner →  Block → SafetyData → LBFT (Either ErrLog Vote)
 constructAndSignVoteM-continue2 : VoteProposal → ValidatorSigner →  Block → SafetyData → LBFT (Either ErrLog Vote)
@@ -234,7 +299,7 @@ constructAndSignVoteM-continue2 = constructAndSignVoteM-continue2.step₀
 signProposalM : BlockData → LBFT (Either ErrLog Block)
 signProposalM blockData = do
  vs ← use (lSafetyRules ∙ srValidatorSigner)
- maybeS vs (bail fakeErr) {-ErrL (here' ["srValidatorSigner", "Nothing"])-} $ λ validatorSigner -> do
+ maybeS vs (bail fakeErr) {-ErrL (here' ["srValidatorSigner", "Nothing"])-} $ λ validatorSigner → do
   safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
   verifyAuthorM (blockData ^∙ bdAuthor) ∙?∙ λ _ →
     verifyEpochM (blockData ^∙ bdEpoch) safetyData ∙?∙ λ _ →
@@ -245,7 +310,7 @@ signProposalM blockData = do
       --                    , lsR (blockData ^∙ bdRound), lsR (safetyData ^∙ sdLastVotedRound) ])-}
       else do
         verifyQcM (blockData ^∙ bdQuorumCert) ∙?∙ λ _ →
-          verifyAndUpdatePreferredRoundM (blockData ^∙ bdQuorumCert) safetyData ∙?∙ λ safetyData1 -> do
+          verifyAndUpdatePreferredRoundM (blockData ^∙ bdQuorumCert) safetyData ∙?∙ λ safetyData1 → do
             pssSafetyData-rm ∙= safetyData1
             let signature  = ValidatorSigner.sign validatorSigner blockData
             ok (Block.newProposalFromBlockDataAndSignature blockData signature)
@@ -260,19 +325,19 @@ signTimeoutM timeout = do
  vs ← use (lSafetyRules ∙ srValidatorSigner)
  maybeS vs (bail fakeErr) {-"srValidatorSigner", "Nothing"-} $ λ validatorSigner → do
    safetyData ← use (lPersistentSafetyStorage ∙ pssSafetyData)
-   verifyEpochM (timeout ^∙ toEpoch) safetyData ∙^∙ withErrCtx (here' []) ∙?∙ λ _ -> do
+   verifyEpochM (timeout ^∙ toEpoch) safetyData ∙^∙ withErrCtx (here' []) ∙?∙ λ _ → do
      ifD‖ timeout ^∙ toRound ≤? safetyData ^∙ sdPreferredRound ≔
           bail fakeErr
-          --(ErrIncorrectPreferredRound (here []) (timeout^.toRound) (safetyData^.sdPreferredRound))
+          --(ErrIncorrectPreferredRound (here []) (timeout ^∙ toRound) (safetyData ^∙ sdPreferredRound))
         ‖ timeout ^∙ toRound <? safetyData ^∙ sdLastVotedRound ≔
           bail fakeErr
-          --(ErrIncorrectLastVotedRound (here []) (timeout^.toRound) (safetyData^.sdLastVotedRound))
+          --(ErrIncorrectLastVotedRound (here []) (timeout ^∙ toRound) (safetyData ^∙ sdLastVotedRound))
         ‖ timeout ^∙ toRound >? safetyData ^∙ sdLastVotedRound ≔
           verifyAndUpdateLastVoteRoundM (timeout ^∙ toRound) safetyData
             ∙^∙ withErrCtx (here' [])
             ∙?∙ (λ safetyData1 → do
             pssSafetyData-rm ∙= safetyData1
-            logInfo fakeInfo -- (InfoUpdateLastVotedRound (timeout^.toRound))
+            logInfo fakeInfo -- (InfoUpdateLastVotedRound (timeout ^∙ toRound))
             continue validatorSigner)
 
         ‖ otherwise≔

--- a/LibraBFT/Impl/Consensus/TestUtils/MockStorage.agda
+++ b/LibraBFT/Impl/Consensus/TestUtils/MockStorage.agda
@@ -75,3 +75,10 @@ saveHighestTimeoutCertificateM
 saveHighestTimeoutCertificateM tc db = do
   logInfo fakeInfo -- ["MockStorage", "saveHighestTimeoutCertificateM", lsTC tc]
   ok (db & msSharedStorage ∙ mssHighestTimeoutCertificate ?~ tc)
+
+retrieveEpochChangeProofE
+  : Version → MockStorage
+  → Either ErrLog EpochChangeProof
+retrieveEpochChangeProofE v db = case Map.lookup v (db ^∙ msSharedStorage ∙ mssLis) of λ where
+  nothing    → Left fakeErr -- ["MockStorage", "retrieveEpochChangeProofE", "not found", show v])
+  (just lis) → pure (EpochChangeProof∙new (lis ∷ []) false)

--- a/LibraBFT/Impl/Crypto/Crypto/Hash.agda
+++ b/LibraBFT/Impl/Crypto/Crypto/Hash.agda
@@ -1,0 +1,16 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.Crypto.Crypto.Hash where
+
+postulate
+  valueZero : HashValue

--- a/LibraBFT/Impl/OBM/Crypto.agda
+++ b/LibraBFT/Impl/OBM/Crypto.agda
@@ -11,8 +11,19 @@ open import LibraBFT.Prelude
 
 module LibraBFT.Impl.OBM.Crypto where
 
+------------------------------------------------------------------------------
+-- keys
+
+postulate
+  makePK : SK → PK
+
+------------------------------------------------------------------------------
+
 postulate -- TODO-1: implement it
   obmHashVersion : Version → HashValue
+
+------------------------------------------------------------------------------
+-- sign and verify
 
 record CryptoHash (A : Set) : Set where
   field

--- a/LibraBFT/Impl/Types/ValidatorSigner.agda
+++ b/LibraBFT/Impl/Types/ValidatorSigner.agda
@@ -13,3 +13,6 @@ module LibraBFT.Impl.Types.ValidatorSigner where
 
 sign : {C : Set} ⦃ enc : Encoder C ⦄ → ValidatorSigner → C → Signature
 sign (ValidatorSigner∙new _ sk) c = PKCS.sign-encodable c sk
+
+postulate
+  publicKey_ONLY_USE_AT_INIT : ValidatorSigner → PK

--- a/LibraBFT/Impl/Types/ValidatorSigner.agda
+++ b/LibraBFT/Impl/Types/ValidatorSigner.agda
@@ -15,4 +15,4 @@ sign : {C : Set} ⦃ enc : Encoder C ⦄ → ValidatorSigner → C → Signature
 sign (ValidatorSigner∙new _ sk) c = PKCS.sign-encodable c sk
 
 postulate
-  publicKey_ONLY_USE_AT_INIT : ValidatorSigner → PK
+  publicKey_USE_ONLY_AT_INIT : ValidatorSigner → PK

--- a/LibraBFT/Impl/Types/Waypoint.agda
+++ b/LibraBFT/Impl/Types/Waypoint.agda
@@ -1,0 +1,13 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.Prelude
+
+module LibraBFT.Impl.Types.Waypoint where
+
+postulate
+  newEpochBoundary : LedgerInfo → Either ErrLog Waypoint

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -125,8 +125,8 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
       --, _biTimestamp       :: Instant
       _biNextEpochState  : Maybe EpochState
   open BlockInfo public
-  unquoteDecl biEpoch   biRound   biId   biExecutedState   biVersion   biNextEpochState = mkLens (quote BlockInfo)
-             (biEpoch ∷ biRound ∷ biId ∷ biExecutedState ∷ biVersion ∷ biNextEpochState ∷ [])
+  unquoteDecl biEpoch   biRound   biId   biExecutedStateId   biVersion   biNextEpochState = mkLens (quote BlockInfo)
+             (biEpoch ∷ biRound ∷ biId ∷ biExecutedStateId ∷ biVersion ∷ biNextEpochState ∷ [])
   postulate instance enc-BlockInfo : Encoder BlockInfo
 
   postulate
@@ -176,8 +176,16 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   postulate instance ws-LedgerInfo  : WithSig LedgerInfo
 
   -- GETTER only in Haskell
+  liEpoch : Lens LedgerInfo Epoch
+  liEpoch = liCommitInfo ∙ biEpoch
+
+  -- GETTER only in Haskell
   liConsensusBlockId : Lens LedgerInfo HashValue
   liConsensusBlockId = liCommitInfo ∙ biId
+
+  -- GETTER only in Haskell
+  liTransactionAccumulatorHash : Lens LedgerInfo HashValue
+  liTransactionAccumulatorHash = liCommitInfo ∙ biExecutedStateId
 
   -- GETTER only in Haskell
   liVersion : Lens LedgerInfo Version

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -49,6 +49,13 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   Instant : Set
   Instant = ℕ   -- TODO-2: should eventually be a time stamp
 
+  -- TODO-2
+  postulate
+    _≟-PK_ : (pk1 pk2 : PK) → Dec (pk1 ≡ pk2)
+  instance
+    Eq-PK : Eq PK
+    Eq._≟_ Eq-PK = _≟-PK_
+
   -- LBFT-OBM-DIFF: We do not have world state.  We just count the Epoch/Round as the version.
   record Version : Set where
     constructor Version∙new
@@ -815,6 +822,9 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     field
       _wVersion : Version
       _wValue   : HashValue
+  open Waypoint public
+  unquoteDecl wVersion   wValue = mkLens (quote Waypoint)
+             (wVersion ∷ wValue ∷ [])
   postulate instance enc-Waypoint : Encoder Waypoint
 
   record PersistentSafetyStorage : Set where

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -49,8 +49,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   Instant : Set
   Instant = ℕ   -- TODO-2: should eventually be a time stamp
 
-  -- TODO-2
-  postulate
+  postulate -- TODO-1: implement/prove PK equality
     _≟-PK_ : (pk1 pk2 : PK) → Dec (pk1 ≡ pk2)
   instance
     Eq-PK : Eq PK


### PR DESCRIPTION
I started this work by looking for postulated things used by epoch change.
Writing those postulates led to writing new functions and new postulates (to be handled in a future PR).

- Block
  - implemented makeGenesisBlockFromLedgerInfo, newNil
- BlockData
  - implemented newGenesis, newGenesisFromLedgerInfo, newNil
- QuorumCert
  - implemented certificateForGenesisFromLedgerInfo
- EpochManagerTypes
  - added record ConsensusState
- LedgerRecoveryData.agda
  - update to handle Either from Block.makeGenesisBlockFromLedgerInfo
- ProposalGenerator
  - implement generateNilBlockM
- MetricsSafetyRules
  - implement performInitialize
- PersistentSafetyStorage
  - implement consensusKeyForVersion
- SafetyRules
  - implement consensusState, initialize
- MockStorage
  - implement retrieveEpochChangeProofE
- LibraBFT/Impl/Crypto/Crypto/Hash.agda b/LibraBFT/Impl/Crypto/Crypto/Hash.agda
  - new file
- LibraBFT/Impl/OBM/Crypto.agda
  - postulate makePK : SK → PK
- ValidatorSigner
  - postulate publicKey_ONLY_USE_AT_INIT
- LibraBFT/Impl/Types/Waypoint.agda b/LibraBFT/Impl/Types/Waypoint.agda
  - new file
- EpochIndep
  - postulate _≟-PK_ (i.e., Eq PK)
  - added needed lens
