### PR TITLE
Start refining `insertBlockESpec`

### DIFF
--- a/LibraBFT/Base/KVMap.agda
+++ b/LibraBFT/Base/KVMap.agda
@@ -89,6 +89,11 @@ module LibraBFT.Base.KVMap  where
                   → (prf : lookup k kvm ≡ nothing)
                   → lookup k (kvm-insert k v kvm prf) ≡ just v
 
+   -- Haskell's insert updates the value even if the key is already in the map
+   lookup-correct-haskell
+                  : {kvm : KVMap Key Val}
+                  → lookup k (kvm-insert-Haskell k v kvm) ≡ just v
+
    lookup-correct-update
                   : {kvm : KVMap Key Val}
                   → (prf : lookup k kvm ≢ nothing)

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -197,9 +197,8 @@ module executeAndInsertBlockE (bs0 : BlockStore) (block : Block) where
       ifD btRound ≥?ℕ block ^∙ bRound
       then LeftD fakeErr -- block with old round
       else step₂ bsr
-      -- else step₂ bsr
 
-  step₂ bsr = do
+  step₂ _ = do
         eb ← case⊎D executeBlockE bs0 block of λ where
           (Right res) → RightD res
           -- OBM-LBFT-DIFF : This is never thrown in OBM.
@@ -236,7 +235,9 @@ module executeAndInsertBlockE (bs0 : BlockStore) (block : Block) where
 
 executeAndInsertBlockE = executeAndInsertBlockE.E
 
-executeBlockE bs block = do
+module executeBlockE (bs : BlockStore) (block : Block) where
+
+  step₀ = do
 -- TODO-3: hook up proper implementation (in comments below).  Requires addressing the issue that
 -- doing so breaks the existing proof of executeAndInsertBlockESpec.contract₂, which currently
 -- violates an abstraction boundary and looks into the implementation of this function, rather than
@@ -246,12 +247,15 @@ executeBlockE bs block = do
     (Right stateComputeResult) →
 -}
       pure (ExecutedBlock∙new block stateComputeResult)
- where
-  here' : List String → List String
-  here' t = "BlockStore" ∷ "executeBlockE" {-∷ lsB block-} ∷ t
+   where
+    here' : List String → List String
+    here' t = "BlockStore" ∷ "executeBlockE" {-∷ lsB block-} ∷ t
 
-executeBlockE₀ bs block = fromEither $ executeBlockE bs block
-
+abstract
+  executeBlockE = executeBlockE.step₀
+  executeBlockE₀ bs block = fromEither $ executeBlockE bs block
+  executeBlockE≡ : ∀ {bs block r} → executeBlockE bs block ≡ r → executeBlockE₀ bs block ≡ fromEither r
+  executeBlockE≡ refl = refl
 ------------------------------------------------------------------------------
 
 insertSingleQuorumCertM

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -238,15 +238,10 @@ executeAndInsertBlockE = executeAndInsertBlockE.E
 module executeBlockE (bs : BlockStore) (block : Block) where
 
   step₀ = do
