### PR TITLE
implement ConsensusProvider, DiemDB and LedgerStore

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -186,6 +186,10 @@ module executeAndInsertBlockE (bs0 : BlockStore) (block : Block) where
   step₄ : ExecutedBlock → VariantFor EitherD
 
   step₀ =
+    -- NOTE: if the hash is already in our blockstore, then HASH-COLLISION
+    -- because we have already confirmed the new block is for the expected round
+    -- and if there is already a block for that round then our expected round
+    -- should be higher.
     maybeSD (getBlock (block ^∙ bId) bs0) continue (pure ∘ (bs0 ,_))
 
   here' : List String.String → List String.String

--- a/LibraBFT/Impl/Consensus/ConsensusProvider.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusProvider.agda
@@ -1,0 +1,105 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Base.Types
+import      LibraBFT.Impl.Consensus.EpochManager           as EpochManager
+open import LibraBFT.Impl.Consensus.EpochManagerTypes
+import      LibraBFT.Impl.Consensus.TestUtils.MockStorage  as MockStorage
+open import LibraBFT.Impl.Types.OnChainConfig.ValidatorSet as ValidatorSet
+open import LibraBFT.Impl.Types.ValidatorSigner            as ValidatorSigner
+open import LibraBFT.Impl.Types.Waypoint                   as Waypoint
+open import LibraBFT.Impl.OBM.ConfigHardCoded              as ConfigHardCoded
+open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.Impl.OBM.Rust.RustTypes
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
+open import LibraBFT.ImplShared.Interface.Output
+open import LibraBFT.Prelude                               hiding (_++_)
+open import Optics.All
+------------------------------------------------------------------------------
+open import Data.String                                    using (String; _++_)
+
+module LibraBFT.Impl.Consensus.ConsensusProvider where
+
+NfLiwsVssVvPe =
+  (U64 × LedgerInfoWithSignatures × List ValidatorSigner × ValidatorVerifier × ProposerElection)
+
+-- IMPL-DIFF: Haskell uses panic/errorExit.  This version uses Either.
+obmInitialData
+  : AuthorName
+  → {-GenKeyFile.-}NfLiwsVssVvPe
+  → Either String (NodeConfig × OnChainConfigPayload × LedgerInfoWithSignatures × SK × ProposerElection)
+obmInitialData me ( _numFaults , genesisLIWS , validatorSigners
+                  , validatorVerifier , proposerElection ) = do
+  let vs   = ValidatorSet.obmFromVV validatorVerifier
+      occp = onChainConfigPayload vs
+  wp       ← eitherS (Waypoint.newEpochBoundary (genesisLIWS ^∙ liwsLedgerInfo))
+                     (\e → Left (here' ++ errText' e))
+                     Right
+  let nc   = nodeConfig wp
+  eitherS (ValidatorSigner.obmGetValidatorSigner (nc ^∙ ncObmMe) validatorSigners)
+          (λ e → Left (here' ++ errText' e))
+          (λ vsigner →
+            Right (nc , occp , genesisLIWS , vsigner ^∙ vsPrivateKey , proposerElection))
+ where
+  here' : String
+  here' = "ConsensusProvider.obmInitialData' "
+
+  onChainConfigPayload : ValidatorSet → OnChainConfigPayload
+  onChainConfigPayload = OnChainConfigPayload∙new ({-Epoch-} 1)
+
+  nodeConfig : Waypoint → NodeConfig
+  nodeConfig genesisWaypoint =
+    record -- NodeConfig
+    { _ncObmMe     = me
+    ; _ncConsensus = record -- ConsensusConfig
+      { _ccMaxPrunedBlocksInMem  = ConfigHardCoded.maxPrunedBlocksInMem
+      ; _ccRoundInitialTimeoutMS = ConfigHardCoded.roundInitialTimeoutMS
+      ; _ccSafetyRules           = record -- SafetyRulesConfig
+        { _srcService                     = SRSLocal
+        ; _srcExportConsensusKey          = true
+        ; _srcObmGenesisWaypoint          = genesisWaypoint
+        }
+      ; _ccSyncOnly              = false
+      }
+    }
+
+------------------------------------------------------------------------------
+
+-- LBFT-OBM-DIFF
+-- 'start_consensus' in Rust inits and loops
+-- that is split so 'startConsensus' returns init data
+-- then loop is called with that data.
+-- IMPL-DIFF: This is IO (Either ...) in Haskell.   Just Either here.
+startConsensus
+  : Instant -- IMPL-DIFF
+  → NodeConfig
+  -- BEGIN OBM
+  → OnChainConfigPayload → LedgerInfoWithSignatures → SK
+  → ObmNeedFetch → ProposalGenerator → StateComputer
+  -- END OBM
+  → Either ErrLog (EpochManager × List Output)
+startConsensus obmNow
+               nodeConfig
+               obmPayload obmGenesisLIWS obmSK
+               obmNeedFetch obmProposalGenerator obmStateComputer = do
+  let obmValidatorSet = obmPayload ^∙ occpObmValidatorSet
+  case MockStorage.startForTesting obmValidatorSet (just obmGenesisLIWS) of λ where
+    (Left e) → Left e
+    (Right (_obmRecoveryData , persistentLivenessStorage)) → do
+      let stateComputer = obmStateComputer
+      case ValidatorSet.obmGetValidatorInfo (nodeConfig ^∙ ncObmMe) obmValidatorSet of λ where
+        (Left   e) → Left e
+        (Right vi) → case EpochManager.new nodeConfig {-stateComputer-} persistentLivenessStorage
+                          (vi ^∙ viAccountAddress) obmSK of λ where
+          (Left  e)        → Left e
+          (Right epochMgr) → do
+            -- obmNow <- Time.getCurrentInstant
+            EpochManager.start
+              epochMgr obmNow
+              obmPayload obmNeedFetch obmProposalGenerator
+              obmGenesisLIWS

