### PR TITLE
types

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -5,12 +5,12 @@
 -}
 
 open import LibraBFT.Base.ByteString
-open import LibraBFT.Base.KVMap                                  as Map
+import      LibraBFT.Base.KVMap                                  as Map
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
-open import LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock as ExecutedBlock
-open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote          as Vote
+import      LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock as ExecutedBlock
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote          as Vote
 open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.Impl.OBM.Prelude
 open import LibraBFT.Impl.OBM.Rust.RustTypes
@@ -22,7 +22,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String as String
+open import Data.String                                          using (String)
 
 
 module LibraBFT.Impl.Consensus.BlockStorage.BlockTree where
@@ -123,7 +123,7 @@ module insertQuorumCertE (qc : QuorumCert) (bt0 : BlockTree) where
   step₃     : HashValue → ExecutedBlock → ExecutedBlock → VariantFor EitherD
   continue1 : BlockTree → HashValue → ExecutedBlock → List InfoLog → (BlockTree × List InfoLog)
   continue2 : BlockTree → List InfoLog → (BlockTree × List InfoLog)
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "BlockTree" ∷ "insertQuorumCert" ∷ t
 
   blockId = qc ^∙ qcCertifiedBlock ∙ biId

--- a/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/SyncManager.agda
@@ -5,19 +5,19 @@
 -}
 
 open import LibraBFT.Hash
-open import LibraBFT.Impl.Consensus.BlockStorage.BlockRetriever as BlockRetriever
-open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore     as BlockStore
-import      LibraBFT.Impl.Consensus.BlockStorage.BlockTree      as BlockTree
+import      LibraBFT.Impl.Consensus.BlockStorage.BlockRetriever     as BlockRetriever
+import      LibraBFT.Impl.Consensus.BlockStorage.BlockStore         as BlockStore
+import      LibraBFT.Impl.Consensus.BlockStorage.BlockTree          as BlockTree
 import      LibraBFT.Impl.OBM.ECP-LBFT-OBM-Diff.ECP-LBFT-OBM-Diff-1 as ECP-LBFT-OBM-Diff-1
-open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote         as Vote
-open import LibraBFT.Impl.Consensus.PersistentLivenessStorage   as PersistentLivenessStorage
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote             as Vote
+import      LibraBFT.Impl.Consensus.PersistentLivenessStorage       as PersistentLivenessStorage
 open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                       as String
+open import Data.String                                             using (String)
 
 module LibraBFT.Impl.Consensus.BlockStorage.SyncManager where
 
