### PR TITLE
Refactor `insertBlockESpec` requirements and start propagating them

### DIFF
--- a/LibraBFT/Impl/Consensus/Network/Properties.agda
+++ b/LibraBFT/Impl/Consensus/Network/Properties.agda
@@ -10,10 +10,13 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.NetworkMsg
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.Network
+open import LibraBFT.Impl.Properties.Util
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Consensus.Network.Properties where
+
+open Invariants
 
 module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : ValidatorVerifier) where
   postulate -- TODO-2: Refine contract
@@ -23,5 +26,5 @@ module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : Vali
       : case (processProposal proposal myEpoch vv) of λ where
           (Left _) → Unit
           (Right _) → proposal ^∙ pmProposal ∙ bEpoch ≡ myEpoch
-                      × hashBD (proposal ^∙ pmProposal ∙ bBlockData) ≡ proposal ^∙ pmProposal ∙ bId
+                      × BlockId-correct (proposal ^∙ pmProposal)
 

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -96,14 +96,14 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
           with processProposalSpec.contract pm myEpoch vv
         ...| con rewrite pp≡Right = sym (proj₁ con)
 
-        proposalId≡ : hashBD (pm ^∙ pmProposal ∙ bBlockData) ≡ pm ^∙ pmProposal ∙ bId
+        proposalId≡ : BlockId-correct (pm ^∙ pmProposal)
         proposalId≡
            with processProposalSpec.contract pm myEpoch vv
         ...| con rewrite pp≡Right = proj₂ con
 
         pf : RWS-Post-⇒ (PPM.Contract pre) Contract
         pf unit st outs con =
-          mkContract PPMSpec.rmInv PPMSpec.noEpochChange
+          mkContract (PPMSpec.rmInv proposalId≡) PPMSpec.noEpochChange
             vac PPMSpec.outQcs∈RM PPMSpec.qcPost
           where
           module PPMSpec = processProposalMsgMSpec.Contract con

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -269,8 +269,20 @@ module Invariants where
                    → BlockHash-correct b2 bid
                    → b1 ≈Block b2
 
+  module Reqs (b : Block) (bid : HashValue) (bt : BlockTree) where
+   ReqNewBlock = BlockHash-correct b bid
+   ReqPreBlock = ∀ {eb} → btGetBlock bid bt ≡ just eb → BlockHash-correct (eb ^∙ ebBlock) bid
+   -- TODO: State and use assumptions about hash collisions.  The following is one example that will
+   -- likely need to be refined.
+   NoHC1       = ∀ {eb}
+                 → btGetBlock bid bt ≡ just eb
+                   -- TODO-1: do we have a more succinct way to say this?
+                 → hashBD (b ^∙ bBlockData) ≡ hashBD (eb ^∙ ebBlock ∙ bBlockData)
+                 → b ≡L eb ^∙ ebBlock at bBlockData
+
   ExecutedBlockHash-correct : ExecutedBlock → HashValue → Set
   ExecutedBlockHash-correct = BlockHash-correct ∘ (_^∙ ebBlock)
+  
   ValidBlock : HashValue → ExecutedBlock → Set
   ValidBlock bid eb = eb ^∙ ebBlock ∙ bId ≡ bid
                     × ExecutedBlockHash-correct eb bid

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -263,6 +263,9 @@ module Invariants where
   BlockHash-correct : Block → HashValue → Set
   BlockHash-correct b bid = hashBD (b ^∙ bBlockData) ≡ bid
 
+  BlockId-correct : Block → Set
+  BlockId-correct b = BlockHash-correct b (b ^∙ bId)
+
   postulate -- TODO-2: move somewhere sensible and prove
     hash≡⇒≈Block : ∀ {b1 b2 : Block} {bid : HashValue}
                    → BlockHash-correct b1 bid


### PR DESCRIPTION
This builds on #147, refactoring the `Requirement`s provided to the proof for `insertBlockESpec.contract*` so that each component of the `Contract` receives only the `Requirement` its proof is expected to need.  These requirements are then propagated up.

There are requirements relating a `Block` to be inserted to its ID (specifically, a `Block`s ID should be the hash of its `BlockData`), and these have been propagated all the way up to `InputOutputHandler`, where the required check is made.  

Other requirements concern similar properties for `Block`s stored in the `BlockTree` and the beginning of propagating assumptions about hash collisions towards a context in which they can be tied to a specific reachable system state.  The latter two requirements have not yet been propagated all the way up to where they can be provided, and are postulated (via `obm-dangerous-magic'` for now).

This experiment makes me think this is the right way to go, but I am keeping two separate pull requests for comparison and discussion.  I propose to merge and squash this one, and forget the initial steps represented by #147.