--- TODO-3: hook up proper implementation (in comments below).  Requires addressing the issue that
--- doing so breaks the existing proof of executeAndInsertBlockESpec.contract₂, which currently
--- violates an abstraction boundary and looks into the implementation of this function, rather than
--- using its contract.
-{-  case SCBS.compute (bs ^∙ bsStateComputer) block (block ^∙ bParentId) of λ where
-    (Left e)                   → Left fakeErr -- (here' e)
-    (Right stateComputeResult) →
--}
-      pure (ExecutedBlock∙new block stateComputeResult)
+    case SCBS.compute (bs ^∙ bsStateComputer) block (block ^∙ bParentId) of λ where
+      (Left e)                   → Left fakeErr -- (here' e)
+      (Right stateComputeResult) →
+        pure (ExecutedBlock∙new block stateComputeResult)
    where
     here' : List String → List String
     here' t = "BlockStore" ∷ "executeBlockE" {-∷ lsB block-} ∷ t

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -91,8 +91,8 @@ module insertBlockE (block : ExecutedBlock)(bt : BlockTree) where
         nothing → LeftD fakeErr
         (just parentBlock) → (do
           parentBlock' ← addChild parentBlock blockId
-          let bt' = bt & btIdToBlock ∙~ Map.insert (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
-          pure (  (bt' & btIdToBlock ∙~ Map.insert blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
+          let bt' = bt & btIdToBlock ∙~ Map.kvm-insert-Haskell (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
+          pure (  (bt' & btIdToBlock ∙~ Map.kvm-insert-Haskell blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
                , block))
 
   E : VariantFor Either

--- a/LibraBFT/Impl/Consensus/EpochManager.agda
+++ b/LibraBFT/Impl/Consensus/EpochManager.agda
@@ -83,9 +83,9 @@ startRoundManager'
 ------------------------------------------------------------------------------
 
 new
-  : NodeConfig → {-StateComputer →-} PersistentLivenessStorage → Author → SK
+  : NodeConfig → StateComputer → PersistentLivenessStorage → Author → SK
   → Either ErrLog EpochManager
-new nodeConfig {-stateComputer-} persistentLivenessStorage obmAuthor obmSK = do
+new nodeConfig stateComputer persistentLivenessStorage obmAuthor obmSK = do
   let -- author = node_config.validator_network.as_ref().unwrap().peer_id();
       config = nodeConfig ^∙ ncConsensus
   safetyRulesManager ← SafetyRulesManager.new (config ^∙ ccSafetyRules) obmAuthor obmSK

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -206,7 +206,7 @@ module executeAndVoteMSpec (b : Block) where
 
     contract
       : ∀ Post
-        → (∀ r st outs → Contract r st outs → Post r st outs)
+        → RWS-Post-⇒ Contract Post
         → LBFT-weakestPre (executeAndVoteM b) Post pre
     contract Post pf =
       RWS-⇒ Contract Post pf (executeAndVoteM b) unit pre contract'

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -183,7 +183,7 @@ module executeAndVoteMSpec (b : Block) where
                 vgc₃ bid≡ =
                   Voting.glue-VoteNotGenerated-VoteGeneratedCorrect
                     (mkVoteNotGenerated refl refl)
-                    (Voting.substVoteGeneratedCorrect proposedBlock b (EAIBECon.ebBlock≈ bid≡) vrc)
+                    (Voting.substVoteGeneratedCorrect proposedBlock b EAIBECon.ebBlock≈ vrc)
 
                 noMsgOutsBail₃ : ∀ outs → NoMsgs outs → NoMsgs (CASVouts ++ outs)
                 noMsgOutsBail₃ outs noMsgs = ++-NoMsgs CASVouts outs CASVCon.noMsgOuts noMsgs

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -260,9 +260,15 @@ module Invariants where
   AllValidQCs : (𝓔 : EpochConfig) (bt : BlockTree) → Set
   AllValidQCs 𝓔 bt = (hash : HashValue) → maybe (WithEC.MetaIsValidQC 𝓔) ⊤ (lookup hash (bt ^∙ btIdToQuorumCert))
 
+  BlockHash-correct : Block → HashValue → Set
+  BlockHash-correct b bid = hashBD (b ^∙ bBlockData) ≡ bid
+
+
+  ExecutedBlockHash-correct : ExecutedBlock → HashValue → Set
+  ExecutedBlockHash-correct = BlockHash-correct ∘ (_^∙ ebBlock)
   ValidBlock : HashValue → ExecutedBlock → Set
   ValidBlock bid eb = eb ^∙ ebBlock ∙ bId ≡ bid
-                    × hashBD (eb ^∙ ebBlock ∙ bBlockData) ≡ bid
+                    × ExecutedBlockHash-correct eb bid
 
   AllValidBlocks : BlockTree → Set
   AllValidBlocks bt = ∀ {bid eb}

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -263,6 +263,11 @@ module Invariants where
   BlockHash-correct : Block → HashValue → Set
   BlockHash-correct b bid = hashBD (b ^∙ bBlockData) ≡ bid
 
+  postulate -- TODO-2: move somewhere sensible and prove
+    hash≡⇒≈Block : ∀ {b1 b2 : Block} {bid : HashValue}
+                   → BlockHash-correct b1 bid
+                   → BlockHash-correct b2 bid
+                   → b1 ≈Block b2
 
   ExecutedBlockHash-correct : ExecutedBlock → HashValue → Set
   ExecutedBlockHash-correct = BlockHash-correct ∘ (_^∙ ebBlock)

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -548,9 +548,14 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   bPayload : Lens Block (Maybe TX)
   bPayload = bBlockData ∙ bdPayload
 
+  bdQcSigs : Lens Block (KVMap Author Signature)
+  bdQcSigs = bBlockData ∙ bdQuorumCert ∙ qcLedgerInfo ∙ liwsSignatures
+
+  -- Equivalence of Blocks modulo signatures (both on the Block and in the QuorumCert it contains)
   infix 4 _≈Block_
   _≈Block_ : (b₁ b₂ : Block) → Set
-  b₁ ≈Block b₂ = b₁ ≡ record b₂ { _bSignature = _bSignature b₁ }
+  b₁ ≈Block b₂ = b₁ ≡ (b₂ & bSignature ∙~ (b₁ ^∙ bSignature)
+                          & bdQcSigs   ∙~ (b₁ ^∙ bdQcSigs))
 
   sym≈Block : Symmetric _≈Block_
   sym≈Block refl = refl

--- a/LibraBFT/ImplShared/Util/Crypto.agda
+++ b/LibraBFT/ImplShared/Util/Crypto.agda
@@ -58,9 +58,16 @@ module LibraBFT.ImplShared.Util.Crypto where
       bdInjBTGen  : bd1 ^∙ bdBlockType ≡ Genesis  → bd2 ^∙ bdBlockType ≡ Genesis
       bdInjBTProp : ∀ {tx}{auth} → bd1 ^∙ bdBlockType ≡ Proposal tx auth
                                  → bd1 ^∙ bdBlockType ≡ bd2 ^∙ bdBlockType
+  postulate
+    hashBD-bs  : BlockData → BitString
+
+  hashBD : BlockData → HashValue
+  hashBD = sha256 ∘ hashBD-bs
+
+  _hasSameHashInput-BD_ : BlockData → BlockData → Set
+  bd1 hasSameHashInput-BD bd2 = hashBD-bs bd1 ≡ hashBD-bs bd2
 
   postulate
-    hashBD     : BlockData → HashValue
     hashBD-inj : ∀ {bd1 bd2}
                → hashBD bd1 ≡ hashBD bd2
                → NonInjective-≡ sha256 ⊎ BlockDataInjectivityProps bd1 bd2

--- a/LibraBFT/ImplShared/Util/Dijkstra/EitherD.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/EitherD.agda
@@ -49,6 +49,9 @@ EitherD-Pre E A = Set
 EitherD-Post : (E A : Set) → Set₁
 EitherD-Post E A = Either E A → Set
 
+EitherD-Post-⇒ : ∀ {E A : Set} → (P Q : EitherD-Post E A) → Set
+EitherD-Post-⇒ P Q = ∀ r → P r → Q r
+
 EitherD-PredTrans : (E A : Set) → Set₁
 EitherD-PredTrans E A = EitherD-Post E A → EitherD-Pre E A
 
@@ -107,3 +110,11 @@ EitherD-contract (EitherD-maybe nothing f₁ f₂) P wp =
   EitherD-contract f₁ P (proj₁ wp refl)
 EitherD-contract (EitherD-maybe (just x) f₁ f₂) P wp =
   EitherD-contract (f₂ x) P (proj₂ wp x refl)
+
+postulate -- TODO-2: prove
+  EitherD-⇒
+    : (P Q : EitherD-Post E A)
+      → (EitherD-Post-⇒ P Q)
+      → ∀ m
+      → EitherD-weakestPre m P
+      → EitherD-weakestPre m Q

--- a/docs/PeerHandlerContracts.org
+++ b/docs/PeerHandlerContracts.org
@@ -473,12 +473,17 @@ abstract
     general) behaves in Agda.
 
     At the time of writing, there is no set discipline for when to use
-    =abstract= blocks. Conceivably, they could be used for *every* function,
-    since this would greatly improve the readability of the proof state for any
+    =abstract= blocks. Arguably, they should be used for *every* nontrivial function,
+    for several reasons.  First, it significantly improves the readability of the proof state for any
     peer handler contract proof. This is especially true in the instances where
     =with= or =rewrite= are used, which irrevocably normalize the proof state in
     an attempt to abstract over the given expression in both the goal type and
-    the type of (non-parameter) variables in context.
+    the type of (non-parameter) variables in context.  Second, it enforces
+    abstraction boundaries between functions, ensuring that changing the
+    implementation of a function doesn't change the shape of proofs of
+    functions that call it.  The overhead of this is that we must state and prove
+    explicit contracts for each function, but it is worth it for the sake of
+    sustainability.  For an example, see ~executeBlockESpec~ in 
 
 
 * Peer handler code


### PR DESCRIPTION
This is the first of two closely related PRs.  This one refines the contract for `insertBlockESpec`, providing it with `Requirements` that will be needed to prove its contract.  The [next one](#148) refactors that, so that each part of the contract is provided with only the prerequisite properties that its proof is expected to require.

This one also:
* reinstates the `stateComputerResult` that broke the proof in`executeAndInsertBlockE`, fixes that proof, and documents it in a little more detail for "tutorial" purposes; also updates the description in `PeerHandlerContracts.org` accordingly.
* Establishes some utility types for more clearly expressing requirements relating `Block`s and their ids.
* Refines the notion of two `Block`s being "equivalent" (`_≈Block_`), so that it does not require them to have the same `QC` signatures
* Adds initial machinery for ` EitherD-⇒` analogous to ` RWS-⇒` (not used yet)
* Various other small changes and fixes