@@ -38,7 +38,7 @@ needSyncForQuorumCert qc bs = maybeS (bs ^∙ bsRoot) (Left fakeErr) {-bsRootErr
   (not (  BlockStore.blockExists (qc ^∙ qcCommitInfo ∙ biId) bs
         ∨ ⌊ btr ^∙ ebRound ≥?ℕ qc ^∙ qcCommitInfo ∙ biRound ⌋ ))
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "SyncManager" ∷ "needSyncForQuorumCert" ∷ t
 
 needFetchForQuorumCert : QuorumCert → BlockStore → Either ErrLog NeedFetchResult
@@ -52,7 +52,7 @@ needFetchForQuorumCert qc bs = maybeS (bs ^∙ bsRoot) (Left fakeErr) {-bsRootEr
     ‖ otherwise≔
       Right NeedFetch
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "SyncManager" ∷ "needFetchForQuorumCert" ∷ t
 
 ------------------------------------------------------------------------------
@@ -116,7 +116,7 @@ insertQuorumCertM = insertQuorumCertM.step₀
 
 loop1     : BlockRetriever → List Block → QuorumCert → LBFT (Either ErrLog (List Block))
 loop2     : List Block → LBFT (Either ErrLog Unit)
-hereFQCM' : List String.String → List String.String
+hereFQCM' : List String → List String
 
 fetchQuorumCertM qc retriever =
   loop1 retriever [] qc ∙?∙ loop2
@@ -172,7 +172,7 @@ syncToHighestCommitCertM highestCommitCert retriever = do
               pure unit
             ok unit
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "SyncManager" ∷ "syncToHighestCommitCertM" ∷ t
 
 ------------------------------------------------------------------------------
@@ -190,7 +190,7 @@ fastForwardSyncM highestCommitCert retriever = do
 
  where
 
-  here' : List String.String → List String.String
+  here' : List String → List String
 
   zipWithNatsFrom : {A : Set} → ℕ → List A → List (ℕ × A)
   zipWithNatsFrom n = λ where

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Block.agda
@@ -19,7 +19,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                       as String
+open import Data.String                                       using (String)
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.Block where
 
@@ -57,7 +57,7 @@ validateSignature self validator = case self ^∙ bBlockData ∙ bdBlockType of 
         (ValidatorVerifier.verify validator author (self ^∙ bBlockData) sig)
     QuorumCert.verify (self ^∙ bQuorumCert) validator
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "Block" ∷ "validateSignatures" {-∷ lsB self-} ∷ t
 
 verifyWellFormed : Block → Either ErrLog Unit
@@ -78,5 +78,5 @@ verifyWellFormed self = do
   lcheck (self ^∙ bId == hashBD (self ^∙ bBlockData))
          (here' ("Block id hash mismatch" ∷ []))
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "Block" ∷ "verifyWellFormed" {-∷ lsB self-} ∷ t

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/BlockRetrieval.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/BlockRetrieval.agda
@@ -21,7 +21,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                       as String
+open import Data.String                                       using (String)
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.BlockRetrieval where
 
@@ -34,7 +34,7 @@ verify self blockId numBlocks sigVerifier =
      ‖ otherwise≔
        verifyBlocks (self ^∙ brpBlocks)
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "BlockRetrieval" ∷ "verify" ∷ t
 
   verifyBlock : HashValue → Block → Either ErrLog HashValue

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/ProposalMsg.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/ProposalMsg.agda
@@ -15,7 +15,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                               as String
+open import Data.String                                               using (String)
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.ProposalMsg where
 
@@ -49,7 +49,7 @@ verifyWellFormed self = do
   lcheck (self ^∙ pmProposal ∙ bParentId == self ^∙ pmProposal ∙ bQuorumCert ∙ qcCertifiedBlock ∙ biId)
          (here' ("parent id /= qcCB" ∷ [])) -- show (self ^∙ pmProposal)
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "ProposalMsg" ∷ "verifyWellFormed" {-∷ lsPM self-} ∷ t
 
 

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/QuorumCert.agda
@@ -16,7 +16,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                     as String
+open import Data.String                                     using (String)
 
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert where
@@ -58,5 +58,5 @@ verify self validator = do
         (LedgerInfoWithSignatures.verifySignatures (self ^∙ qcLedgerInfo) validator)
       VoteData.verify (self ^∙ qcVoteData)
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "QuorumCert" ∷ "verify" {- ∷ lsQC self-} ∷ t

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/SyncInfo.agda
@@ -15,7 +15,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                         as String
+open import Data.String                                               using (String)
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.SyncInfo where
 
@@ -29,7 +29,7 @@ verifyM self validator = pure (verify self validator)
 
 module verify (self : SyncInfo) (validator : ValidatorVerifier) where
   step₀ step₁ step₂ step₃ step₄ step₅ step₆ : Either ErrLog Unit
-  here' : List String.String → List String.String
+  here' : List String → List String
 
   epoch = self ^∙ siHighestQuorumCert ∙ qcCertifiedBlock ∙ biEpoch
 

--- a/LibraBFT/Impl/Consensus/ConsensusTypes/Vote.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusTypes/Vote.agda
@@ -14,7 +14,7 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                         as String
+open import Data.String                                     using (String)
 
 module LibraBFT.Impl.Consensus.ConsensusTypes.Vote where
 
@@ -41,7 +41,7 @@ verify self validator = do
         (ValidatorVerifier.verify validator (self ^∙ vAuthor) (timeout self) tos)
   withErrCtx' (here' ("VoteData" ∷ [])) (VoteData.verify (self ^∙ vVoteData))
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "Vote" ∷ "verify" ∷ "failed" {-∷lsV self-} ∷ t
 
 addTimeoutSignature : Vote → Signature → Vote

--- a/LibraBFT/Impl/Consensus/EpochManager.agda
+++ b/LibraBFT/Impl/Consensus/EpochManager.agda
@@ -15,6 +15,7 @@ import      LibraBFT.Impl.Consensus.MetricsSafetyRules               as MetricsS
 import      LibraBFT.Impl.Consensus.RoundManager                     as RoundManager
 import      LibraBFT.Impl.Consensus.SafetyRules.SafetyRulesManager   as SafetyRulesManager
 import      LibraBFT.Impl.Consensus.TestUtils.MockStorage            as MockStorage
+open import LibraBFT.Impl.IO.OBM.Messages
 import      LibraBFT.Impl.OBM.ECP-LBFT-OBM-Diff.ECP-LBFT-OBM-Diff-1  as ECP-LBFT-OBM-Diff-1
 open import LibraBFT.Impl.OBM.Logging.Logging
 import      LibraBFT.Impl.OBM.Rust.Duration                          as Duration

--- a/LibraBFT/Impl/Consensus/EpochManager.agda
+++ b/LibraBFT/Impl/Consensus/EpochManager.agda
@@ -31,7 +31,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                              as String
+open import Data.String                                              using (String)
 
 module LibraBFT.Impl.Consensus.EpochManager where
 
@@ -140,7 +140,7 @@ processEpochRetrieval self {-wireOrInternal-} (EpRRqWire∙new {-why fromE fromR
           tell (PMInfo fakeInfo {-["Exit", "SendEpochRRp", why, lsA peerAddress, lsECP ecp]-} ∷ [])
           pure (PMSendECP ecp peerAddress me {-why-} e r)
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "EpochManager" ∷ "processEpochRetrieval" ∷ t
 
 processDifferentEpoch
@@ -175,7 +175,7 @@ processDifferentEpoch self obmI peerAddress peerDifferentEpoch obmPeerRound = do
           tell (PMErr fakeErr ∷ []) -- (here ["EQ should not happen"])
           pure PMContinue
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "EpochManager" ∷ "processDifferentEpoch" ∷ t
 {-
   why    = show (msgType obmI)               <> "/" <>
@@ -206,7 +206,7 @@ startNewEpoch self now mrlec proof = do
   pure PMContinue
   expectNewEpoch self' now rlec liws
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "EpochManager" ∷ "startNewEpoch" ∷ t
 
 startRoundManager
@@ -238,9 +238,9 @@ startRoundManager' self now recoveryData epochState0 obmNeedFetch obmProposalGen
     (Left  e) -> err ("BlockStore.new" ∷ []) e
     (Right r) -> continue1 lastVote r
  where
-  err : ∀ {B} → List String.String → ErrLog → Either ErrLog B
+  err : ∀ {B} → List String → ErrLog → Either ErrLog B
   err  t = withErrCtx' t ∘ Left
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "EpochManager" ∷ "startRoundManager" ∷ t
 
   continue2 : Maybe Vote → BlockStore → SafetyRules → Either ErrLog (EpochManager × List Output)
@@ -335,7 +335,7 @@ processMessage self now = λ where
  where
   doRlecEcp : Maybe ReconfigEventEpochChange → EpochChangeProof → EM ProcessMessageAction
 
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "EpochManager" ∷ "processMessage" ∷ t
 
   maybeDifferentEpoch : Input → AccountAddress → Epoch → Round → EM ProcessMessageAction
@@ -444,16 +444,16 @@ obmStartLoop self initializationOutput
       rm'                 ← pure rm -- TEMPORARY for previous line
       loop (setProcessor self rm') {-to'-} RSNothing
  where
-  show : ∀ {A : Set} → A → String.String
+  show : ∀ {A : Set} → A → String
   show _ = ""
 
-  singleShow : ∀ {A : Set} → A → List String.String
+  singleShow : ∀ {A : Set} → A → List String
   singleShow {A} x = show {A} x ∷ []
 
-  errorExit : List String.String → IO Unit
+  errorExit : List String → IO Unit
   errorExit _ = pure unit
 
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "EpochManager" ∷ "obmStartLoop" ∷ t
 
   setProcessor : EpochManager → RoundManager → EpochManager

--- a/LibraBFT/Impl/Consensus/EpochManagerTypes.agda
+++ b/LibraBFT/Impl/Consensus/EpochManagerTypes.agda
@@ -11,8 +11,6 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.Prelude
 open import Optics.All
-------------------------------------------------------------------------------
-import      Data.String                          as String
 
 module LibraBFT.Impl.Consensus.EpochManagerTypes where
 
@@ -72,37 +70,3 @@ emObmRoundManager = mkLens' g s
            nothing                           → Left fakeErr
   s : EpochManager → Either ErrLog RoundManager -> EpochManager
   s em _ = em
-
-------------------------------------------------------------------------------
--- from LBFT.IO.OBM.Messages
-
-record ECPWire : Set where
-  constructor ECPWire∙new
-  field
-    --_ecpwWhy    : Text           -- for log visualization
-    --_ecpwEpoch  : Epoch          -- for log visualization; epoch of sender
-    --_ecpwRound  : Round          -- for log visualization; round of sender
-    _ecpwECP      : EpochChangeProof
--- instance S.Serialize ECPWire
-
-record EpRRqWire : Set where
-  constructor EpRRqWire∙new
-  field
-    --_eprrqwWhy  : Text           -- for log visualization
-    --_eprrqEpoch : Epoch          -- for log visualization; epoch of sender
-    --_eprrqRound : Round          -- for log visualization; round of sender
-    _eprrqEpRRq   : EpochRetrievalRequest
--- instance S.Serialize EpRRqWire
-
-data Input : Set where
-  IBlockRetrievalRequest    : Instant                  →          BlockRetrievalRequest  → Input
-  IBlockRetrievalResponse   : Instant                  →          BlockRetrievalResponse → Input
-  IEpochChangeProof         :           AccountAddress →          ECPWire                → Input
-  IEpochRetrievalRequest    :           AccountAddress →          EpRRqWire              → Input
-  IInit                     : Instant                                                    → Input
-  IProposal                 : Instant → AccountAddress →          ProposalMsg            → Input
-  IReconfigLocalEpochChange :                                   ReconfigEventEpochChange → Input
-  ISyncInfo                 : Instant → AccountAddress →          SyncInfo               → Input
-  ITimeout                  : Instant → String.String {-String is ThreadId-} → Epoch → Round → Input
-  IVote                     : Instant → AccountAddress →          VoteMsg                → Input
-

--- a/LibraBFT/Impl/Consensus/EpochManagerTypes.agda
+++ b/LibraBFT/Impl/Consensus/EpochManagerTypes.agda
@@ -15,11 +15,8 @@ open import Optics.All
 module LibraBFT.Impl.Consensus.EpochManagerTypes where
 
 ------------------------------------------------------------------------------
-
--- TODO-1 : These types will eventually go into the existing types modules
-
-------------------------------------------------------------------------------
--- from LBFT.Consensus.Types
+-- in Haskell, this lives in LBFT.Consensus.Types
+-- It lives here because of the dependency on RoundManager.
 
 data RoundProcessor : Set where
   RoundProcessorRecovery : RecoveryManager → RoundProcessor

--- a/LibraBFT/Impl/Consensus/MetricsSafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/MetricsSafetyRules.agda
@@ -5,7 +5,6 @@
 -}
 
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 import      LibraBFT.Impl.Consensus.SafetyRules.SafetyRules as SafetyRules
 import      LibraBFT.Impl.Consensus.TestUtils.MockStorage   as MockStorage
 open import LibraBFT.Impl.OBM.Logging.Logging

--- a/LibraBFT/Impl/Consensus/MetricsSafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/MetricsSafetyRules.agda
@@ -7,14 +7,9 @@
 open import LibraBFT.Base.Types
 import      LibraBFT.Impl.Consensus.SafetyRules.SafetyRules as SafetyRules
 import      LibraBFT.Impl.Consensus.TestUtils.MockStorage   as MockStorage
-open import LibraBFT.Impl.OBM.Logging.Logging
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
-------------------------------------------------------------------------------
-import      Data.String                                   as String
 
 module LibraBFT.Impl.Consensus.MetricsSafetyRules where
 

--- a/LibraBFT/Impl/Consensus/Network.agda
+++ b/LibraBFT/Impl/Consensus/Network.agda
@@ -9,7 +9,7 @@ open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.NetworkMsg
 open import LibraBFT.ImplShared.Util.Util
-open import LibraBFT.Impl.Consensus.ConsensusTypes.ProposalMsg as ProposalMsg
+import      LibraBFT.Impl.Consensus.ConsensusTypes.ProposalMsg as ProposalMsg
 import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteMsg     as VoteMsg
 open import LibraBFT.Prelude
 open import Optics.All

--- a/LibraBFT/Impl/Consensus/PendingVotes.agda
+++ b/LibraBFT/Impl/Consensus/PendingVotes.agda
@@ -3,14 +3,14 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.KVMap                                       as Map
+import      LibraBFT.Base.KVMap                                       as Map
 open import LibraBFT.Hash
-open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote               as Vote
-open import LibraBFT.Impl.Consensus.ConsensusTypes.TimeoutCertificate as TimeoutCertificate
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote               as Vote
+import      LibraBFT.Impl.Consensus.ConsensusTypes.TimeoutCertificate as TimeoutCertificate
 open import LibraBFT.Impl.OBM.Rust.RustTypes
-open import LibraBFT.Impl.Types.CryptoProxies                         as CryptoProxies
-open import LibraBFT.Impl.Types.LedgerInfoWithSignatures              as LedgerInfoWithSignatures
-open import LibraBFT.Impl.Types.ValidatorVerifier                     as ValidatorVerifier
+import      LibraBFT.Impl.Types.CryptoProxies                         as CryptoProxies
+import      LibraBFT.Impl.Types.LedgerInfoWithSignatures              as LedgerInfoWithSignatures
+import      LibraBFT.Impl.Types.ValidatorVerifier                     as ValidatorVerifier
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Util

--- a/LibraBFT/Impl/Consensus/PendingVotesSpec.agda
+++ b/LibraBFT/Impl/Consensus/PendingVotesSpec.agda
@@ -3,16 +3,16 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.KVMap                                       as Map
+import      LibraBFT.Base.KVMap                                       as Map
 open import LibraBFT.Hash
-open import LibraBFT.Impl.Consensus.ConsensusTypes.TimeoutCertificate as TimeoutCertificate
-open import LibraBFT.Impl.Consensus.ConsensusTypes.Vote               as Vote
-open import LibraBFT.Impl.Consensus.PendingVotes                      as PendingVotes
-open import LibraBFT.Impl.Types.CryptoProxies                         as CryptoProxies
-open import LibraBFT.Impl.Types.LedgerInfoWithSignatures              as LedgerInfoWithSignatures
-open import LibraBFT.Impl.Types.ValidatorSigner                       as ValidatorSigner
-open import LibraBFT.Impl.Types.ValidatorVerifier                     as ValidatorVerifier
-open import LibraBFT.ImplFake.Handle                                  as Handle
+import      LibraBFT.Impl.Consensus.ConsensusTypes.TimeoutCertificate as TimeoutCertificate
+import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote               as Vote
+import      LibraBFT.Impl.Consensus.PendingVotes                      as PendingVotes
+import      LibraBFT.Impl.Types.CryptoProxies                         as CryptoProxies
+import      LibraBFT.Impl.Types.LedgerInfoWithSignatures              as LedgerInfoWithSignatures
+import      LibraBFT.Impl.Types.ValidatorSigner                       as ValidatorSigner
+import      LibraBFT.Impl.Types.ValidatorVerifier                     as ValidatorVerifier
+import      LibraBFT.ImplFake.Handle                                  as Handle
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Util

--- a/LibraBFT/Impl/Consensus/PersistentLivenessStorage.agda
+++ b/LibraBFT/Impl/Consensus/PersistentLivenessStorage.agda
@@ -13,7 +13,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                   as String
+open import Data.String                                   using (String)
 
 module LibraBFT.Impl.Consensus.PersistentLivenessStorage where
 
@@ -51,7 +51,7 @@ startM : LBFT (Either ErrLog RecoveryData)
 startM =
   use (lBlockStore ∙ bsStorage) >>= λ s → pure (MockStorage.start s) ∙^∙ withErrCtx (here' [])
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "PersistentLivenessStorage" ∷ "startM" ∷ t
 
 saveHighestTimeoutCertM : TimeoutCertificate → LBFT (Either ErrLog Unit)

--- a/LibraBFT/Impl/Consensus/RecoveryData.agda
+++ b/LibraBFT/Impl/Consensus/RecoveryData.agda
@@ -9,7 +9,7 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                as String
+open import Data.String                                using (String)
 
 module LibraBFT.Impl.Consensus.RecoveryData where
 
@@ -44,7 +44,7 @@ new lastVote storageLedger blocks0 rootMetadata quorumCerts0 highestTimeoutCerti
         (just tc) → if-dec tc ^∙ tcEpoch ≟ epoch then just tc else nothing
         nothing   → nothing)
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "RecoveryData" ∷ "new" ∷ t
 
 -- TODO (the "TODO" is in the Haskell code)

--- a/LibraBFT/Impl/Consensus/RoundManager.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager.agda
@@ -6,7 +6,7 @@
 
 ------------------------------------------------------------------------------
 open import LibraBFT.Base.ByteString
-open import LibraBFT.Base.KVMap                                  as Map
+import      LibraBFT.Base.KVMap                                  as Map
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
@@ -30,7 +30,7 @@ open import LibraBFT.Prelude
 open import Optics.All
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 -----------------------------------------------------------------------------
-import      Data.String                                          as String
+open import Data.String                                          using (String)
 ------------------------------------------------------------------------------
 
 module LibraBFT.Impl.Consensus.RoundManager where
@@ -64,7 +64,7 @@ processNewRoundEventM now nre@(NewRoundEvent∙new r _ _) = do
           (Left e)            → logErr (withErrCtx (here' ("Error generating proposal" ∷ [])) e)
           (Right proposalMsg) → act (BroadcastProposal proposalMsg rcvrs)
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "RoundManager" ∷ "processNewRoundEventM" ∷ t
 
 generateProposalM now newRoundEvent =
@@ -116,7 +116,7 @@ module syncUpM (now : Instant) (syncInfo : SyncInfo) (author : Author) (_helpRem
   step₁ step₂ : SyncInfo                     → LBFT (Either ErrLog Unit)
   step₃ step₄ : SyncInfo → ValidatorVerifier → LBFT (Either ErrLog Unit)
 
-  here' : List String.String → List String.String
+  here' : List String → List String
 
   step₀ = do
     -- logEE (here' []) $ do
@@ -192,7 +192,7 @@ processSyncInfoMsgM now syncInfo peer =
     (Left  e) → logErr (withErrCtx (here' []) e)
     (Right _) → pure unit
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "RoundManager" ∷ "processSyncInfoMsgM" ∷ {- lsA peer ∷ lsSI syncInfo ∷ -} t
 
 ------------------------------------------------------------------------------
@@ -203,7 +203,7 @@ processLocalTimeoutM now obmEpoch round = do
   -- logEE lTO (here []) $
   ifMD (RoundState.processLocalTimeoutM now obmEpoch round) continue1 (pure unit)
  where
-  here'     : List String.String → List String.String
+  here'     : List String → List String
   continue2 : LBFT Unit
   continue3 : (Bool × Vote) → LBFT Unit
   continue4 : Vote → LBFT Unit
@@ -453,5 +453,5 @@ start now lastVoteSent = do
       maybeSMP (pure lastVoteSent) unit RoundState.recordVoteM
       processNewRoundEventM now nre -- error!("[RoundManager] Error during start: {:?}", e);
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "RoundManager" ∷ "start" ∷ t

--- a/LibraBFT/Impl/Consensus/SafetyRules/PersistentSafetyStorage.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/PersistentSafetyStorage.agda
@@ -12,7 +12,7 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                         as String
+open import Data.String                         using (String)
 ------------------------------------------------------------------------------
 
 module LibraBFT.Impl.Consensus.SafetyRules.PersistentSafetyStorage where
@@ -36,5 +36,5 @@ consensusKeyForVersion self pk =
     then Left fakeErr -- ["sk /= pk"]
     else pure sk
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "PersistentSafetyStorage" ∷ "consensusKeyForVersion" ∷ t

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -27,7 +27,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                       as String
+open import Data.String                                                 using (String)
 ------------------------------------------------------------------------------
 
 module LibraBFT.Impl.Consensus.SafetyRules.SafetyRules where
@@ -120,7 +120,7 @@ verifyAuthorM author = do
         then bail fakeErr -- (ErrL (here' ["InvalidProposal", "Proposal author is not validator signer"]))
         else ok unit)
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "SafetyRules" ∷ "verifyAuthorM" ∷ t
 
 ------------------------------------------------------------------------------
@@ -181,7 +181,7 @@ initialize self proof = do
     else continue1 self epochState
  where
   continue2 : SafetyRules → EpochState → Either ErrLog SafetyRules
-  here'     : List String.String → List String.String
+  here'     : List String → List String
 
   continue1 : SafetyRules → EpochState → Either ErrLog SafetyRules
   continue1 self1 epochState =
@@ -315,7 +315,7 @@ signProposalM blockData = do
             let signature  = ValidatorSigner.sign validatorSigner blockData
             ok (Block.newProposalFromBlockDataAndSignature blockData signature)
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "SafetyRules" ∷ "signProposalM" ∷ t
 
 ------------------------------------------------------------------------------
@@ -348,5 +348,5 @@ signTimeoutM timeout = do
     let signature = ValidatorSigner.sign validatorSigner timeout
     ok signature
 
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "SafetyRules" ∷ "signTimeoutM" ∷ {-lsTO timeout ∷-}   t

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRules.agda
@@ -11,7 +11,6 @@ import      LibraBFT.Impl.Consensus.ConsensusTypes.Block                as Block
 import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert           as QuorumCert
 import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote                 as Vote
 import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData             as VoteData
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 import      LibraBFT.Impl.Consensus.SafetyRules.PersistentSafetyStorage as PersistentSafetyStorage
 import      LibraBFT.Impl.OBM.Crypto                                    as Crypto
 open import LibraBFT.Impl.OBM.Logging.Logging

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRulesManager.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRulesManager.agda
@@ -6,25 +6,11 @@
 
 ------------------------------------------------------------------------------
 open import LibraBFT.Base.PKCS
-open import LibraBFT.Base.Types
-import      LibraBFT.Impl.Consensus.ConsensusTypes.Block                as Block
-import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert           as QuorumCert
-import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote                 as Vote
-import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData             as VoteData
 import      LibraBFT.Impl.Consensus.SafetyRules.PersistentSafetyStorage as PersistentSafetyStorage
 import      LibraBFT.Impl.Consensus.SafetyRules.SafetyRules             as SafetyRules
-import      LibraBFT.Impl.OBM.Crypto                                    as Crypto
-open import LibraBFT.Impl.OBM.Logging.Logging
-open import LibraBFT.Impl.Types.BlockInfo                               as BlockInfo
-open import LibraBFT.Impl.Types.ValidatorSigner                         as ValidatorSigner
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
-import      LibraBFT.ImplShared.Util.Crypto                             as Crypto
-open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
-------------------------------------------------------------------------------
-import      Data.String                                       as String
 ------------------------------------------------------------------------------
 
 module LibraBFT.Impl.Consensus.SafetyRules.SafetyRulesManager where

--- a/LibraBFT/Impl/Consensus/SafetyRules/SafetyRulesManager.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/SafetyRulesManager.agda
@@ -7,7 +7,6 @@
 ------------------------------------------------------------------------------
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 import      LibraBFT.Impl.Consensus.ConsensusTypes.Block                as Block
 import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert           as QuorumCert
 import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote                 as Vote

--- a/LibraBFT/Impl/Consensus/StateComputerByteString.agda
+++ b/LibraBFT/Impl/Consensus/StateComputerByteString.agda
@@ -8,15 +8,11 @@ open import LibraBFT.Base.ByteString                          as BS
 import      LibraBFT.Base.Encode                              as S
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
-import      LibraBFT.Impl.Consensus.ConsensusTypes.Block      as Block
-import      LibraBFT.Impl.Consensus.ConsensusTypes.QuorumCert as QuorumCert
 import      LibraBFT.Impl.OBM.ConfigHardCoded                 as ConfigHardCoded
 open import LibraBFT.Impl.OBM.Logging.Logging
 import      LibraBFT.Impl.Storage.DiemDB.DiemDB               as DiemDB
 import      LibraBFT.Impl.Types.OnChainConfig.ValidatorSet    as ValidatorSet
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------

--- a/LibraBFT/Impl/Consensus/TestUtils/MockSharedStorage.agda
+++ b/LibraBFT/Impl/Consensus/TestUtils/MockSharedStorage.agda
@@ -4,19 +4,10 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.KVMap                            as Map
-open import LibraBFT.Base.Types
-import      LibraBFT.Impl.Consensus.RecoveryData           as RecoveryData
-open import LibraBFT.Impl.OBM.Logging.Logging
-import      LibraBFT.Impl.Types.LedgerInfo                 as LedgerInfo
-open import LibraBFT.ImplShared.Base.Types
+import      LibraBFT.Base.KVMap                            as Map
 open import LibraBFT.ImplShared.Consensus.Types
-import      LibraBFT.ImplShared.Consensus.Types.EpochIndep
-open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
-------------------------------------------------------------------------------
-import      Data.String                               as String
 
 module LibraBFT.Impl.Consensus.TestUtils.MockSharedStorage where
 

--- a/LibraBFT/Impl/Consensus/TestUtils/MockStorage.agda
+++ b/LibraBFT/Impl/Consensus/TestUtils/MockStorage.agda
@@ -6,7 +6,6 @@
 
 open import LibraBFT.Base.KVMap                                  as Map
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 import      LibraBFT.Impl.Consensus.RecoveryData                 as RecoveryData
 import      LibraBFT.Impl.Consensus.TestUtils.MockSharedStorage  as MockSharedStorage
 open import LibraBFT.Impl.OBM.Logging.Logging

--- a/LibraBFT/Impl/Consensus/TestUtils/MockStorage.agda
+++ b/LibraBFT/Impl/Consensus/TestUtils/MockStorage.agda
@@ -4,21 +4,19 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.KVMap                                  as Map
+import      LibraBFT.Base.KVMap                                  as Map
 open import LibraBFT.Base.Types
 import      LibraBFT.Impl.Consensus.RecoveryData                 as RecoveryData
 import      LibraBFT.Impl.Consensus.TestUtils.MockSharedStorage  as MockSharedStorage
 open import LibraBFT.Impl.OBM.Logging.Logging
 import      LibraBFT.Impl.Storage.DiemDB.LedgerStore.LedgerStore as LedgerStore
 import      LibraBFT.Impl.Types.LedgerInfo                       as LedgerInfo
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
-import      LibraBFT.ImplShared.Consensus.Types.EpochIndep
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.String                                          as String
+open import Data.String                                          using (String)
 
 module LibraBFT.Impl.Consensus.TestUtils.MockStorage where
 
@@ -59,7 +57,7 @@ tryStart self =
     (Map.elems (self ^∙ msSharedStorage ∙ mssQc))
     (self ^∙ msSharedStorage ∙ mssHighestTimeoutCertificate)
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "MockStorage" ∷ "tryStart" ∷ t
 
 startForTesting : ValidatorSet → Maybe LedgerInfoWithSignatures
@@ -74,7 +72,7 @@ startForTesting validatorSet obmMLIWS = do
   ss ← withErrCtx' (here' []) (start storage)
   pure (ss , storage)
  where
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "MockStorage" ∷ "startForTesting" ∷ t
 
 ------------------------------------------------------------------------------

--- a/LibraBFT/Impl/Crypto/Crypto/Hash.agda
+++ b/LibraBFT/Impl/Crypto/Crypto/Hash.agda
@@ -4,11 +4,7 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.PKCS
-open import LibraBFT.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.Prelude
-open import Optics.All
 
 module LibraBFT.Impl.Crypto.Crypto.Hash where
 

--- a/LibraBFT/Impl/Execution/ExecutorTypes/StateComputeResult.agda
+++ b/LibraBFT/Impl/Execution/ExecutorTypes/StateComputeResult.agda
@@ -4,12 +4,7 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.Types
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
-open import LibraBFT.ImplShared.Util.Util
-open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Execution.ExecutorTypes.StateComputeResult where

--- a/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/InputOutputHandlers.agda
@@ -5,12 +5,10 @@
 -}
 
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.Network as Network
-open import LibraBFT.Impl.Consensus.RoundManager as RoundManager
+import      LibraBFT.Impl.Consensus.Network      as Network
+import      LibraBFT.Impl.Consensus.RoundManager as RoundManager
 open import LibraBFT.Impl.OBM.Logging.Logging
-open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.ImplShared.NetworkMsg
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
 open import Optics.All

--- a/LibraBFT/Impl/IO/OBM/Messages.agda
+++ b/LibraBFT/Impl/IO/OBM/Messages.agda
@@ -1,0 +1,43 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.Types
+open import LibraBFT.ImplShared.Consensus.Types
+------------------------------------------------------------------------------
+open import Data.String                         using (String)
+
+module LibraBFT.Impl.IO.OBM.Messages where
+
+record ECPWire : Set where
+  constructor ECPWire∙new
+  field
+    --_ecpwWhy    : Text           -- for log visualization
+    --_ecpwEpoch  : Epoch          -- for log visualization; epoch of sender
+    --_ecpwRound  : Round          -- for log visualization; round of sender
+    _ecpwECP      : EpochChangeProof
+-- instance S.Serialize ECPWire
+
+record EpRRqWire : Set where
+  constructor EpRRqWire∙new
+  field
+    --_eprrqwWhy  : Text           -- for log visualization
+    --_eprrqEpoch : Epoch          -- for log visualization; epoch of sender
+    --_eprrqRound : Round          -- for log visualization; round of sender
+    _eprrqEpRRq   : EpochRetrievalRequest
+-- instance S.Serialize EpRRqWire
+
+data Input : Set where
+  IBlockRetrievalRequest    : Instant                  →          BlockRetrievalRequest  → Input
+  IBlockRetrievalResponse   : Instant                  →          BlockRetrievalResponse → Input
+  IEpochChangeProof         :           AccountAddress →          ECPWire                → Input
+  IEpochRetrievalRequest    :           AccountAddress →          EpRRqWire              → Input
+  IInit                     : Instant                                                    → Input
+  IProposal                 : Instant → AccountAddress →          ProposalMsg            → Input
+  IReconfigLocalEpochChange :                                   ReconfigEventEpochChange → Input
+  ISyncInfo                 : Instant → AccountAddress →          SyncInfo               → Input
+  ITimeout                  : Instant → String {-String is ThreadId-} → Epoch → Round    → Input
+  IVote                     : Instant → AccountAddress →          VoteMsg                → Input
+

--- a/LibraBFT/Impl/OBM/ECP-LBFT-OBM-Diff/ECP-LBFT-OBM-Diff-2.agda
+++ b/LibraBFT/Impl/OBM/ECP-LBFT-OBM-Diff/ECP-LBFT-OBM-Diff-2.agda
@@ -5,17 +5,8 @@
 -}
 
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 import      LibraBFT.Impl.OBM.ECP-LBFT-OBM-Diff.ECP-LBFT-OBM-Diff-0 as ECP-LBFT-OBM-Diff-0
-open import LibraBFT.Impl.OBM.Logging.Logging
-import      LibraBFT.Impl.Storage.DiemDB.DiemDB                     as DiemDB
-import      LibraBFT.Impl.Types.EpochChangeProof                    as EpochChangeProof
-open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.ImplShared.Interface.Output
-open import LibraBFT.ImplShared.Util.Dijkstra.Syntax
-open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Prelude
-open import Optics.All
 
 module LibraBFT.Impl.OBM.ECP-LBFT-OBM-Diff.ECP-LBFT-OBM-Diff-2 where
 

--- a/LibraBFT/Impl/OBM/Time.agda
+++ b/LibraBFT/Impl/OBM/Time.agda
@@ -4,9 +4,9 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Prelude
 open import LibraBFT.Impl.OBM.Rust.Duration as Duration
 open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
+open import LibraBFT.Prelude
 
 module LibraBFT.Impl.OBM.Time where
 

--- a/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
@@ -5,15 +5,11 @@
 
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.Prelude
-open import Optics.All
-------------------------------------------------------------------------------
-import      Data.String                                            as String
-
 open import LibraBFT.ImplShared.Util.Dijkstra.EitherD
 open import LibraBFT.ImplShared.Util.Dijkstra.EitherD.Syntax
+open import LibraBFT.Prelude
+open import Optics.All
 
 module LibraBFT.Impl.Storage.DiemDB.DiemDB where
 

--- a/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
@@ -3,13 +3,11 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Dijkstra.EitherD
 open import LibraBFT.ImplShared.Util.Dijkstra.EitherD.Syntax
 open import LibraBFT.Prelude
-open import Optics.All
 
 module LibraBFT.Impl.Storage.DiemDB.DiemDB where
 

--- a/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
@@ -3,15 +3,9 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-import      LibraBFT.Base.KVMap                         as Map
-open import LibraBFT.Base.PKCS
-open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
+import      LibraBFT.Base.KVMap                 as Map
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
-open import Optics.All
-------------------------------------------------------------------------------
-import      Data.String                                 as String
 
 module LibraBFT.Impl.Storage.DiemDB.LedgerStore.LedgerStore where
 

--- a/LibraBFT/Impl/Types/BlockInfo.agda
+++ b/LibraBFT/Impl/Types/BlockInfo.agda
@@ -5,7 +5,6 @@
 -}
 
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 import      LibraBFT.Impl.Crypto.Crypto.Hash               as Hash
 import      LibraBFT.Impl.OBM.Crypto                       as Crypto
 import      LibraBFT.Impl.Types.OnChainConfig.ValidatorSet as ValidatorSet

--- a/LibraBFT/Impl/Types/CryptoProxies.agda
+++ b/LibraBFT/Impl/Types/CryptoProxies.agda
@@ -5,7 +5,7 @@
 -}
 
 open import LibraBFT.Base.PKCS
-open import LibraBFT.Impl.Types.LedgerInfoWithSignatures as LedgerInfoWithSignatures
+import      LibraBFT.Impl.Types.LedgerInfoWithSignatures as LedgerInfoWithSignatures
 open import LibraBFT.ImplShared.Consensus.Types
 
 module LibraBFT.Impl.Types.CryptoProxies where

--- a/LibraBFT/Impl/Types/EpochChangeProof.agda
+++ b/LibraBFT/Impl/Types/EpochChangeProof.agda
@@ -5,17 +5,16 @@
 -}
 
 open import LibraBFT.Base.Encode
-open import LibraBFT.Base.PKCS                        hiding (verify)
+open import LibraBFT.Base.PKCS                  hiding (verify)
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 open import LibraBFT.Impl.OBM.Logging.Logging
-import      LibraBFT.Impl.Types.Verifier              as Verifier
+import      LibraBFT.Impl.Types.Verifier        as Verifier
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 open import Optics.All
 ------------------------------------------------------------------------------
-import      Data.List.Base                            as List
-import      Data.String                               as String
+import      Data.List.Base                      as List
+open import Data.String                         using (String)
 
 module LibraBFT.Impl.Types.EpochChangeProof where
 
@@ -67,7 +66,7 @@ verify self verifier = do
         (just vs) → pure vs
       loop verifierRef' liwss
 
-  here' : List String.String → List String.String
+  here' : List String → List String
   here' t = "EpochChangeProof" ∷ "verify" ∷ t
 
   last : ∀ {A : Set} → List A → Either ErrLog A

--- a/LibraBFT/Impl/Types/Ledger2WaypointConverter.agda
+++ b/LibraBFT/Impl/Types/Ledger2WaypointConverter.agda
@@ -4,10 +4,9 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 open import LibraBFT.Impl.OBM.Logging.Logging
 open import LibraBFT.ImplShared.Consensus.Types
-import      LibraBFT.ImplShared.Util.Crypto           as Crypto
+import      LibraBFT.ImplShared.Util.Crypto     as Crypto
 open import LibraBFT.Prelude
 open import Optics.All
 

--- a/LibraBFT/Impl/Types/LedgerInfo.agda
+++ b/LibraBFT/Impl/Types/LedgerInfo.agda
@@ -4,13 +4,10 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Impl.OBM.Logging.Logging
 import      LibraBFT.Impl.Types.BlockInfo             as BlockInfo
 import      LibraBFT.Impl.Crypto.Crypto.Hash          as Hash
 open import LibraBFT.ImplShared.Consensus.Types
-import      LibraBFT.ImplShared.Util.Crypto           as Crypto
 open import LibraBFT.Prelude
-open import Optics.All
 
 module LibraBFT.Impl.Types.LedgerInfo where
 

--- a/LibraBFT/Impl/Types/LedgerInfo.agda
+++ b/LibraBFT/Impl/Types/LedgerInfo.agda
@@ -4,7 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 open import LibraBFT.Impl.OBM.Logging.Logging
 import      LibraBFT.Impl.Types.BlockInfo             as BlockInfo
 import      LibraBFT.Impl.Crypto.Crypto.Hash          as Hash

--- a/LibraBFT/Impl/Types/LedgerInfoWithSignatures.agda
+++ b/LibraBFT/Impl/Types/LedgerInfoWithSignatures.agda
@@ -4,7 +4,7 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.KVMap                   as Map
+import      LibraBFT.Base.KVMap                   as Map
 open import LibraBFT.Base.PKCS
 import      LibraBFT.Impl.OBM.Crypto              as Crypto
 open import LibraBFT.Impl.OBM.Logging.Logging

--- a/LibraBFT/Impl/Types/OnChainConfig/ValidatorSet.agda
+++ b/LibraBFT/Impl/Types/OnChainConfig/ValidatorSet.agda
@@ -6,7 +6,6 @@
 
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 open import Optics.All

--- a/LibraBFT/Impl/Types/OnChainConfig/ValidatorSet.agda
+++ b/LibraBFT/Impl/Types/OnChainConfig/ValidatorSet.agda
@@ -4,11 +4,8 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.PKCS
-open import LibraBFT.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
-open import Optics.All
 
 module LibraBFT.Impl.Types.OnChainConfig.ValidatorSet where
 

--- a/LibraBFT/Impl/Types/ValidatorSigner.agda
+++ b/LibraBFT/Impl/Types/ValidatorSigner.agda
@@ -5,9 +5,8 @@
 -}
 
 open import LibraBFT.Base.Encode
-open import LibraBFT.Base.PKCS                           as PKCS hiding (sign)
+open import LibraBFT.Base.PKCS                  as PKCS hiding (sign)
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.Prelude
 
 module LibraBFT.Impl.Types.ValidatorSigner where
 

--- a/LibraBFT/Impl/Types/ValidatorVerifier.agda
+++ b/LibraBFT/Impl/Types/ValidatorVerifier.agda
@@ -4,18 +4,17 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.KVMap                            as Map
+import      LibraBFT.Base.KVMap                            as Map
 open import LibraBFT.Base.PKCS                             hiding (verify)
 import      LibraBFT.Impl.OBM.Crypto                       as Crypto
 open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Types.ValidatorVerifier where
 
-checkNumOfSignatures : ValidatorVerifier → KVMap AccountAddress Signature → Either ErrLog Unit
+checkNumOfSignatures : ValidatorVerifier → Map.KVMap AccountAddress Signature → Either ErrLog Unit
 checkVotingPower     : ValidatorVerifier → List AccountAddress → Either ErrLog Unit
 getPublicKey         : ValidatorVerifier → AccountAddress → Maybe PK
 getVotingPower       : ValidatorVerifier → AccountAddress → Maybe U64
@@ -40,7 +39,7 @@ verify = verifyIfAuthor -- (icSemi ["ValidatorVerifier", "verifySignature"])
 
 verifyAggregatedStructSignature
   : {V : Set} ⦃ _ : Crypto.CryptoHash V ⦄
-  → ValidatorVerifier → V → KVMap AccountAddress Signature
+  → ValidatorVerifier → V → Map.KVMap AccountAddress Signature
   → Either ErrLog Unit
 verifyAggregatedStructSignature self v aggregatedSignature = do
   checkNumOfSignatures self aggregatedSignature
@@ -50,7 +49,7 @@ verifyAggregatedStructSignature self v aggregatedSignature = do
 
 batchVerifyAggregatedSignatures
   : {V : Set} ⦃ _ : Crypto.CryptoHash V ⦄
-  → ValidatorVerifier → V → KVMap AccountAddress Signature
+  → ValidatorVerifier → V → Map.KVMap AccountAddress Signature
   → Either ErrLog Unit
 batchVerifyAggregatedSignatures = verifyAggregatedStructSignature
 

--- a/LibraBFT/Impl/Types/ValidatorVerifier.agda
+++ b/LibraBFT/Impl/Types/ValidatorVerifier.agda
@@ -6,7 +6,6 @@
 
 open import LibraBFT.Base.KVMap                            as Map
 open import LibraBFT.Base.PKCS                             hiding (verify)
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 import      LibraBFT.Impl.OBM.Crypto                       as Crypto
 open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Consensus.Types

--- a/LibraBFT/Impl/Types/Verifier.agda
+++ b/LibraBFT/Impl/Types/Verifier.agda
@@ -35,7 +35,7 @@ instance
   VerifierWaypoint   : Verifier Waypoint
   VerifierWaypoint   = record
     { verify                          = Waypoint.verifierVerify
-    ;  epochChangeVerificationRequired = Waypoint.epochChangeVerificationRequired
-    ;  isLedgerInfoStale               = Waypoint.isLedgerInfoStale
+    ; epochChangeVerificationRequired = Waypoint.epochChangeVerificationRequired
+    ; isLedgerInfoStale               = Waypoint.isLedgerInfoStale
     }
 

--- a/LibraBFT/Impl/Types/Waypoint.agda
+++ b/LibraBFT/Impl/Types/Waypoint.agda
@@ -6,7 +6,6 @@
 
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
-open import LibraBFT.Impl.Consensus.EpochManagerTypes
 open import LibraBFT.Impl.OBM.Logging.Logging
 import      LibraBFT.Impl.Types.Ledger2WaypointConverter as Ledger2WaypointConverter
 open import LibraBFT.ImplShared.Consensus.Types

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -8,7 +8,6 @@ open import LibraBFT.Base.Encode
 open import LibraBFT.Base.KVMap             as KVMap
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
-open import LibraBFT.Impl.OBM.Rust.Duration
 open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.Prelude
 open import Optics.All
@@ -35,19 +34,6 @@ module LibraBFT.ImplShared.Consensus.Types where
   open import LibraBFT.ImplShared.Base.Types                     public
   open import LibraBFT.ImplShared.Consensus.Types.EpochIndep     public
   open import LibraBFT.ImplShared.Util.Crypto                    public
-
-  data NewRoundReason : Set where
-    QCReady : NewRoundReason
-    TOReady : NewRoundReason
-
-  record NewRoundEvent : Set where
-    constructor NewRoundEvent∙new
-    field
-      _nreRound   : Round
-      _nreReason  : NewRoundReason
-      _nreTimeout : Duration
-  unquoteDecl nreRound   nreReason   nreTimeout = mkLens (quote NewRoundEvent)
-             (nreRound ∷ nreReason ∷ nreTimeout ∷ [])
 
   record ExponentialTimeInterval : Set where
     constructor mkExponentialTimeInterval

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -6,10 +6,11 @@
 
 open import LibraBFT.Base.ByteString
 open import LibraBFT.Base.Encode
-open import LibraBFT.Base.KVMap            as Map
+open import LibraBFT.Base.KVMap              as Map
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Base.Types
 open import LibraBFT.Hash
+open import LibraBFT.Impl.OBM.Rust.Duration
 open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.Prelude
@@ -958,8 +959,21 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
 
 -- ------------------------------------------------------------------------------
 
--- in LibraBFT.ImplShared.Consensus.Types
--- NewRoundReason, NewRoundEvent, ExponentialTimeInterval, RoundState
+  data NewRoundReason : Set where
+    QCReady : NewRoundReason
+    TOReady : NewRoundReason
+
+  record NewRoundEvent : Set where
+    constructor NewRoundEvent∙new
+    field
+      _nreRound   : Round
+      _nreReason  : NewRoundReason
+      _nreTimeout : Duration
+  unquoteDecl nreRound   nreReason   nreTimeout = mkLens (quote NewRoundEvent)
+             (nreRound ∷ nreReason ∷ nreTimeout ∷ [])
+
+-- LibraBFT.ImplShared.Consensus.Types contains
+-- ExponentialTimeInterval, RoundState
 
 -- ------------------------------------------------------------------------------
 

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -106,9 +106,38 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   ...| no  rgt  = no (⊥-elim ∘ λ { (inj₁ x) → ege x
                                  ; (inj₂ (_ , x)) → rgt x })
 
-  -----------------
-  -- Information --
-  -----------------
+-- ------------------------------------------------------------------------------
+
+  record ValidatorSigner : Set where
+    constructor ValidatorSigner∙new
+    field
+      _vsAuthor     : AccountAddress
+      _vsPrivateKey : SK      -- Note that the SystemModel doesn't
+                              -- allow one node to examine another's
+                              -- state, so we don't model someone being
+                              -- able to impersonate someone else unless
+                              -- PK is "dishonest", which models the
+                              -- possibility that the corresponding secret
+                              -- key may have been leaked.
+  open ValidatorSigner public
+  unquoteDecl  vsAuthor = mkLens (quote ValidatorSigner)
+              (vsAuthor ∷ [])
+
+  record ValidatorConfig : Set where
+    constructor ValidatorConfig∙new
+    field
+     _vcConsensusPublicKey : PK
+  open ValidatorConfig public
+  unquoteDecl vcConsensusPublicKey = mkLens (quote ValidatorConfig)
+    (vcConsensusPublicKey ∷ [])
+
+  record ValidatorInfo : Set where
+    constructor ValidatorInfo∙new
+    field
+      -- _viAccountAddress       : AccountAddress
+      -- _viConsensusVotingPower : Int -- TODO-2: Each validator has one vote. Generalize later.
+      _viConfig : ValidatorConfig
+  open ValidatorInfo public
 
   record ValidatorConsensusInfo : Set where
     constructor ValidatorConsensusInfo∙new
@@ -138,6 +167,16 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     s : ValidatorVerifier → List AccountAddress → ValidatorVerifier
     s vv _ = vv -- TODO-1 : cannot be done: need a way to defined only getters
 
+  data ConsensusScheme : Set where ConsensusScheme∙new : ConsensusScheme
+  -- instance S.Serialize ConsensusScheme
+
+  record ValidatorSet : Set where
+    constructor ValidatorSet∙new
+    field
+      _vsScheme  : ConsensusScheme
+      _vsPayload : List ValidatorInfo
+  -- instance S.Serialize ValidatorSet
+
   record EpochState : Set where
     constructor EpochState∙new
     field
@@ -147,24 +186,12 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl esEpoch   esVerifier = mkLens (quote EpochState)
              (esEpoch ∷ esVerifier ∷ [])
 
-  record Ledger2WaypointConverter : Set where
-    constructor mkLedger2WaypointConverter
-    field
-      _l2wcEpoch          : Epoch
-      _l2wcRootHash       : HashValue
-      _l2wcVersion        : Version
-    --_l2wcTimestamp      : Instant
-      _l2wcNextEpochState : Maybe EpochState
-  open Ledger2WaypointConverter public
-  unquoteDecl l2wcEpoch   2wcRootHash   2wcVersion
-              {-l2wcTimestamp-} l2wcNextEpochState = mkLens (quote Ledger2WaypointConverter)
-             (l2wcEpoch ∷ 2wcRootHash ∷ 2wcVersion ∷
-              {-l2wcTimestamp-} l2wcNextEpochState ∷ [])
-
   postulate -- one valid assumption, one that can be proved using it
     instance
       Enc-EpochState   : Encoder EpochState
       Enc-EpochStateMB : Encoder (Maybe EpochState)  -- TODO-1: make combinator to build this
+
+-- ------------------------------------------------------------------------------
 
   record BlockInfo : Set where
     constructor BlockInfo∙new
@@ -215,6 +242,8 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
               → BlockInfo∙new e1 r1 i1 ≡ BlockInfo∙new e2 r2 i2
   BlockInfo-η refl refl refl = refl
 -}
+
+-- ------------------------------------------------------------------------------
 
   record LedgerInfo : Set where
     constructor LedgerInfo∙new
@@ -289,9 +318,19 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   liwsNextEpochState : Lens LedgerInfoWithSignatures (Maybe EpochState)
   liwsNextEpochState = liwsLedgerInfo ∙ liNextEpochState
 
-  -------------------
-  -- Votes and QCs --
-  -------------------
+-- ------------------------------------------------------------------------------
+
+  record Timeout : Set where
+    constructor Timeout∙new
+    field
+      _toEpoch : Epoch
+      _toRound : Round
+  open Timeout public
+  unquoteDecl toEpoch   toRound = mkLens (quote Timeout)
+             (toEpoch ∷ toRound ∷ [])
+  postulate instance enc-Timeout : Encoder Timeout
+
+-- ------------------------------------------------------------------------------
 
   record VoteData : Set where
     constructor VoteData∙new
@@ -350,6 +389,8 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   -- getter only in Haskell
   vRound : Lens Vote Round
   vRound = vVoteData ∙ vdProposed ∙ biRound
+
+-- ------------------------------------------------------------------------------
 
   record QuorumCert : Set where
     constructor QuorumCert∙new
@@ -431,9 +472,29 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   _qcRound : QuorumCert → Round
   _qcRound q = q ^∙ qcRound
 
-  ------------
-  -- Blocks --
-  ------------
+-- ------------------------------------------------------------------------------
+
+  record TimeoutCertificate : Set where
+    constructor mkTimeoutCertificate
+    field
+      _tcTimeout    : Timeout
+      _tcSignatures : KVMap Author Signature
+  open TimeoutCertificate public
+  unquoteDecl tcTimeout   tcSignatures = mkLens (quote TimeoutCertificate)
+             (tcTimeout ∷ tcSignatures ∷ [])
+
+  TimeoutCertificate∙new : Timeout → TimeoutCertificate
+  TimeoutCertificate∙new to = mkTimeoutCertificate to Map.empty
+
+  -- getter only in haskell
+  tcEpoch : Lens TimeoutCertificate Epoch
+  tcEpoch = tcTimeout ∙ toEpoch
+
+  -- getter only in haskell
+  tcRound : Lens TimeoutCertificate Round
+  tcRound = tcTimeout ∙ toRound
+
+-- ------------------------------------------------------------------------------
 
   data BlockType : Set where
     Proposal : TX → Author → BlockType
@@ -517,6 +578,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     s : BlockData → Maybe TX → BlockData
     s bd _ = bd -- TODO-1 : cannot be done: need a way to define only getters
 
+-- ------------------------------------------------------------------------------
 
   -- The signature is a Maybe to allow us to use 'nothing' as the
   -- 'bSignature' when constructing a block to sign later.  Also,
@@ -568,14 +630,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   sym≈Block : Symmetric _≈Block_
   sym≈Block refl = refl
 
-  record BlockRetriever : Set where
-    constructor BlockRetriever∙new
-    field
-      _brDeadline      : Instant
-      _brPreferredPeer : Author
-  open BlockRetriever public
-  unquoteDecl brDeadline   brPreferredPeer = mkLens (quote BlockRetriever)
-             (brDeadline ∷ brPreferredPeer ∷ [])
+-- ------------------------------------------------------------------------------
 
   record AccumulatorExtensionProof : Set where
     constructor AccumulatorExtensionProof∙new
@@ -603,35 +658,405 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl  msvpVoteProposal = mkLens (quote MaybeSignedVoteProposal)
               (msvpVoteProposal ∷ [])
 
-  record Timeout : Set where
-    constructor Timeout∙new
-    field
-      _toEpoch : Epoch
-      _toRound : Round
-  open Timeout public
-  unquoteDecl toEpoch   toRound = mkLens (quote Timeout)
-             (toEpoch ∷ toRound ∷ [])
-  postulate instance enc-Timeout : Encoder Timeout
+-- ------------------------------------------------------------------------------
 
-  record TimeoutCertificate : Set where
-    constructor mkTimeoutCertificate
+  record LastVoteInfo : Set where
+    constructor LastVoteInfo∙new
     field
-      _tcTimeout    : Timeout
-      _tcSignatures : KVMap Author Signature
-  open TimeoutCertificate public
-  unquoteDecl tcTimeout   tcSignatures = mkLens (quote TimeoutCertificate)
-             (tcTimeout ∷ tcSignatures ∷ [])
+      _lviLiDigest  : HashValue
+      _lviRound     : Round
+      _lviIsTimeout : Bool
+  open LastVoteInfo public
 
-  TimeoutCertificate∙new : Timeout → TimeoutCertificate
-  TimeoutCertificate∙new to = mkTimeoutCertificate to Map.empty
+  record PendingVotes : Set where
+    constructor mkPendingVotes
+    field
+      _pvLiDigestToVotes   : KVMap HashValue LedgerInfoWithSignatures
+      _pvMaybePartialTC    : Maybe TimeoutCertificate
+      _pvAuthorToVote      : KVMap Author Vote
+  open PendingVotes public
+  unquoteDecl pvLiDigestToVotes   pvMaybePartialTC   pvAuthorToVote = mkLens (quote PendingVotes)
+             (pvLiDigestToVotes ∷ pvMaybePartialTC ∷ pvAuthorToVote ∷ [])
+
+  PendingVotes∙new : PendingVotes
+  PendingVotes∙new = mkPendingVotes Map.empty nothing Map.empty
+
+-- ------------------------------------------------------------------------------
+
+  record StateComputeResult : Set where
+    constructor StateComputeResult∙new
+    field
+      _scrObmNumLeaves : Version
+      _scrEpochState   : Maybe EpochState
+  open StateComputeResult public
+  unquoteDecl scrObmNumLeaves   scrEpochState = mkLens (quote StateComputeResult)
+             (scrObmNumLeaves ∷ scrEpochState ∷ [])
+
+  postulate -- TODO: eliminate after fully implementing executeBlockE
+    stateComputeResult : StateComputeResult
+
+  record ExecutedBlock : Set where
+    constructor ExecutedBlock∙new
+    field
+      _ebBlock              : Block
+      _ebStateComputeResult : StateComputeResult
+  open ExecutedBlock public
+  unquoteDecl ebBlock   ebStateComputeResult = mkLens (quote ExecutedBlock)
+             (ebBlock ∷ ebStateComputeResult ∷ [])
+
+  -- getter only in Haskell
+  ebId : Lens ExecutedBlock HashValue
+  ebId = ebBlock ∙ bId
+
+  -- getter only in Haskell
+  ebQuorumCert : Lens ExecutedBlock QuorumCert
+  ebQuorumCert = ebBlock ∙ bQuorumCert
+
+  -- getter only in Haskell
+  ebParentId : Lens ExecutedBlock HashValue
+  ebParentId = ebQuorumCert ∙ qcCertifiedBlock ∙ biId
+
+  -- getter only in Haskell
+  ebRound : Lens ExecutedBlock Round
+  ebRound = ebBlock ∙ bRound
+
+-- ------------------------------------------------------------------------------
+
+  record LinkableBlock : Set where
+    constructor LinkableBlock∙new
+    field
+      _lbExecutedBlock : ExecutedBlock
+      -- _lbChildren      : Set HashValue
+  open LinkableBlock public
+  unquoteDecl lbExecutedBlock = mkLens (quote LinkableBlock)
+             (lbExecutedBlock ∷ [])
+
+  -- getter only in Haskell
+  lbId : Lens LinkableBlock HashValue
+  lbId = lbExecutedBlock ∙ ebId
+
+-- ------------------------------------------------------------------------------
+
+  -- A block tree depends on a epoch config but works regardlesss of which
+  -- EpochConfig we have.
+  record BlockTree : Set where
+    constructor mkBlockTree
+    field
+      _btIdToBlock               : KVMap HashValue LinkableBlock
+      _btRootId                  : HashValue
+      _btHighestCertifiedBlockId : HashValue
+      _btHighestQuorumCert       : QuorumCert
+      _btHighestTimeoutCert      : Maybe TimeoutCertificate
+      _btHighestCommitCert       : QuorumCert
+      _btIdToQuorumCert          : KVMap HashValue QuorumCert
+      _btPrunedBlockIds          : VecDeque
+      _btMaxPrunedBlocksInMem    : ℕ
+  open BlockTree public
+  unquoteDecl btIdToBlock   btRootId  btHighestCertifiedBlockId   btHighestQuorumCert
+              btHighestTimeoutCert   btHighestCommitCert
+              btIdToQuorumCert   btPrunedBlockIds
+              btMaxPrunedBlocksInMem = mkLens (quote BlockTree)
+             (btIdToBlock ∷ btRootId ∷ btHighestCertifiedBlockId ∷ btHighestQuorumCert ∷
+              btHighestTimeoutCert ∷ btHighestCommitCert ∷
+              btIdToQuorumCert ∷ btPrunedBlockIds ∷
+              btMaxPrunedBlocksInMem ∷ [])
+
+  btGetLinkableBlock : HashValue → BlockTree → Maybe LinkableBlock
+  btGetLinkableBlock hv bt = Map.lookup hv (bt ^∙ btIdToBlock)
+
+  btGetBlock : HashValue → BlockTree → Maybe ExecutedBlock
+  btGetBlock hv bt = (_^∙ lbExecutedBlock) <$> btGetLinkableBlock hv bt
+
+  -- getter only in Haskell
+  btRoot : Lens BlockTree (Maybe ExecutedBlock)
+  btRoot = mkLens' g s
+    where
+    g : BlockTree → Maybe ExecutedBlock
+    g bt = btGetBlock (bt ^∙ btRootId) bt
+
+    -- TODO-1 : the setter is not needed/defined in Haskell
+    -- Defining it just to make progress, but it can't be defined
+    -- correctly in terms of type correctness (let alone setting a new root!)
+    s : BlockTree → Maybe ExecutedBlock → BlockTree
+    s bt _ = bt -- TODO-1 : cannot be done: need a way to defined only getters
 
   -- getter only in haskell
-  tcEpoch : Lens TimeoutCertificate Epoch
-  tcEpoch = tcTimeout ∙ toEpoch
+  btHighestCertifiedBlock : Lens BlockTree (Maybe ExecutedBlock)
+  btHighestCertifiedBlock = mkLens' g s
+    where
+    g : BlockTree → (Maybe ExecutedBlock)
+    g bt = btGetBlock (bt ^∙ btHighestCertifiedBlockId) bt
 
-  -- getter only in haskell
-  tcRound : Lens TimeoutCertificate Round
-  tcRound = tcTimeout ∙ toRound
+    s : BlockTree → (Maybe ExecutedBlock) → BlockTree
+    s bt _ = bt -- TODO-1 : cannot be done: need a way to defined only getters
+
+-- ------------------------------------------------------------------------------
+
+  record LedgerStore : Set where
+    constructor mkLedgerStore
+    field
+      _lsObmVersionToEpoch : Map.KVMap Version Epoch
+      _lsObmEpochToLIWS    : Map.KVMap Epoch   LedgerInfoWithSignatures
+      _lsLatestLedgerInfo  : Maybe LedgerInfoWithSignatures
+
+  record DiemDB : Set where
+    constructor DiemDB∙new
+    field
+      _ddbLedgerStore : LedgerStore
+  open DiemDB public
+  unquoteDecl ddbLedgerStore = mkLens (quote DiemDB)
+             (ddbLedgerStore ∷ [])
+
+  record LedgerRecoveryData : Set where
+    constructor LedgerRecoveryData∙new
+    field
+      _lrdStorageLedger : LedgerInfo
+
+  record MockSharedStorage : Set where
+    constructor mkMockSharedStorage
+    field
+      -- Safety state
+      _mssBlock                     : Map.KVMap HashValue Block
+      _mssQc                        : Map.KVMap HashValue QuorumCert
+      _mssLis                       : Map.KVMap Version   LedgerInfoWithSignatures
+      _mssLastVote                  : Maybe Vote
+      -- Liveness state
+      _mssHighestTimeoutCertificate : Maybe TimeoutCertificate
+      _mssValidatorSet              : ValidatorSet
+  open MockSharedStorage public
+  unquoteDecl mssBlock    mssQc   mssLis    mssLastVote
+              mssHighestTimeoutCertificate  mssValidatorSet = mkLens (quote MockSharedStorage)
+             (mssBlock ∷  mssQc ∷ mssLis ∷ mssLastVote ∷
+              mssHighestTimeoutCertificate ∷ mssValidatorSet ∷ [])
+
+  record MockStorage : Set where
+    constructor MockStorage∙new
+    field
+      _msSharedStorage : MockSharedStorage
+      _msStorageLedger : LedgerInfo
+      _msObmDiemDB     : DiemDB
+  open MockStorage public
+  unquoteDecl msSharedStorage   msStorageLedger   msObmDiemDB = mkLens (quote MockStorage)
+             (msSharedStorage ∷ msStorageLedger ∷ msObmDiemDB ∷ [])
+
+  PersistentLivenessStorage = MockStorage
+
+  -- IMPL-DIFF : This is defined without record fields in Haskell.
+  -- The record fields below are never used.  But RootInfo must be a record for pattern matching.
+  record RootInfo : Set where
+    constructor RootInfo∙new
+    field
+      _riBlock : Block
+      _riQC1   : QuorumCert
+      _riQC2   : QuorumCert
+
+-- ------------------------------------------------------------------------------
+
+  record SafetyData : Set where
+    constructor SafetyData∙new
+    field
+      _sdEpoch          : Epoch
+      _sdLastVotedRound : Round
+      _sdPreferredRound : Round
+      _sdLastVote       : Maybe Vote
+  open SafetyData public
+  unquoteDecl sdEpoch sdLastVotedRound sdPreferredRound sdLastVote =
+    mkLens (quote SafetyData)
+    (sdEpoch ∷ sdLastVotedRound ∷ sdPreferredRound ∷ sdLastVote ∷  [])
+
+  record Waypoint : Set where
+    constructor Waypoint∙new
+    field
+      _wVersion : Version
+      _wValue   : HashValue
+  open Waypoint public
+  unquoteDecl wVersion   wValue = mkLens (quote Waypoint)
+             (wVersion ∷ wValue ∷ [])
+  postulate instance enc-Waypoint : Encoder Waypoint
+
+  record PersistentSafetyStorage : Set where
+    constructor mkPersistentSafetyStorage
+    field
+      _pssSafetyData : SafetyData
+      _pssAuthor     : Author
+      _pssWaypoint   : Waypoint
+      _pssObmSK      : Maybe SK
+  open PersistentSafetyStorage public
+  unquoteDecl pssSafetyData   pssAuthor   pssWaypoint   pssObmSK = mkLens (quote PersistentSafetyStorage)
+             (pssSafetyData ∷ pssAuthor ∷ pssWaypoint ∷ pssObmSK ∷ [])
+
+  record OnChainConfigPayload : Set where
+    constructor OnChainConfigPayload∙new
+    field
+      _occpEpoch           : Epoch
+      _occpObmValidatorSet : ValidatorSet
+  open OnChainConfigPayload public
+  unquoteDecl occpEpoch   occpObmValidatorSet = mkLens (quote OnChainConfigPayload)
+             (occpEpoch ∷ occpObmValidatorSet ∷ [])
+  -- instance S.Serialize OnChainConfigPayload
+
+  record ReconfigEventEpochChange : Set where
+    constructor ReconfigEventEpochChange∙new
+    field
+      _reecOnChainConfigPayload : OnChainConfigPayload
+  -- instance S.Serialize ReconfigEventEpochChange
+
+-- ------------------------------------------------------------------------------
+
+  -- IMPL-DIFF : Haskell StateComputer has pluggable functions.
+  -- The Agda version just calls them directly
+  record StateComputer : Set where
+    constructor StateComputer∙new
+    field
+      _scObmVersion : Version
+  open StateComputer public
+  unquoteDecl scObmVersion = mkLens (quote StateComputer)
+             (scObmVersion ∷ [])
+
+  StateComputerComputeType
+    = StateComputer → Block → HashValue
+    → Either (List String) StateComputeResult
+
+  StateComputerCommitType
+    = StateComputer → DiemDB → ExecutedBlock → LedgerInfoWithSignatures
+    → Either (List String) (StateComputer × DiemDB × Maybe ReconfigEventEpochChange)
+
+  StateComputerSyncToType
+    = LedgerInfoWithSignatures
+    → Either (List String) ReconfigEventEpochChange
+
+-- ------------------------------------------------------------------------------
+
+  record BlockStore : Set where
+    constructor BlockStore∙new
+    field
+      _bsInner         : BlockTree
+      _bsStateComputer : StateComputer
+      _bsStorage       : PersistentLivenessStorage
+  open BlockStore public
+  unquoteDecl bsInner   bsStateComputer   bsStorage = mkLens (quote BlockStore)
+             (bsInner ∷ bsStateComputer ∷ bsStorage ∷ [])
+
+  postulate  -- TODO: stateComputer
+    stateComputer : StateComputer
+
+  -- getter only in Haskell
+  bsRoot : Lens BlockStore (Maybe ExecutedBlock)
+  bsRoot = bsInner ∙ btRoot
+
+  -- getter only in Haskell
+  bsHighestQuorumCert : Lens BlockStore QuorumCert
+  bsHighestQuorumCert = bsInner ∙ btHighestQuorumCert
+
+  -- getter only in Haskell
+  bsHighestCommitCert : Lens BlockStore QuorumCert
+  bsHighestCommitCert = bsInner ∙ btHighestCommitCert
+
+  -- getter only in Haskell
+  bsHighestTimeoutCert : Lens BlockStore (Maybe TimeoutCertificate)
+  bsHighestTimeoutCert = bsInner ∙ btHighestTimeoutCert
+
+-- ------------------------------------------------------------------------------
+
+-- in LibraBFT.ImplShared.Consensus.Types
+-- NewRoundReason, NewRoundEvent, ExponentialTimeInterval, RoundState
+
+-- ------------------------------------------------------------------------------
+
+  record ProposalGenerator : Set where
+    constructor ProposalGenerator∙new
+    field
+      _pgLastRoundGenerated : Round
+  open ProposalGenerator
+  unquoteDecl pgLastRoundGenerated = mkLens (quote ProposalGenerator)
+              (pgLastRoundGenerated ∷ [])
+
+-- ------------------------------------------------------------------------------
+
+  data ObmNotValidProposerReason : Set where
+    ProposalDoesNotHaveAnAuthor ProposerForBlockIsNotValidForThisRound NotValidProposer : ObmNotValidProposerReason
+
+  record ProposerElection : Set where
+    constructor ProposerElection∙new
+    -- field
+      -- _peProposers : Set Author
+      -- _peObmLeaderOfRound : LeaderOfRoundFn
+      -- _peObmNodesInOrder  : NodesInOrder
+  open ProposerElection
+
+-- ------------------------------------------------------------------------------
+
+  record SafetyRules : Set where
+    constructor mkSafetyRules
+    field
+      _srPersistentStorage  : PersistentSafetyStorage
+      _srExportConsensusKey : Bool
+      _srValidatorSigner    : Maybe ValidatorSigner
+      _srEpochState         : Maybe EpochState
+  open SafetyRules public
+  unquoteDecl srPersistentStorage   srExportConsensusKey   srValidatorSigner   srEpochState = mkLens (quote SafetyRules)
+             (srPersistentStorage ∷ srExportConsensusKey ∷ srValidatorSigner ∷ srEpochState ∷ [])
+
+-- ------------------------------------------------------------------------------
+
+  record BlockRetrievalRequest : Set where
+    constructor BlockRetrievalRequest∙new
+    field
+      _brqObmFrom   : Author
+      _brqBlockId   : HashValue
+      _brqNumBlocks : U64
+  open BlockRetrievalRequest public
+  unquoteDecl brqObmFrom   brqBlockId   brqNumBlocks = mkLens (quote BlockRetrievalRequest)
+             (brqObmFrom ∷ brqBlockId ∷ brqNumBlocks ∷ [])
+  postulate instance enc-BlockRetrievalRequest : Encoder BlockRetrievalRequest
+
+  data BlockRetrievalStatus : Set where
+    BRSSucceeded BRSIdNotFound BRSNotEnoughBlocks : BlockRetrievalStatus
+  open BlockRetrievalStatus public
+  postulate instance enc-BlockRetrievalState : Encoder BlockRetrievalStatus
+
+  brs-eq : (brs₁ brs₂ : BlockRetrievalStatus) → Dec (brs₁ ≡ brs₂)
+  brs-eq BRSSucceeded       BRSSucceeded       = yes refl
+  brs-eq BRSSucceeded       BRSIdNotFound      = no λ ()
+  brs-eq BRSSucceeded       BRSNotEnoughBlocks = no λ ()
+  brs-eq BRSIdNotFound      BRSSucceeded       = no λ ()
+  brs-eq BRSIdNotFound      BRSIdNotFound      = yes refl
+  brs-eq BRSIdNotFound      BRSNotEnoughBlocks = no λ ()
+  brs-eq BRSNotEnoughBlocks BRSSucceeded       = no λ ()
+  brs-eq BRSNotEnoughBlocks BRSIdNotFound      = no λ ()
+  brs-eq BRSNotEnoughBlocks BRSNotEnoughBlocks = yes refl
+
+  instance
+    Eq-BlockRetrievalStatus : Eq BlockRetrievalStatus
+    Eq._≟_ Eq-BlockRetrievalStatus = brs-eq
+
+  record BlockRetrievalResponse : Set where
+    constructor BlockRetrievalResponse∙new
+    field
+      _brpObmFrom : (Author × Epoch × Round) -- for logging
+      _brpStatus  : BlockRetrievalStatus
+      _brpBlocks  : List Block
+  unquoteDecl brpObmFrom   brpStatus   brpBlocks   = mkLens (quote BlockRetrievalResponse)
+             (brpObmFrom ∷ brpStatus ∷ brpBlocks ∷ [])
+  postulate instance enc-BlockRetrievalResponse : Encoder BlockRetrievalResponse
+
+-- ------------------------------------------------------------------------------
+
+-- LibraBFT.ImplShared.Consensus.Types contains
+-- ObmNeedFetch, RoundManager
+
+-- ------------------------------------------------------------------------------
+
+  record BlockRetriever : Set where
+    constructor BlockRetriever∙new
+    field
+      _brDeadline      : Instant
+      _brPreferredPeer : Author
+  open BlockRetriever public
+  unquoteDecl brDeadline   brPreferredPeer = mkLens (quote BlockRetriever)
+             (brDeadline ∷ brPreferredPeer ∷ [])
+
+-- ------------------------------------------------------------------------------
 
   record SyncInfo : Set where
     constructor mkSyncInfo -- Bare constructor to enable pattern matching against SyncInfo; "smart"
@@ -688,9 +1113,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   siObmRound : Lens SyncInfo Round
   siObmRound = siHighestQuorumCert ∙ qcCertifiedBlock ∙ biRound
 
-  ----------------------
-  -- Network Messages --
-  ----------------------
+-- ------------------------------------------------------------------------------
 
   record ProposalMsg : Set where
     constructor ProposalMsg∙new
@@ -713,6 +1136,8 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   -- getter only in Haskell
   pmProposer : Lens ProposalMsg (Maybe Author)
   pmProposer = pmProposal ∙ bAuthor
+
+-- ------------------------------------------------------------------------------
 
   record VoteMsg : Set where
     constructor  VoteMsg∙new
@@ -740,32 +1165,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   vmRound : Lens VoteMsg Round
   vmRound = vmVote ∙ vRound
 
-  -- IMPL-DIFF : This is defined without record fields in Haskell.
-  -- The record fields below are never used.  But RootInfo must be a record for pattern matching.
-  record RootInfo : Set where
-    constructor RootInfo∙new
-    field
-      _riBlock : Block
-      _riQC1   : QuorumCert
-      _riQC2   : QuorumCert
-
-  data RootMetadata : Set where RootMetadata∙new : RootMetadata
-
-  record RecoveryData : Set where
-    constructor mkRecoveryData
-    field
-      _rdLastVote                  : Maybe Vote
-      _rdRoot                      : RootInfo
-      _rdRootMetadata              : RootMetadata
-      _rdBlocks                    : List Block
-      _rdQuorumCerts               : List QuorumCert
-      _rdBlocksToPrune             : Maybe (List HashValue)
-      _rdHighestTimeoutCertificate : Maybe TimeoutCertificate
-  open RecoveryData public
-  unquoteDecl rdLastVote      rdRoot            rdRootMetadata                rdBlocks
-              rdQuorumCerts   rdBlocksToPrune   rdHighestTimeoutCertificate = mkLens (quote RecoveryData)
-             (rdLastVote    ∷ rdRoot          ∷ rdRootMetadata              ∷ rdBlocks ∷
-              rdQuorumCerts ∷ rdBlocksToPrune ∷ rdHighestTimeoutCertificate ∷ [])
+-- ------------------------------------------------------------------------------
 
   -- This is a notification of a commit.  It may not be explicitly included in an implementation,
   -- but we need something to be able to express correctness conditions.  It will
@@ -783,217 +1183,136 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
              (cmEpoch ∷ cmAuthor ∷ cmRound ∷ cmCert ∷ cmSigMB ∷ [])
   postulate instance enc-CommitMsg : Encoder CommitMsg
 
-  record LastVoteInfo : Set where
-    constructor LastVoteInfo∙new
-    field
-      _lviLiDigest  : HashValue
-      _lviRound     : Round
-      _lviIsTimeout : Bool
-  open LastVoteInfo public
+-- ------------------------------------------------------------------------------
 
-  record PendingVotes : Set where
-    constructor mkPendingVotes
-    field
-      _pvLiDigestToVotes   : KVMap HashValue LedgerInfoWithSignatures
-      _pvMaybePartialTC    : Maybe TimeoutCertificate
-      _pvAuthorToVote      : KVMap Author Vote
-  open PendingVotes public
-  unquoteDecl pvLiDigestToVotes   pvMaybePartialTC   pvAuthorToVote = mkLens (quote PendingVotes)
-             (pvLiDigestToVotes ∷ pvMaybePartialTC ∷ pvAuthorToVote ∷ [])
-
-  PendingVotes∙new : PendingVotes
-  PendingVotes∙new = mkPendingVotes Map.empty nothing Map.empty
-
-  record StateComputeResult : Set where
-    constructor StateComputeResult∙new
-    field
-      _scrObmNumLeaves : Version
-      _scrEpochState   : Maybe EpochState
-  open StateComputeResult public
-  unquoteDecl scrObmNumLeaves   scrEpochState = mkLens (quote StateComputeResult)
-             (scrObmNumLeaves ∷ scrEpochState ∷ [])
-
-  postulate -- TODO: eliminate after fully implementing executeBlockE
-    stateComputeResult : StateComputeResult
-
-  record ExecutedBlock : Set where
-    constructor ExecutedBlock∙new
-    field
-      _ebBlock              : Block
-      _ebStateComputeResult : StateComputeResult
-  open ExecutedBlock public
-  unquoteDecl ebBlock   ebStateComputeResult = mkLens (quote ExecutedBlock)
-             (ebBlock ∷ ebStateComputeResult ∷ [])
-
-  -- getter only in Haskell
-  ebId : Lens ExecutedBlock HashValue
-  ebId = ebBlock ∙ bId
-
-  -- getter only in Haskell
-  ebQuorumCert : Lens ExecutedBlock QuorumCert
-  ebQuorumCert = ebBlock ∙ bQuorumCert
-
-  -- getter only in Haskell
-  ebParentId : Lens ExecutedBlock HashValue
-  ebParentId = ebQuorumCert ∙ qcCertifiedBlock ∙ biId
-
-  -- getter only in Haskell
-  ebRound : Lens ExecutedBlock Round
-  ebRound = ebBlock ∙ bRound
+  data RootMetadata : Set where RootMetadata∙new : RootMetadata
 
 -- ------------------------------------------------------------------------------
 
-  record LinkableBlock : Set where
-    constructor LinkableBlock∙new
+  record RecoveryData : Set where
+    constructor mkRecoveryData
     field
-      _lbExecutedBlock : ExecutedBlock
-      -- _lbChildren      : Set HashValue
-  open LinkableBlock public
-  unquoteDecl lbExecutedBlock = mkLens (quote LinkableBlock)
-             (lbExecutedBlock ∷ [])
+      _rdLastVote                  : Maybe Vote
+      _rdRoot                      : RootInfo
+      _rdRootMetadata              : RootMetadata
+      _rdBlocks                    : List Block
+      _rdQuorumCerts               : List QuorumCert
+      _rdBlocksToPrune             : Maybe (List HashValue)
+      _rdHighestTimeoutCertificate : Maybe TimeoutCertificate
+  open RecoveryData public
+  unquoteDecl rdLastVote      rdRoot            rdRootMetadata                rdBlocks
+              rdQuorumCerts   rdBlocksToPrune   rdHighestTimeoutCertificate = mkLens (quote RecoveryData)
+             (rdLastVote    ∷ rdRoot          ∷ rdRootMetadata              ∷ rdBlocks ∷
+              rdQuorumCerts ∷ rdBlocksToPrune ∷ rdHighestTimeoutCertificate ∷ [])
 
-  -- getter only in Haskell
-  lbId : Lens LinkableBlock HashValue
-  lbId = lbExecutedBlock ∙ ebId
+------------------------------------------------------------------------------
+
+  record EpochChangeProof : Set where
+    constructor EpochChangeProof∙new
+    field
+      _ecpLedgerInfoWithSigs : List LedgerInfoWithSignatures
+      _ecpMore               : Bool
+  open EpochChangeProof public
+  unquoteDecl ecpLedgerInfoWithSigs   ecpMore = mkLens (quote EpochChangeProof)
+             (ecpLedgerInfoWithSigs ∷ ecpMore ∷ [])
+  -- instance S.Serialize EpochChangeProof
+
+  record Ledger2WaypointConverter : Set where
+    constructor mkLedger2WaypointConverter
+    field
+      _l2wcEpoch          : Epoch
+      _l2wcRootHash       : HashValue
+      _l2wcVersion        : Version
+    --_l2wcTimestamp      : Instant
+      _l2wcNextEpochState : Maybe EpochState
+  open Ledger2WaypointConverter public
+  unquoteDecl l2wcEpoch   2wcRootHash   2wcVersion
+              {-l2wcTimestamp-} l2wcNextEpochState = mkLens (quote Ledger2WaypointConverter)
+             (l2wcEpoch ∷ 2wcRootHash ∷ 2wcVersion ∷
+              {-l2wcTimestamp-} l2wcNextEpochState ∷ [])
+
+  record EpochRetrievalRequest : Set where
+    constructor EpochRetrievalRequest∙new
+    field
+      _eprrqStartEpoch : Epoch
+      _eprrqEndEpoch   : Epoch
+  unquoteDecl eprrqStartEpoch   eprrqEndEpoch   = mkLens (quote EpochRetrievalRequest)
+             (eprrqStartEpoch ∷ eprrqEndEpoch ∷ [])
+  -- instance S.Serialize EpochRetrievalRequest
+
+------------------------------------------------------------------------------
+
+  record ConsensusState : Set where
+    constructor ConsensusState∙new
+    field
+      _csSafetyData     : SafetyData
+      _csWaypoint       : Waypoint
+    --_csInValidatorSet : Bool -- LBFT-OBM-DIFF: only used in tests in Rust
+  open ConsensusState public
+  unquoteDecl csSafetyData   csWaypoint   {-csInValidatorSet-} = mkLens (quote ConsensusState)
+             (csSafetyData ∷ csWaypoint {-∷ csInValidatorSet-} ∷ [])
+
+------------------------------------------------------------------------------
+
+  data SafetyRulesWrapper : Set where
+    SRWLocal : SafetyRules → SafetyRulesWrapper
+
+  record SafetyRulesManager : Set where
+    constructor mkSafetyRulesManager
+    field
+      _srmInternalSafetyRules : SafetyRulesWrapper
+  open SafetyRulesWrapper public
+  unquoteDecl srmInternalSafetyRules = mkLens  (quote SafetyRulesManager)
+             (srmInternalSafetyRules ∷ [])
+
+  data SafetyRulesService : Set where
+    SRSLocal : SafetyRulesService
+
+  record SafetyRulesConfig : Set where
+    constructor SafetyRulesConfig∙new
+    field
+      _srcService                     : SafetyRulesService
+      _srcExportConsensusKey          : Bool
+      _srcObmGenesisWaypoint          : Waypoint
+  open SafetyRulesConfig public
+  unquoteDecl srcService   srcExportConsensusKey   srcObmGenesisWaypoint = mkLens  (quote SafetyRulesConfig)
+             (srcService ∷ srcExportConsensusKey ∷ srcObmGenesisWaypoint ∷ [])
+
+  record ConsensusConfig : Set where
+    constructor ConsensusConfig∙new
+    field
+      _ccMaxPrunedBlocksInMem  : Usize
+      _ccRoundInitialTimeoutMS : U64
+      _ccSafetyRules           : SafetyRulesConfig
+      _ccSyncOnly              : Bool
+  open ConsensusConfig public
+  unquoteDecl ccMaxPrunedBlocksInMem   ccRoundInitialTimeoutMS   ccSafetyRules   ccSyncOnly = mkLens (quote ConsensusConfig)
+             (ccMaxPrunedBlocksInMem ∷ ccRoundInitialTimeoutMS ∷ ccSafetyRules ∷ ccSyncOnly ∷ [])
+
+  record NodeConfig : Set where
+    constructor NodeConfig∙new
+    field
+      _ncObmMe     : AuthorName
+      _ncConsensus : ConsensusConfig
+  open NodeConfig public
+  unquoteDecl ncOmbMe    ncConsensus = mkLens  (quote NodeConfig)
+             (ncOmbMe ∷  ncConsensus ∷ [])
+
+  record RecoveryManager : Set where
+    constructor RecoveryManager∙new
+    field
+      _rcmEpochState         : EpochState
+      _rcmStorage            : PersistentLivenessStorage
+    --_rcmStateComputer      : StateComputer
+      _rcmLastCommittedRound : Round
+  open RecoveryManager public
+  unquoteDecl rcmEpochState   rcmStorage {-  rcmStateComputer-}  rcmLastCommittedRound = mkLens (quote RecoveryManager)
+             (rcmEpochState ∷ rcmStorage {-∷ rcmStateComputer-} ∷ rcmLastCommittedRound ∷ [])
+
+  -- RoundProcessor  in EpochManagerTypes (because it depends on RoundManager)
+  -- EpochManager    in EpochManagerTypes (because it depends on RoundProcessor)
 
 -- ------------------------------------------------------------------------------
-
-  -- Note BlockTree and BlockStore are defined in EpochDep.agda as they depend on an EpochConfig
-
-  record SafetyData : Set where
-    constructor SafetyData∙new
-    field
-      _sdEpoch          : Epoch
-      _sdLastVotedRound : Round
-      _sdPreferredRound : Round
-      _sdLastVote       : Maybe Vote
-  open SafetyData public
-  unquoteDecl sdEpoch sdLastVotedRound sdPreferredRound sdLastVote =
-    mkLens (quote SafetyData)
-    (sdEpoch ∷ sdLastVotedRound ∷ sdPreferredRound ∷ sdLastVote ∷  [])
-
-  record Waypoint : Set where
-    constructor Waypoint∙new
-    field
-      _wVersion : Version
-      _wValue   : HashValue
-  open Waypoint public
-  unquoteDecl wVersion   wValue = mkLens (quote Waypoint)
-             (wVersion ∷ wValue ∷ [])
-  postulate instance enc-Waypoint : Encoder Waypoint
-
-  record PersistentSafetyStorage : Set where
-    constructor mkPersistentSafetyStorage
-    field
-      _pssSafetyData : SafetyData
-      _pssAuthor     : Author
-      _pssWaypoint   : Waypoint
-      _pssObmSK      : Maybe SK
-  open PersistentSafetyStorage public
-  unquoteDecl pssSafetyData   pssAuthor   pssWaypoint   pssObmSK = mkLens (quote PersistentSafetyStorage)
-             (pssSafetyData ∷ pssAuthor ∷ pssWaypoint ∷ pssObmSK ∷ [])
-
-  record ValidatorSigner : Set where
-    constructor ValidatorSigner∙new
-    field
-      _vsAuthor     : AccountAddress
-      _vsPrivateKey : SK      -- Note that the SystemModel doesn't
-                              -- allow one node to examine another's
-                              -- state, so we don't model someone being
-                              -- able to impersonate someone else unless
-                              -- PK is "dishonest", which models the
-                              -- possibility that the corresponding secret
-                              -- key may have been leaked.
-  open ValidatorSigner public
-  unquoteDecl  vsAuthor = mkLens (quote ValidatorSigner)
-              (vsAuthor ∷ [])
-
-  record ValidatorConfig : Set where
-    constructor ValidatorConfig∙new
-    field
-     _vcConsensusPublicKey : PK
-  open ValidatorConfig public
-  unquoteDecl vcConsensusPublicKey = mkLens (quote ValidatorConfig)
-    (vcConsensusPublicKey ∷ [])
-
-  record ValidatorInfo : Set where
-    constructor ValidatorInfo∙new
-    field
-      -- _viAccountAddress       : AccountAddress
-      -- _viConsensusVotingPower : Int -- TODO-2: Each validator has one vote. Generalize later.
-      _viConfig : ValidatorConfig
-  open ValidatorInfo public
-
-  data ObmNotValidProposerReason : Set where
-    ProposalDoesNotHaveAnAuthor ProposerForBlockIsNotValidForThisRound NotValidProposer : ObmNotValidProposerReason
-
-  record ProposalGenerator : Set where
-    constructor ProposalGenerator∙new
-    field
-      _pgLastRoundGenerated : Round
-  open ProposalGenerator
-  unquoteDecl pgLastRoundGenerated = mkLens (quote ProposalGenerator)
-              (pgLastRoundGenerated ∷ [])
-
-  record ProposerElection : Set where
-    constructor ProposerElection∙new
-    -- field
-      -- _peProposers : Set Author
-      -- _peObmLeaderOfRound : LeaderOfRoundFn
-      -- _peObmNodesInOrder  : NodesInOrder
-  open ProposerElection
-
-  record SafetyRules : Set where
-    constructor mkSafetyRules
-    field
-      _srPersistentStorage  : PersistentSafetyStorage
-      _srExportConsensusKey : Bool
-      _srValidatorSigner    : Maybe ValidatorSigner
-      _srEpochState         : Maybe EpochState
-  open SafetyRules public
-  unquoteDecl srPersistentStorage   srExportConsensusKey   srValidatorSigner   srEpochState = mkLens (quote SafetyRules)
-             (srPersistentStorage ∷ srExportConsensusKey ∷ srValidatorSigner ∷ srEpochState ∷ [])
-
-  record BlockRetrievalRequest : Set where
-    constructor BlockRetrievalRequest∙new
-    field
-      _brqObmFrom   : Author
-      _brqBlockId   : HashValue
-      _brqNumBlocks : U64
-  open BlockRetrievalRequest public
-  unquoteDecl brqObmFrom   brqBlockId   brqNumBlocks = mkLens (quote BlockRetrievalRequest)
-             (brqObmFrom ∷ brqBlockId ∷ brqNumBlocks ∷ [])
-  postulate instance enc-BlockRetrievalRequest : Encoder BlockRetrievalRequest
-
-  data BlockRetrievalStatus : Set where
-    BRSSucceeded BRSIdNotFound BRSNotEnoughBlocks : BlockRetrievalStatus
-  open BlockRetrievalStatus public
-  postulate instance enc-BlockRetrievalState : Encoder BlockRetrievalStatus
-
-  brs-eq : (brs₁ brs₂ : BlockRetrievalStatus) → Dec (brs₁ ≡ brs₂)
-  brs-eq BRSSucceeded       BRSSucceeded       = yes refl
-  brs-eq BRSSucceeded       BRSIdNotFound      = no λ ()
-  brs-eq BRSSucceeded       BRSNotEnoughBlocks = no λ ()
-  brs-eq BRSIdNotFound      BRSSucceeded       = no λ ()
-  brs-eq BRSIdNotFound      BRSIdNotFound      = yes refl
-  brs-eq BRSIdNotFound      BRSNotEnoughBlocks = no λ ()
-  brs-eq BRSNotEnoughBlocks BRSSucceeded       = no λ ()
-  brs-eq BRSNotEnoughBlocks BRSIdNotFound      = no λ ()
-  brs-eq BRSNotEnoughBlocks BRSNotEnoughBlocks = yes refl
-
-  instance
-    Eq-BlockRetrievalStatus : Eq BlockRetrievalStatus
-    Eq._≟_ Eq-BlockRetrievalStatus = brs-eq
-
-  record BlockRetrievalResponse : Set where
-    constructor BlockRetrievalResponse∙new
-    field
-      _brpObmFrom : (Author × Epoch × Round) -- for logging
-      _brpStatus  : BlockRetrievalStatus
-      _brpBlocks  : List Block
-  unquoteDecl brpObmFrom   brpStatus   brpBlocks   = mkLens (quote BlockRetrievalResponse)
-             (brpObmFrom ∷ brpStatus ∷ brpBlocks ∷ [])
-  postulate instance enc-BlockRetrievalResponse : Encoder BlockRetrievalResponse
 
   data VoteReceptionResult : Set where
     QCVoteAdded           : U64 →                VoteReceptionResult
@@ -1005,187 +1324,15 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
     UnexpectedRound       : Round → Round →      VoteReceptionResult
     VRR_TODO              :                      VoteReceptionResult
 
+-- ------------------------------------------------------------------------------
+
+-- LibraBFT.ImplShared.Interface.Output contains
+-- Output
+
+-- ------------------------------------------------------------------------------
+
   data VerifyError : Set where
     UnknownAuthor        : AuthorName →    VerifyError
     TooLittleVotingPower : U64 → U64 →     VerifyError
     TooManySignatures    : Usize → Usize → VerifyError
     InvalidSignature     :                 VerifyError
-
-  -- A block tree depends on a epoch config but works regardlesss of which
-  -- EpochConfig we have.
-  record BlockTree : Set where
-    constructor mkBlockTree
-    field
-      _btIdToBlock               : KVMap HashValue LinkableBlock
-      _btRootId                  : HashValue
-      _btHighestCertifiedBlockId : HashValue
-      _btHighestQuorumCert       : QuorumCert
-      _btHighestTimeoutCert      : Maybe TimeoutCertificate
-      _btHighestCommitCert       : QuorumCert
-      _btIdToQuorumCert          : KVMap HashValue QuorumCert
-      _btPrunedBlockIds          : VecDeque
-      _btMaxPrunedBlocksInMem    : ℕ
-  open BlockTree public
-  unquoteDecl btIdToBlock   btRootId  btHighestCertifiedBlockId   btHighestQuorumCert
-              btHighestTimeoutCert   btHighestCommitCert
-              btIdToQuorumCert   btPrunedBlockIds
-              btMaxPrunedBlocksInMem = mkLens (quote BlockTree)
-             (btIdToBlock ∷ btRootId ∷ btHighestCertifiedBlockId ∷ btHighestQuorumCert ∷
-              btHighestTimeoutCert ∷ btHighestCommitCert ∷
-              btIdToQuorumCert ∷ btPrunedBlockIds ∷
-              btMaxPrunedBlocksInMem ∷ [])
-
-  btGetLinkableBlock : HashValue → BlockTree → Maybe LinkableBlock
-  btGetLinkableBlock hv bt = Map.lookup hv (bt ^∙ btIdToBlock)
-
-  btGetBlock : HashValue → BlockTree → Maybe ExecutedBlock
-  btGetBlock hv bt = (_^∙ lbExecutedBlock) <$> btGetLinkableBlock hv bt
-
-  -- getter only in Haskell
-  btRoot : Lens BlockTree (Maybe ExecutedBlock)
-  btRoot = mkLens' g s
-    where
-    g : BlockTree → Maybe ExecutedBlock
-    g bt = btGetBlock (bt ^∙ btRootId) bt
-
-    -- TODO-1 : the setter is not needed/defined in Haskell
-    -- Defining it just to make progress, but it can't be defined
-    -- correctly in terms of type correctness (let alone setting a new root!)
-    s : BlockTree → Maybe ExecutedBlock → BlockTree
-    s bt _ = bt -- TODO-1 : cannot be done: need a way to defined only getters
-
-  -- getter only in haskell
-  btHighestCertifiedBlock : Lens BlockTree (Maybe ExecutedBlock)
-  btHighestCertifiedBlock = mkLens' g s
-    where
-    g : BlockTree → (Maybe ExecutedBlock)
-    g bt = btGetBlock (bt ^∙ btHighestCertifiedBlockId) bt
-
-    s : BlockTree → (Maybe ExecutedBlock) → BlockTree
-    s bt _ = bt -- TODO-1 : cannot be done: need a way to defined only getters
-
-  record LedgerStore : Set where
-    constructor mkLedgerStore
-    field
-      _lsObmVersionToEpoch : Map.KVMap Version Epoch
-      _lsObmEpochToLIWS    : Map.KVMap Epoch   LedgerInfoWithSignatures
-      _lsLatestLedgerInfo  : Maybe LedgerInfoWithSignatures
-
-  record DiemDB : Set where
-    constructor DiemDB∙new
-    field
-      _ddbLedgerStore : LedgerStore
-  open DiemDB public
-  unquoteDecl ddbLedgerStore = mkLens (quote DiemDB)
-             (ddbLedgerStore ∷ [])
-
-  data ConsensusScheme : Set where ConsensusScheme∙new : ConsensusScheme
-  -- instance S.Serialize ConsensusScheme
-
-  record ValidatorSet : Set where
-    constructor ValidatorSet∙new
-    field
-      _vsScheme  : ConsensusScheme
-      _vsPayload : List ValidatorInfo
-  -- instance S.Serialize ValidatorSet
-
-  record MockSharedStorage : Set where
-    constructor mkMockSharedStorage
-    field
-      -- Safety state
-      _mssBlock                     : Map.KVMap HashValue Block
-      _mssQc                        : Map.KVMap HashValue QuorumCert
-      _mssLis                       : Map.KVMap Version   LedgerInfoWithSignatures
-      _mssLastVote                  : Maybe Vote
-      -- Liveness state
-      _mssHighestTimeoutCertificate : Maybe TimeoutCertificate
-      _mssValidatorSet              : ValidatorSet
-  open MockSharedStorage public
-  unquoteDecl mssBlock    mssQc   mssLis    mssLastVote
-              mssHighestTimeoutCertificate  mssValidatorSet = mkLens (quote MockSharedStorage)
-             (mssBlock ∷  mssQc ∷ mssLis ∷ mssLastVote ∷
-              mssHighestTimeoutCertificate ∷ mssValidatorSet ∷ [])
-
-  record MockStorage : Set where
-    constructor MockStorage∙new
-    field
-      _msSharedStorage : MockSharedStorage
-      _msStorageLedger : LedgerInfo
-      _msObmDiemDB     : DiemDB
-  open MockStorage public
-  unquoteDecl msSharedStorage   msStorageLedger   msObmDiemDB = mkLens (quote MockStorage)
-             (msSharedStorage ∷ msStorageLedger ∷ msObmDiemDB ∷ [])
-
-  PersistentLivenessStorage = MockStorage
-
-  record OnChainConfigPayload : Set where
-    constructor OnChainConfigPayload∙new
-    field
-      _occpEpoch           : Epoch
-      _occpObmValidatorSet : ValidatorSet
-  open OnChainConfigPayload public
-  unquoteDecl occpEpoch   occpObmValidatorSet = mkLens (quote OnChainConfigPayload)
-             (occpEpoch ∷ occpObmValidatorSet ∷ [])
-  -- instance S.Serialize OnChainConfigPayload
-
-  record ReconfigEventEpochChange : Set where
-    constructor ReconfigEventEpochChange∙new
-    field
-      _reecOnChainConfigPayload : OnChainConfigPayload
-  -- instance S.Serialize ReconfigEventEpochChange
-
-  -- IMPL-DIFF : Haskell StateComputer has pluggable functions.
-  -- The Agda version just calls them directly
-  record StateComputer : Set where
-    constructor StateComputer∙new
-    field
-      _scObmVersion : Version
-  open StateComputer public
-  unquoteDecl scObmVersion = mkLens (quote StateComputer)
-             (scObmVersion ∷ [])
-
-  StateComputerComputeType
-    = StateComputer → Block → HashValue
-    → Either (List String) StateComputeResult
-
-  StateComputerCommitType
-    = StateComputer → DiemDB → ExecutedBlock → LedgerInfoWithSignatures
-    → Either (List String) (StateComputer × DiemDB × Maybe ReconfigEventEpochChange)
-
-  StateComputerSyncToType
-    = LedgerInfoWithSignatures
-    → Either (List String) ReconfigEventEpochChange
-
-  record BlockStore : Set where
-    constructor BlockStore∙new
-    field
-      _bsInner         : BlockTree
-      _bsStateComputer : StateComputer
-      _bsStorage       : PersistentLivenessStorage
-  open BlockStore public
-  unquoteDecl bsInner   bsStateComputer   bsStorage = mkLens (quote BlockStore)
-             (bsInner ∷ bsStateComputer ∷ bsStorage ∷ [])
-
-  postulate  -- TODO: stateComputer
-    stateComputer : StateComputer
-
-  -- getter only in Haskell
-  bsRoot : Lens BlockStore (Maybe ExecutedBlock)
-  bsRoot = bsInner ∙ btRoot
-
-  -- getter only in Haskell
-  bsHighestQuorumCert : Lens BlockStore QuorumCert
-  bsHighestQuorumCert = bsInner ∙ btHighestQuorumCert
-
-  -- getter only in Haskell
-  bsHighestCommitCert : Lens BlockStore QuorumCert
-  bsHighestCommitCert = bsInner ∙ btHighestCommitCert
-
-  -- getter only in Haskell
-  bsHighestTimeoutCert : Lens BlockStore (Maybe TimeoutCertificate)
-  bsHighestTimeoutCert = bsInner ∙ btHighestTimeoutCert
-
-  record LedgerRecoveryData : Set where
-    constructor LedgerRecoveryData∙new
-    field
-      _lrdStorageLedger : LedgerInfo


### PR DESCRIPTION
The main thing this PR request does is move most of the types from `EpochManagerTypes` into `EpochIndep`.

It also rearranges the existing types in `EpochIndep` to be in the same order as Haskell.

I suggest looking at the changes in commit order - because the last one just cleans up import statements and touches many files.