--- a/LibraBFT/Impl/Consensus/ConsensusProvider.agda
+++ b/LibraBFT/Impl/Consensus/ConsensusProvider.agda
@@ -81,7 +81,7 @@ startConsensus nodeConfig
     λ (_obmRecoveryData , persistentLivenessStorage) → do
       let stateComputer = obmStateComputer
       eitherS (ValidatorSet.obmGetValidatorInfo (nodeConfig ^∙ ncObmMe) obmValidatorSet) Left $
-        λ vi → eitherS (EpochManager.new nodeConfig {-stateComputer-} persistentLivenessStorage
+        λ vi → eitherS (EpochManager.new nodeConfig stateComputer persistentLivenessStorage
                           (vi ^∙ viAccountAddress) obmSK) Left $
                  λ epochMgr →
                      EpochManager.start

--- a/LibraBFT/Impl/Consensus/EpochManager.agda
+++ b/LibraBFT/Impl/Consensus/EpochManager.agda
@@ -84,16 +84,16 @@ startRoundManager'
 ------------------------------------------------------------------------------
 
 new
-  : NodeConfig → {-StateComputer →-} PersistentLivenessStorage → Author → SK
+  : NodeConfig → StateComputer → PersistentLivenessStorage → Author → SK
   → Either ErrLog EpochManager
-new nodeConfig {-stateComputer-} persistentLivenessStorage obmAuthor obmSK = do
+new nodeConfig stateComputer persistentLivenessStorage obmAuthor obmSK = do
   let -- author = node_config.validator_network.as_ref().unwrap().peer_id();
       config = nodeConfig ^∙ ncConsensus
   safetyRulesManager ← SafetyRulesManager.new (config ^∙ ccSafetyRules) obmAuthor obmSK
   pure $ mkEpochManager
     obmAuthor
     config
-    --stateComputer
+    stateComputer
     persistentLivenessStorage
     safetyRulesManager
     nothing

--- a/LibraBFT/Impl/Consensus/EpochManager.agda
+++ b/LibraBFT/Impl/Consensus/EpochManager.agda
@@ -150,8 +150,8 @@ processDifferentEpoch self obmI peerAddress peerDifferentEpoch obmPeerRound = do
   tell (PMInfo fakeInfo -- (here [ "ReceiveMessageFromDifferentEpoch", lsA peerAddress
                         --       , lsE peerDifferentEpoch, lsR obmPeerRound, logShowI obmI ])
                         ∷ [])
-  eitherSD (self ^∙ emEpoch) (λ err → do tell (PMErr (withErrCtx (here' []) err) ∷ []); pure PMContinue) $ λ epoch' →
-    --eitherSD (self ^∙ emObmRoundManager) (λ err -> do tell (PMErr (withErrCtx (here' []) err) :: []); pure PMContinue) $ λ rm →
+  eitherSD (self ^∙ emEpoch)               pmerr $ λ epoch' →
+    --eitherSD (self ^∙ emObmRoundManager) pmerr $ λ rm →
       case compare peerDifferentEpoch epoch' of λ where
         LT → do -- help nodes that have lower epoch
           -- LBFT-OBM-DIFF : not sure if this is different, but the message that causes
@@ -177,6 +177,8 @@ processDifferentEpoch self obmI peerAddress peerDifferentEpoch obmPeerRound = do
  where
   here' : List String → List String
   here' t = "EpochManager" ∷ "processDifferentEpoch" ∷ t
+  pmerr : ErrLog → EM ProcessMessageAction
+  pmerr err = do tell (PMErr (withErrCtx (here' []) err) ∷ []); pure PMContinue
 {-
   why    = show (msgType obmI)               <> "/" <>
            peerAddress^.aAuthorName          <> "/" <>
@@ -435,14 +437,12 @@ obmStartLoop self initializationOutput
              {-(CLI.FakeNetworkDelay fnd)
              (DAR.DispatchConfig _rm0 toDAR ih oh lg lc stps m)
              lbftInR-} = do
-  case self ^∙ emObmRoundManager of λ where
-    (Left   e) → (errorExit ∘ here' ∘ singleShow) e
-    (Right rm) → do
-      -- This line roughly corresponds to Rust expect_new_epoch.
-      -- It processes the output from start/startProcessor above.
-      -- TODO (rm' , to') ← DAR.runOutputHandler rm toDAR pe initializationOutput oh
-      rm'                 ← pure rm -- TEMPORARY for previous line
-      loop (setProcessor self rm') {-to'-} RSNothing
+  eitherS (self ^∙ emObmRoundManager) ee $ λ rm → do
+    -- This line roughly corresponds to Rust expect_new_epoch.
+    -- It processes the output from start/startProcessor above.
+    -- TODO (rm' , to') ← DAR.runOutputHandler rm toDAR pe initializationOutput oh
+    rm'                 ← pure rm -- TEMPORARY for previous line
+    loop (setProcessor self rm') {-to'-} RSNothing
  where
   show : ∀ {A : Set} → A → String
   show _ = ""
@@ -455,6 +455,9 @@ obmStartLoop self initializationOutput
 
   here' : List String → List String
   here' t = "EpochManager" ∷ "obmStartLoop" ∷ t
+
+  ee : ErrLog → IO Unit
+  ee = errorExit ∘ here' ∘ singleShow
 
   setProcessor : EpochManager → RoundManager → EpochManager
   setProcessor em p = em & emProcessor ?~ RoundProcessorNormal p
@@ -477,13 +480,13 @@ obmStartLoop self initializationOutput
       PMContinue →
         loop em {-to-} rlec
       (PMInput i') →
-       eitherSD (em ^∙ emObmRoundManager) (errorExit ∘ here' ∘ singleShow) $ λ rm → do
+       eitherSD (em ^∙ emObmRoundManager) ee $ λ rm → do
         --(rm'  ,    o) ← DAR.runInputHandler  rm  to pe i' ih
         --(rm'' , to'') ← DAR.runOutputHandler rm' to pe o  oh
         rm'' ← pure rm -- TEMPORARY for previous two lines
         loop (setProcessor em rm'') {-to''-} rlec
       (PMNewEpochManager em' newEpochInitializationOutput) → do
-       eitherSD (em' ^∙ emObmRoundManager) (errorExit ∘ here' ∘ singleShow) $ λ rm → do
+       eitherSD (em' ^∙ emObmRoundManager) ee $ λ rm → do
         -- (rm', to') ← DAR.runOutputHandler   rm  to pe newEpochInitializationOutput oh
         rm' ← pure rm -- TEMPORARY for previous line
         loop (setProcessor em' rm') {-to'-} rlec -- TODO Set₁ != Set

--- a/LibraBFT/Impl/Consensus/EpochManager.agda
+++ b/LibraBFT/Impl/Consensus/EpochManager.agda
@@ -151,7 +151,7 @@ processDifferentEpoch self obmI peerAddress peerDifferentEpoch obmPeerRound = do
                         --       , lsE peerDifferentEpoch, lsR obmPeerRound, logShowI obmI ])
                         ∷ [])
   eitherSD (self ^∙ emEpoch)               pmerr $ λ epoch' →
-    --eitherSD (self ^∙ emObmRoundManager) pmerr $ λ rm →
+    eitherSD (self ^∙ emObmRoundManager) pmerr $ λ rm-NotUsedInAgda-OnlyLoggingInHaskell →
       case compare peerDifferentEpoch epoch' of λ where
         LT → do -- help nodes that have lower epoch
           -- LBFT-OBM-DIFF : not sure if this is different, but the message that causes

--- a/LibraBFT/Impl/Consensus/EpochManagerTypes.agda
+++ b/LibraBFT/Impl/Consensus/EpochManagerTypes.agda
@@ -27,13 +27,13 @@ record EpochManager : Set where
   field
     _emAuthor             : Author
     _emConfig             : ConsensusConfig
-  --_emStateComputer      : StateComputer
+    _emStateComputer      : StateComputer
     _emStorage            : PersistentLivenessStorage
     _emSafetyRulesManager : SafetyRulesManager
     _emProcessor          : Maybe RoundProcessor
 open EpochManager public
-unquoteDecl emAuthor   emConfig {-  emStateComputer-}   emStorage   emSafetyRulesManager   emProcessor = mkLens (quote EpochManager)
-           (emAuthor ∷ emConfig {-∷ emStateComputer-} ∷ emStorage ∷ emSafetyRulesManager ∷ emProcessor ∷ [])
+unquoteDecl emAuthor   emConfig   emStateComputer   emStorage   emSafetyRulesManager   emProcessor = mkLens (quote EpochManager)
+           (emAuthor ∷ emConfig ∷ emStateComputer ∷ emStorage ∷ emSafetyRulesManager ∷ emProcessor ∷ [])
 
 -- getter only in Haskell
 emEpochState : Lens EpochManager (Either ErrLog EpochState)

--- a/LibraBFT/Impl/IO/OBM/GenKeyFile.agda
+++ b/LibraBFT/Impl/IO/OBM/GenKeyFile.agda
@@ -1,0 +1,14 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Impl.OBM.Rust.RustTypes
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.Prelude
+
+module LibraBFT.Impl.IO.OBM.GenKeyFile where
+
+NfLiwsVssVvPe =
+  (U64 × LedgerInfoWithSignatures × List ValidatorSigner × ValidatorVerifier × ProposerElection)

--- a/LibraBFT/Impl/OBM/ConfigHardCoded.agda
+++ b/LibraBFT/Impl/OBM/ConfigHardCoded.agda
@@ -9,9 +9,18 @@ open import LibraBFT.Impl.OBM.Rust.RustTypes
 
 module LibraBFT.Impl.OBM.ConfigHardCoded where
 
+------------------------------------------------------------------------------
+
 postulate -- TODO-1 ePOCHCHANGE
   ePOCHCHANGE : ByteString
 --ePOCHCHANGE = "EPOCHCHANGE"
 
+------------------------------------------------------------------------------
+
+maxPrunedBlocksInMem : Usize
+maxPrunedBlocksInMem = 10
+
 roundInitialTimeoutMS : U64
 roundInitialTimeoutMS = 3000
+
+------------------------------------------------------------------------------

--- a/LibraBFT/Impl/OBM/Logging/Logging.agda
+++ b/LibraBFT/Impl/OBM/Logging/Logging.agda
@@ -19,7 +19,8 @@ module LibraBFT.Impl.OBM.Logging.Logging where
 -- In the future, we may wish to model and reason about errors and logging in more detail.
 
 postulate -- TODO-1 : errText : Note, the existing Agda ErrLog constructors do not contain text.
-  errText : ErrLog → List String
+  errText  : ErrLog → List String
+  errText' : ErrLog →      String
 
 logErr : ErrLog → LBFT Unit
 logErr x = tell1 (LogErr x)

--- a/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
@@ -36,12 +36,12 @@ mAX_NUM_EPOCH_ENDING_LEDGER_INFO = 100
 -- and a flag is set to True to indicate there are more.
 getEpochEndingLedgerInfos
   : DiemDB → Epoch → Epoch
-    → Either ErrLog (List LedgerInfoWithSignatures × Bool)
+  → Either ErrLog (List LedgerInfoWithSignatures × Bool)
 getEpochEndingLedgerInfos self startEpoch endEpoch =
   getEpochEndingLedgerInfosImpl self startEpoch endEpoch mAX_NUM_EPOCH_ENDING_LEDGER_INFO
 
 -- TODO-2: provide EitherD variants before writing proofs about this function;
--- at that time, use `whenD` in place of the two `if`s below
+-- TODO-2: then use `whenD` in place of the two `if`s below
 getEpochEndingLedgerInfosImpl self startEpoch endEpoch limit = do
   if (not ⌊ (startEpoch ≤? endEpoch) ⌋)
     then

--- a/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
@@ -24,6 +24,12 @@ getLatestLedgerInfo
   → Either ErrLog LedgerInfoWithSignatures
 ------------------------------------------------------------------------------
 
+mAX_NUM_EPOCH_ENDING_LEDGER_INFO : Epoch -- Usize
+mAX_NUM_EPOCH_ENDING_LEDGER_INFO = 100
+
+------------------------------------------------------------------------------
+-- impl DiemDB
+
 module getEpochEndingLedgerInfos where
   VariantFor : ∀ {ℓ} EL → EL-func {ℓ} EL
   VariantFor EL =
@@ -41,35 +47,7 @@ module getEpochEndingLedgerInfos where
 
 getEpochEndingLedgerInfos = getEpochEndingLedgerInfos.E
 
-module saveTransactions where
-  VariantFor : ∀ {ℓ} EL → EL-func {ℓ} EL
-  VariantFor EL =
-    DiemDB {- → [TransactionToCommit] → Version-} → Maybe LedgerInfoWithSignatures
-    → EL ErrLog DiemDB
-
-  postulate -- TODO-1: saveTransactions
-    step₀ : VariantFor EitherD
-
-  E : VariantFor Either
-  E db = toEither ∘ step₀ db
-
-  D : VariantFor EitherD
-  D db = fromEither ∘ E db
-
-saveTransactions = saveTransactions.D
-
-------------------------------------------------------------------------------
-
--- TODO-1 integrate the following with the above.
-
-------------------------------------------------------------------------------
-
-mAX_NUM_EPOCH_ENDING_LEDGER_INFO : Epoch -- Usize
-mAX_NUM_EPOCH_ENDING_LEDGER_INFO = 100
-
-------------------------------------------------------------------------------
--- impl DiemDB
-
+-- TODO-2: hook this up with above
 -- Returns ledger infos for epoch changes starting with the given epoch.
 -- If there are less than `MAX_NUM_EPOCH_ENDING_LEDGER_INFO` results, it returns all of them.
 -- Otherwise the first `MAX_NUM_EPOCH_ENDING_LEDGER_INFO` results are returned
@@ -108,6 +86,7 @@ getEpochEndingLedgerInfosImpl self startEpoch endEpoch limit = do
  where
   here t = "DiemDB":"getEpochEndingLedgerInfosImpl":t
 -}
+
 ------------------------------------------------------------------------------
 
 -- impl DbReader for DiemDB
@@ -124,6 +103,24 @@ getEpochEndingLedgerInfo = LedgerStore.getEpochEndingLedgerInfo ∘ _ddbLedgerSt
 
 -- impl DbWriter for DiemDB
 
+module saveTransactions where
+  VariantFor : ∀ {ℓ} EL → EL-func {ℓ} EL
+  VariantFor EL =
+    DiemDB {- → [TransactionToCommit] → Version-} → Maybe LedgerInfoWithSignatures
+    → EL ErrLog DiemDB
+
+  postulate -- TODO-1: saveTransactions
+    step₀ : VariantFor EitherD
+
+  E : VariantFor Either
+  E db = toEither ∘ step₀ db
+
+  D : VariantFor EitherD
+  D db = fromEither ∘ E db
+
+saveTransactions = saveTransactions.D
+
+-- TODO-2: hook this up with above
 -- `first_version` is the version of the first transaction in `txns_to_commit`.
 -- When `ledger_info_with_sigs` is provided, verify that the transaction accumulator root hash
 -- it carries is generated after the `txns_to_commit` are applied.

--- a/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
@@ -62,7 +62,8 @@ getEpochEndingLedgerInfosImpl self startEpoch endEpoch limit = do
         ECP-LBFT-OBM-Diff-2.e_DiemDB_getEpochEndingLedgerInfosImpl_limit startEpoch endEpoch limit
   lis0    ← LedgerStore.getEpochEndingLedgerInfoIter (self ^∙ ddbLedgerStore) startEpoch pagingEpoch
   let lis = LedgerStore.obmEELIICollect lis0
-  if length lis + (startEpoch {-^∙ eEpoch-}) /= (pagingEpoch {-^∙ eEpoch-})
+  if -- genericLength lis /= (pagingEpoch^.eEpoch) - (startEpoch^.eEpoch)
+    length lis + (startEpoch {-^∙ eEpoch-}) /= (pagingEpoch {-^∙ eEpoch-}) -- rewritten to avoid monus
     then Left fakeErr -- [ "DB corruption: missing epoch ending ledger info"
                       -- , lsE startEpoch, lsE endEpoch, lsE pagingEpoch ]
     else pure (lis , more)

--- a/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
@@ -4,12 +4,25 @@
 -}
 
 open import LibraBFT.Base.Types
+import      LibraBFT.Impl.OBM.ECP-LBFT-OBM-Diff.ECP-LBFT-OBM-Diff-2 as ECP-LBFT-OBM-Diff-2
+import      LibraBFT.Impl.Storage.DiemDB.LedgerStore.LedgerStore    as LedgerStore
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Util.Dijkstra.EitherD
 open import LibraBFT.ImplShared.Util.Dijkstra.EitherD.Syntax
+open import LibraBFT.ImplShared.Util.Dijkstra.Syntax
 open import LibraBFT.Prelude
+open import Optics.All
 
 module LibraBFT.Impl.Storage.DiemDB.DiemDB where
+
+------------------------------------------------------------------------------
+getEpochEndingLedgerInfosImpl
+  : DiemDB → Epoch → Epoch → Epoch {-Usize-}
+  → Either ErrLog (List LedgerInfoWithSignatures × Bool)
+getLatestLedgerInfo
+  : DiemDB
+  → Either ErrLog LedgerInfoWithSignatures
+------------------------------------------------------------------------------
 
 module getEpochEndingLedgerInfos where
   VariantFor : ∀ {ℓ} EL → EL-func {ℓ} EL
@@ -44,6 +57,88 @@ module saveTransactions where
   D db = fromEither ∘ E db
 
 saveTransactions = saveTransactions.D
+
+------------------------------------------------------------------------------
+
+-- TODO-1 integrate the following with the above.
+
+------------------------------------------------------------------------------
+
+mAX_NUM_EPOCH_ENDING_LEDGER_INFO : Epoch -- Usize
+mAX_NUM_EPOCH_ENDING_LEDGER_INFO = 100
+
+------------------------------------------------------------------------------
+-- impl DiemDB
+
+-- Returns ledger infos for epoch changes starting with the given epoch.
+-- If there are less than `MAX_NUM_EPOCH_ENDING_LEDGER_INFO` results, it returns all of them.
+-- Otherwise the first `MAX_NUM_EPOCH_ENDING_LEDGER_INFO` results are returned
+-- and a flag is set to True to indicate there are more.
+getEpochEndingLedgerInfosX
+  : DiemDB → Epoch → Epoch
+  → Either ErrLog (List LedgerInfoWithSignatures × Bool)
+getEpochEndingLedgerInfosX self startEpoch endEpoch =
+  getEpochEndingLedgerInfosImpl self startEpoch endEpoch mAX_NUM_EPOCH_ENDING_LEDGER_INFO
+
+getEpochEndingLedgerInfosImpl self startEpoch endEpoch limit = do
+  if (not ⌊ (startEpoch ≤? endEpoch) ⌋)
+    then
+    (Left fakeErr {-here ["bad epoch range", lsE startEpoch, lsE endEpoch]-})
+    else pure unit
+  -- the latest epoch can be the same as the current epoch (in most cases), or
+  -- current_epoch + 1 (when the latest ledger_info carries next validator set)
+  latestEpoch ← getLatestLedgerInfo self >>= pure ∘ (_^∙  liwsLedgerInfo ∙ liNextBlockEpoch)
+  if (not ⌊ (endEpoch ≤? latestEpoch) ⌋)
+    then
+    (Left fakeErr) -- [ "unable to provide epoch change ledger info for still open epoch"
+                   -- , "asked upper bound", lsE endEpoch
+                   -- , "last sealed epoch", lsE (latestEpoch - 1) ])))
+                   -- -1 is OK because genesis LedgerInfo has .next_block_epoch() == 1
+    else pure unit
+
+  let (pagingEpoch , more) =
+        ECP-LBFT-OBM-Diff-2.e_DiemDB_getEpochEndingLedgerInfosImpl_limit startEpoch endEpoch limit
+  lis0    ← LedgerStore.getEpochEndingLedgerInfoIter (self ^∙ ddbLedgerStore) startEpoch pagingEpoch
+  let lis = LedgerStore.obmEELIICollect lis0
+  if length lis /= (pagingEpoch {-^∙ eEpoch-}) ∸ (startEpoch {-^∙ eEpoch-})
+    then Left fakeErr -- [ "DB corruption: missing epoch ending ledger info"
+                      -- , lsE startEpoch, lsE endEpoch, lsE pagingEpoch ]
+    else pure (lis , more)
+{-
+ where
+  here t = "DiemDB":"getEpochEndingLedgerInfosImpl":t
+-}
+------------------------------------------------------------------------------
+
+-- impl DbReader for DiemDB
+
+getLatestLedgerInfo self =
+  maybeS (self ^∙ ddbLedgerStore ∙ lsLatestLedgerInfo)
+         (Left fakeErr {-["DiemDB.Lib", "getLatestLedgerInfo", "Nothing"]-})
+         pure
+
+getEpochEndingLedgerInfo : DiemDB → Version → Either ErrLog LedgerInfoWithSignatures
+getEpochEndingLedgerInfo = LedgerStore.getEpochEndingLedgerInfo ∘ _ddbLedgerStore
+
+------------------------------------------------------------------------------
+
+-- impl DbWriter for DiemDB
+
+-- `first_version` is the version of the first transaction in `txns_to_commit`.
+-- When `ledger_info_with_sigs` is provided, verify that the transaction accumulator root hash
+-- it carries is generated after the `txns_to_commit` are applied.
+-- Note that even if `txns_to_commit` is empty, `frist_version` is checked to be
+-- `ledger_info_with_sigs.ledger_info.version + 1` if `ledger_info_with_sigs` is not `None`.
+-- LBFT-OBM-DIFF : entire impl
+saveTransactionsX
+  : DiemDB {- → [TransactionToCommit] → Version-} → Maybe LedgerInfoWithSignatures
+  → Either ErrLog DiemDB
+saveTransactionsX self {- txnsToCommit firstVersion-} = λ where
+  nothing     → pure self
+  (just liws) → do
+    ls <- LedgerStore.putLedgerInfo (self ^∙ ddbLedgerStore) liws
+    pure (self & ddbLedgerStore ∙~ (ls & lsLatestLedgerInfo ?~ liws))
+
 
 
 

--- a/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
@@ -75,6 +75,11 @@ getEpochEndingLedgerInfoIter self startEpoch endEpoch =
   -- TODO-2: prove endEpoch > 0
   -- Use of monus in context where it is not clear that endEpoch > 0.
   -- If not, Agda and Haskell code would behave differently.
+  -- TODO-2: IMPL-DIFF: Haskell uses a list comprehension; Agda uses homegrown 'fromToList'
+  -- The combination of monus and fromToList risks misunderstanding/misuse of fromToList later.
+  -- Ranges would differ in Haskell and Agda if, say, startEpoch were negative and endEpoch was 0.
+  -- It could be correct and verified in Agda, but wrong in Haskell
+  -- (e.g., if the Haskell code accidentally calculates a negative epoch).
   EpochEndingLedgerInfoIter∙new <$> (foldM) go [] (fromToList startEpoch (endEpoch ∸ 1))
  where
   go : List LedgerInfoWithSignatures → Epoch → Either ErrLog (List LedgerInfoWithSignatures)

--- a/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
@@ -72,8 +72,9 @@ getEpochEndingLedgerInfoIter
   : LedgerStore → Epoch → Epoch
   → Either ErrLog EpochEndingLedgerInfoIter
 getEpochEndingLedgerInfoIter self startEpoch endEpoch =
-  -- TODO-2: Use of monus in context where it is not clear that endEpoch > 0; if not,
-  -- Agda and Haskell code would behave differently, so we should prove that endEpoch > 0
+  -- TODO-2: prove endEpoch > 0
+  -- Use of monus in context where it is not clear that endEpoch > 0.
+  -- If not, Agda and Haskell code would behave differently.
   EpochEndingLedgerInfoIter∙new <$> (foldM) go [] (fromToList startEpoch (endEpoch ∸ 1))
  where
   go : List LedgerInfoWithSignatures → Epoch → Either ErrLog (List LedgerInfoWithSignatures)

--- a/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
@@ -5,13 +5,14 @@
 
 open import LibraBFT.Base.Types
 import      LibraBFT.Base.KVMap                 as Map
-open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.Impl.OBM.Logging.Logging
+open import LibraBFT.ImplShared.Consensus.Types hiding (getEpoch)
 open import LibraBFT.Prelude
+open import Optics.All
+------------------------------------------------------------------------------
+open import Data.String                         using (String)
 
 module LibraBFT.Impl.Storage.DiemDB.LedgerStore.LedgerStore where
-
-new : LedgerStore
-new = mkLedgerStore Map.empty Map.empty nothing
 
 record EpochEndingLedgerInfoIter : Set where
   constructor EpochEndingLedgerInfoIter∙new
@@ -19,10 +20,78 @@ record EpochEndingLedgerInfoIter : Set where
     _eeliiObmLIWS : List LedgerInfoWithSignatures
 open EpochEndingLedgerInfoIter public
 
-postulate
- getEpochEndingLedgerInfo     : LedgerStore → Version → Either ErrLog LedgerInfoWithSignatures
- getEpochEndingLedgerInfoIter : LedgerStore → Epoch → Epoch → Either ErrLog EpochEndingLedgerInfoIter
- putLedgerInfo                : LedgerStore → LedgerInfoWithSignatures → Either ErrLog LedgerStore
+new : LedgerStore
+new = mkLedgerStore Map.empty Map.empty nothing
+
+-- OBM-LBFT-DIFF : this entire impl file is VERY different
+
+getEpoch : LedgerStore → Version → Either ErrLog Epoch
+getEpoch self version =
+  maybeS (Map.lookup version (self ^∙ lsObmVersionToEpoch))
+         -- COMMENT FROM RUST CODE:
+         -- There should be a genesis LedgerInfo at version 0.
+         -- This normally doesn't happen.
+         -- This part of impl does not need to rely on this assumption.
+         (pure 0)
+         pure
+
+getEpochEndingLedgerInfo : LedgerStore → Version → Either ErrLog LedgerInfoWithSignatures
+getEpochEndingLedgerInfo self version = do
+  epoch ← getEpoch self version
+  case Map.lookup epoch (self ^∙ lsObmEpochToLIWS) of λ where
+    nothing   → Left fakeErr -- ["DiemDbError::NotFound", "LedgerInfo for epoch", lsE epoch]
+    (just li) →
+      grd‖ li ^∙ liwsLedgerInfo ∙ liVersion /= version ≔
+           Left fakeErr --["epoch did not end at version", lsE epoch, lsVersion version]
+         ‖ is-nothing (li ^∙ liwsLedgerInfo ∙ liNextEpochState) ≔
+           Left fakeErr -- ["not an epoch change at version", lsVersion version]
+         ‖ otherwise≔
+           pure li
+--where
+-- here t = "LedgerStore":"getEpochEndingLedgerInfo":t
+
+getEpochState : LedgerStore → Epoch → Either ErrLog EpochState
+getEpochState self epoch = do
+  lcheck (epoch >? 0) (here' ("EpochState only queryable for epoch >= 1" {-∷ lsE epoch-} ∷ []))
+  case Map.lookup (epoch ∸ 1) (self ^∙ lsObmEpochToLIWS) of λ where
+    nothing → Left fakeErr --[ "DiemDbError::NotFound"
+                           --, "last LedgerInfo of epoch", lsE (epoch - 1) ]))
+    (just ledgerInfoWithSigs) →
+      maybeS (ledgerInfoWithSigs ^∙ liwsNextEpochState)
+             (Left fakeErr) --[ "last LedgerInfo in epoch must carry nextEpochState"
+                            --, lsE epoch, lsLI (ledgerInfoWithSigs^.liwsLedgerInfo) ]
+             pure
+ where
+  here' : List String → List String
+  here' t = "LedgerStore" ∷ "getEPochState" ∷ t
+
+-- iterator that yields epoch ending ledger infos
+-- starting from `start_epoch`
+-- ends at the one before `end_epoch`
+getEpochEndingLedgerInfoIter
+  : LedgerStore → Epoch → Epoch
+  → Either ErrLog EpochEndingLedgerInfoIter
+getEpochEndingLedgerInfoIter self startEpoch endEpoch =
+  EpochEndingLedgerInfoIter∙new <$> (foldM) go [] (fromToList startEpoch (endEpoch ∸ 1))
+ where
+  go : List LedgerInfoWithSignatures → Epoch → Either ErrLog (List LedgerInfoWithSignatures)
+  go acc e = maybeS (Map.lookup e (self ^∙ lsObmEpochToLIWS))
+                    (Left fakeErr) --[ "LedgerStore", "getEpochEndingLedgerInfoIter"
+                                   --, "no LIWS for epoch", lsE e ]
+                    (λ x → Right (acc ++ (x ∷ []))) -- TODO
+
+putLedgerInfo : LedgerStore → LedgerInfoWithSignatures → Either ErrLog LedgerStore
+putLedgerInfo self ledgerInfoWithSigs =
+  let ledgerInfo = ledgerInfoWithSigs ^∙ liwsLedgerInfo
+   in pure
+    $ mkLedgerStore
+      ((if ledgerInfo ^∙ liEndsEpoch
+         then Map.insert (ledgerInfo ^∙ liVersion) (ledgerInfo ^∙ liEpoch)
+         else identity)
+       (self ^∙ lsObmVersionToEpoch))
+      (Map.insert (ledgerInfo ^∙ liEpoch) ledgerInfoWithSigs
+       (self ^∙ lsObmEpochToLIWS))
+      (self ^∙ lsLatestLedgerInfo)
 
 obmEELIICollect : EpochEndingLedgerInfoIter → List LedgerInfoWithSignatures
 obmEELIICollect = _eeliiObmLIWS

--- a/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
@@ -3,6 +3,7 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import LibraBFT.Base.Types
 import      LibraBFT.Base.KVMap                 as Map
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
@@ -11,3 +12,17 @@ module LibraBFT.Impl.Storage.DiemDB.LedgerStore.LedgerStore where
 
 new : LedgerStore
 new = mkLedgerStore Map.empty Map.empty nothing
+
+record EpochEndingLedgerInfoIter : Set where
+  constructor EpochEndingLedgerInfoIter∙new
+  field
+    _eeliiObmLIWS : List LedgerInfoWithSignatures
+open EpochEndingLedgerInfoIter public
+
+postulate
+ getEpochEndingLedgerInfo     : LedgerStore → Version → Either ErrLog LedgerInfoWithSignatures
+ getEpochEndingLedgerInfoIter : LedgerStore → Epoch → Epoch → Either ErrLog EpochEndingLedgerInfoIter
+ putLedgerInfo                : LedgerStore → LedgerInfoWithSignatures → Either ErrLog LedgerStore
+
+obmEELIICollect : EpochEndingLedgerInfoIter → List LedgerInfoWithSignatures
+obmEELIICollect = _eeliiObmLIWS

--- a/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/LedgerStore/LedgerStore.agda
@@ -72,6 +72,8 @@ getEpochEndingLedgerInfoIter
   : LedgerStore → Epoch → Epoch
   → Either ErrLog EpochEndingLedgerInfoIter
 getEpochEndingLedgerInfoIter self startEpoch endEpoch =
+  -- TODO-2: Use of monus in context where it is not clear that endEpoch > 0; if not,
+  -- Agda and Haskell code would behave differently, so we should prove that endEpoch > 0
   EpochEndingLedgerInfoIter∙new <$> (foldM) go [] (fromToList startEpoch (endEpoch ∸ 1))
  where
   go : List LedgerInfoWithSignatures → Epoch → Either ErrLog (List LedgerInfoWithSignatures)

--- a/LibraBFT/Impl/Types/OnChainConfig/ValidatorSet.agda
+++ b/LibraBFT/Impl/Types/OnChainConfig/ValidatorSet.agda
@@ -15,5 +15,6 @@ new = ValidatorSet∙new ConsensusScheme∙new
 empty : ValidatorSet
 empty = new []
 
-postulate -- TODO-1 obmFromVV
+postulate -- TODO-1 obmFromVV, obmGetValidatorInfo
   obmFromVV : ValidatorVerifier → ValidatorSet
+  obmGetValidatorInfo : AuthorName → ValidatorSet → Either ErrLog ValidatorInfo

--- a/LibraBFT/Impl/Types/ValidatorSigner.agda
+++ b/LibraBFT/Impl/Types/ValidatorSigner.agda
@@ -7,6 +7,8 @@
 open import LibraBFT.Base.Encode
 open import LibraBFT.Base.PKCS                  as PKCS hiding (sign)
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.Prelude
+open import Optics.All
 
 module LibraBFT.Impl.Types.ValidatorSigner where
 
@@ -15,3 +17,14 @@ sign (ValidatorSigner∙new _ sk) c = PKCS.sign-encodable c sk
 
 postulate -- TODO-1: publicKey_USE_ONLY_AT_INIT
   publicKey_USE_ONLY_AT_INIT : ValidatorSigner → PK
+
+obmGetValidatorSigner : AuthorName → List ValidatorSigner → Either ErrLog ValidatorSigner
+obmGetValidatorSigner name vss =
+  case List-filter go vss of λ where
+    (vs ∷ []) → pure vs
+    _         → Left fakeErr -- ["ValidatorSigner", "obmGetSigner", "TODO better err msg"]
+ where
+  go : (vs : ValidatorSigner) → Dec (vs ^∙ vsAuthor ≡ name)
+  go (ValidatorSigner∙new _vsAuthor _) = _vsAuthor ≟ name
+
+

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -244,6 +244,16 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   BlockInfo-η refl refl refl = refl
 -}
 
+  biNextBlockEpoch : Lens BlockInfo Epoch
+  biNextBlockEpoch = mkLens' g s
+   where
+    g : BlockInfo → Epoch
+    g bi = maybeS (bi ^∙ biNextEpochState)
+                  (bi ^∙ biEpoch)
+                  (  _^∙ esEpoch)
+    s : BlockInfo → Epoch → BlockInfo
+    s bi _ = bi -- TODO-1 : cannot be done: need a way to defined only getters
+
 -- ------------------------------------------------------------------------------
 
   record LedgerInfo : Set where
@@ -260,6 +270,10 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   -- GETTER only in Haskell
   liEpoch : Lens LedgerInfo Epoch
   liEpoch = liCommitInfo ∙ biEpoch
+
+  -- GETTER only in Haskell
+  liNextBlockEpoch : Lens LedgerInfo Epoch
+  liNextBlockEpoch = liCommitInfo ∙ biNextBlockEpoch
 
   -- GETTER only in Haskell
   liConsensusBlockId : Lens LedgerInfo HashValue
@@ -799,6 +813,9 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
       _lsObmVersionToEpoch : Map.KVMap Version Epoch
       _lsObmEpochToLIWS    : Map.KVMap Epoch   LedgerInfoWithSignatures
       _lsLatestLedgerInfo  : Maybe LedgerInfoWithSignatures
+  open LedgerStore public
+  unquoteDecl lsObmVersionToEpoch   lsObmEpochToLIWS   lsLatestLedgerInfo = mkLens (quote LedgerStore)
+             (lsObmVersionToEpoch ∷ lsObmEpochToLIWS ∷ lsLatestLedgerInfo ∷ [])
 
   record DiemDB : Set where
     constructor DiemDB∙new

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -121,13 +121,13 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
                               -- possibility that the corresponding secret
                               -- key may have been leaked.
   open ValidatorSigner public
-  unquoteDecl  vsAuthor = mkLens (quote ValidatorSigner)
-              (vsAuthor ∷ [])
+  unquoteDecl  vsAuthor   vsPrivateKey = mkLens (quote ValidatorSigner)
+              (vsAuthor ∷ vsPrivateKey ∷ [])
 
   record ValidatorConfig : Set where
     constructor ValidatorConfig∙new
     field
-     _vcConsensusPublicKey : PK
+      _vcConsensusPublicKey : PK
   open ValidatorConfig public
   unquoteDecl vcConsensusPublicKey = mkLens (quote ValidatorConfig)
     (vcConsensusPublicKey ∷ [])
@@ -135,10 +135,12 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   record ValidatorInfo : Set where
     constructor ValidatorInfo∙new
     field
-      -- _viAccountAddress       : AccountAddress
-      -- _viConsensusVotingPower : Int -- TODO-2: Each validator has one vote. Generalize later.
-      _viConfig : ValidatorConfig
+      _viAccountAddress       : AccountAddress
+      _viConsensusVotingPower : U64
+      _viConfig               : ValidatorConfig
   open ValidatorInfo public
+  unquoteDecl viAccountAddress   viConsensusVotingPower   viConfig = mkLens (quote ValidatorInfo)
+             (viAccountAddress ∷ viConsensusVotingPower ∷ viConfig ∷ [])
 
   record ValidatorConsensusInfo : Set where
     constructor ValidatorConsensusInfo∙new
@@ -1326,8 +1328,8 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
       _ncObmMe     : AuthorName
       _ncConsensus : ConsensusConfig
   open NodeConfig public
-  unquoteDecl ncOmbMe    ncConsensus = mkLens  (quote NodeConfig)
-             (ncOmbMe ∷  ncConsensus ∷ [])
+  unquoteDecl ncObmMe    ncConsensus = mkLens  (quote NodeConfig)
+             (ncObmMe ∷  ncConsensus ∷ [])
 
   record RecoveryManager : Set where
     constructor RecoveryManager∙new

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -604,6 +604,7 @@ module LibraBFT.Prelude where
   (x ∷ _ ) !?      0   = just x
   (_ ∷ xs) !? (suc n)  = xs !? n
 
+  -- Like a Haskell list-comprehension for ℕ : [ n | n <- [from .. to] ]
   fromToList : ℕ → ℕ → List ℕ
   fromToList from to with from ≤′? to
   ... | no ¬pr = []
@@ -612,4 +613,11 @@ module LibraBFT.Prelude where
     fromToList-le : ∀ (from to : ℕ) (klel : from ≤′ to) (acc : List ℕ) → List ℕ
     fromToList-le from ._        ≤′-refl       acc = from ∷ acc
     fromToList-le from (suc to) (≤′-step klel) acc = fromToList-le from to klel (suc to ∷ acc)
+
+  _ : fromToList 1 1 ≡ 1 ∷ []
+  _ = refl
+  _ : fromToList 1 2 ≡ 1 ∷ 2 ∷ []
+  _ = refl
+  _ : fromToList 2 1 ≡ []
+  _ = refl
 

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -603,3 +603,13 @@ module LibraBFT.Prelude where
   []       !?      _   = nothing
   (x ∷ _ ) !?      0   = just x
   (_ ∷ xs) !? (suc n)  = xs !? n
+
+  fromToList : ℕ → ℕ → List ℕ
+  fromToList from to with from ≤′? to
+  ... | no ¬pr = []
+  ... | yes pr = fromToList-le from to pr []
+   where
+    fromToList-le : ∀ (from to : ℕ) (klel : from ≤′ to) (acc : List ℕ) → List ℕ
+    fromToList-le from ._        ≤′-refl       acc = from ∷ acc
+    fromToList-le from (suc to) (≤′-step klel) acc = fromToList-le from to klel (suc to ∷ acc)
+


### PR DESCRIPTION
ConsensusProvider is used for system initialization.

DiemDB and LedgerStore are used for epoch change.

This PR is built on top of PR https://github.com/oracle/bft-consensus-agda/pull/149