### PR TITLE
Feed requirements to `insertBlockESpec` from network layer, reinstate `stateComputeResult`

### DIFF
--- a/LibraBFT/Base/KVMap.agda
+++ b/LibraBFT/Base/KVMap.agda
@@ -89,6 +89,11 @@ module LibraBFT.Base.KVMap  where
                   → (prf : lookup k kvm ≡ nothing)
                   → lookup k (kvm-insert k v kvm prf) ≡ just v
 
+   -- Haskell's insert updates the value even if the key is already in the map
+   lookup-correct-haskell
+                  : {kvm : KVMap Key Val}
+                  → lookup k (kvm-insert-Haskell k v kvm) ≡ just v
+
    lookup-correct-update
                   : {kvm : KVMap Key Val}
                   → (prf : lookup k kvm ≢ nothing)

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -197,9 +197,8 @@ module executeAndInsertBlockE (bs0 : BlockStore) (block : Block) where
       ifD btRound ≥?ℕ block ^∙ bRound
       then LeftD fakeErr -- block with old round
       else step₂ bsr
-      -- else step₂ bsr
 
-  step₂ bsr = do
+  step₂ _ = do
         eb ← case⊎D executeBlockE bs0 block of λ where
           (Right res) → RightD res
           -- OBM-LBFT-DIFF : This is never thrown in OBM.
@@ -236,7 +235,9 @@ module executeAndInsertBlockE (bs0 : BlockStore) (block : Block) where
 
 executeAndInsertBlockE = executeAndInsertBlockE.E
 
-executeBlockE bs block = do
+module executeBlockE (bs : BlockStore) (block : Block) where
+
+  step₀ = do
 -- TODO-3: hook up proper implementation (in comments below).  Requires addressing the issue that
 -- doing so breaks the existing proof of executeAndInsertBlockESpec.contract₂, which currently
 -- violates an abstraction boundary and looks into the implementation of this function, rather than
@@ -246,12 +247,15 @@ executeBlockE bs block = do
     (Right stateComputeResult) →
 -}
       pure (ExecutedBlock∙new block stateComputeResult)
- where
-  here' : List String → List String
-  here' t = "BlockStore" ∷ "executeBlockE" {-∷ lsB block-} ∷ t
+   where
+    here' : List String → List String
+    here' t = "BlockStore" ∷ "executeBlockE" {-∷ lsB block-} ∷ t
 
-executeBlockE₀ bs block = fromEither $ executeBlockE bs block
-
+abstract
+  executeBlockE = executeBlockE.step₀
+  executeBlockE₀ bs block = fromEither $ executeBlockE bs block
+  executeBlockE≡ : ∀ {bs block r} → executeBlockE bs block ≡ r → executeBlockE₀ bs block ≡ fromEither r
+  executeBlockE≡ refl = refl
 ------------------------------------------------------------------------------
 
 insertSingleQuorumCertM

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -238,15 +238,10 @@ executeAndInsertBlockE = executeAndInsertBlockE.E
 module executeBlockE (bs : BlockStore) (block : Block) where
 
   step₀ = do
--- TODO-3: hook up proper implementation (in comments below).  Requires addressing the issue that
--- doing so breaks the existing proof of executeAndInsertBlockESpec.contract₂, which currently
--- violates an abstraction boundary and looks into the implementation of this function, rather than
--- using its contract.
-{-  case SCBS.compute (bs ^∙ bsStateComputer) block (block ^∙ bParentId) of λ where
-    (Left e)                   → Left fakeErr -- (here' e)
-    (Right stateComputeResult) →
--}
-      pure (ExecutedBlock∙new block stateComputeResult)
+    case SCBS.compute (bs ^∙ bsStateComputer) block (block ^∙ bParentId) of λ where
+      (Left e)                   → Left fakeErr -- (here' e)
+      (Right stateComputeResult) →
+        pure (ExecutedBlock∙new block stateComputeResult)
    where
     here' : List String → List String
     here' t = "BlockStore" ∷ "executeBlockE" {-∷ lsB block-} ∷ t

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -91,8 +91,8 @@ module insertBlockE (block : ExecutedBlock)(bt : BlockTree) where
         nothing → LeftD fakeErr
         (just parentBlock) → (do
           parentBlock' ← addChild parentBlock blockId
-          let bt' = bt & btIdToBlock ∙~ Map.insert (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
-          pure (  (bt' & btIdToBlock ∙~ Map.insert blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
+          let bt' = bt & btIdToBlock ∙~ Map.kvm-insert-Haskell (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
+          pure (  (bt' & btIdToBlock ∙~ Map.kvm-insert-Haskell blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
                , block))
 
   E : VariantFor Either

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -44,7 +44,9 @@ module executeBlockESpec (bs : BlockStore) (block : Block) where
   postulate -- TODO: prove
     contract : (isOk : Ok) → ContractOk (proj₁ isOk)
 
-module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
+module executeAndInsertBlockESpec (bs0 : BlockStore) (vblock : ValidBlock) where
+  block   = vbBlock vblock
+  block-c = vbValid vblock
   open executeAndInsertBlockE bs0 block
 
   open import LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockTree
@@ -55,18 +57,12 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
   Ok : Set
   Ok = ∃₂ λ bs' eb → executeAndInsertBlockE bs0 block ≡ Right (bs' , eb)
 
-  private
-    Ok' : BlockStore → ExecutedBlock → Either ErrLog (BlockStore × ExecutedBlock) → Set
-    Ok' bs' eb m = m ≡ Right (bs' , eb)
-
-  Err : Set
-  Err = ∃[ e ] (executeAndInsertBlockE bs0 block ≡ Left e)
-  ------
+  open Reqs block blockId (bs0 ^∙ bsInner)
 
   record ContractOk (bs' : BlockStore) (eb : ExecutedBlock) : Set where
     constructor mkContractOk
     field
-      ebBlock≈ : eb ^∙ ebBlock ≈Block block
+      ebBlock≈ : AllValidBlocks (bs0 ^∙ bsInner) → NoHC1 → eb ^∙ ebBlock ≈Block block
       bsInv    : ∀ {eci}
                  → Preserves BlockStoreInv (bs0 , eci) (bs' , eci)
       -- executeAndInsertBlockE does not modify BlockTree fields other than btIDToBlock
@@ -76,27 +72,20 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
   Contract (Left x) = ⊤
   Contract (Right (bs' , eb)) = ContractOk bs' eb
 
-  record Requirements : Set where
-    constructor mkRequirements
-    field
-      -- This must be verified before calling
-      reqNewBlock : BlockHash-correct block blockId
-      -- NOTE: This comes from the inductive assumption that BlockStoreInv holds in the prestate.
-      -- Maybe we should just explicitly say that, and extract the needed properties here?  Or have
-      -- a corollary for that purpose?
-      reqPreBlock : ∀ {eb} → getBlock blockId bs0 ≡ just eb → ExecutedBlockHash-correct eb blockId
-  open Requirements
-
-  contract' : Requirements → EitherD-weakestPre step₀ Contract
+  -- TUTORIAL: This proof has some additional commentary helping to understand the structure of the
+  -- proof, and showing an example of how using abstract variants of functions makes proofs more
+  -- resilient to change, as explained in
+  -- https://github.com/oracle/bft-consensus-agda/blob/main/docs/PeerHandlerContracts.org
+  contract' : EitherD-weakestPre step₀ Contract
   -- step₀ is a maybeSD in context of EitherD.  Therefore, via MonadMaybeD and EitherD-MonadMaybeD,
   -- this translates to EitherD-maybe.  We first deal with the easy case.
-  proj₂ (contract' reqs) eb eb≡ =
+  proj₂ contract' eb eb≡ =
     mkContractOk ebBlock≈ id refl
     where
-    ebBlock≈ : eb ^∙ ebBlock ≈Block block
-    ebBlock≈ = hash≡⇒≈Block {b2 = block} (reqPreBlock reqs eb≡) (reqNewBlock reqs)
+    ebBlock≈ : AllValidBlocks (bs0 ^∙ bsInner) → NoHC1 → eb ^∙ ebBlock ≈Block block
+    ebBlock≈ avb _ = hash≡⇒≈Block {b2 = block} (avb eb≡) block-c
 
-  proj₁ (contract' reqs) getBlock≡nothing = contract₁
+  proj₁ contract' getBlock≡nothing = contract₁
     where
     -- step₁ is again a maybeSD; if bs0 ^∙ bsRoot ≡ nothing, the Contract is trivial
     contract₁ : EitherD-weakestPre step₁ Contract
@@ -107,27 +96,42 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
     -- in the else branch, we call step₂ bsr
     proj₂ (proj₂ contract₁ bsr bsr≡) btr<br = contract₂
       where
-      contract₃ : ∀ eb → block ≡ eb ^∙ ebBlock
+      contract₃ : ∀ eb → block ≡ (eb ^∙ ebBlock)
                   → EitherD-weakestPre (step₃ eb) Contract
 
       module EB = executeBlockESpec bs0 block
+      open EB.ContractOk
 
       contract₂ : EitherD-weakestPre (step₂ bsr) Contract
-      proj₂ contract₂ eb eb≡ ._ refl = contract₃ eb (EB.ContractOk.ebBlock≡ (EB.contract (eb , eb≡)))
+      proj₂ contract₂ eb eb≡ ._             executeBlockE≡Right@refl = let con = (EB.contract (eb , eb≡))
+                                                                       in contract₃ eb
+                                                                                    (EB.ContractOk.ebBlock≡ con)
+
       proj₁ contract₂ (ErrCBlockNotFound _) executeBlockE≡Left = tt
       proj₁ contract₂ (ErrVerify _)         executeBlockE≡Left = tt
       proj₁ contract₂ (ErrInfo _)           executeBlockE≡Left = tt
-      -- > eitherSD (pathFromRoot parentBlockId bs0) LeftD λ blocksToReexecute →
-      proj₁ (proj₁ contract₂ (ErrECCBlockNotFound parentBlockId) executeBlockE≡Left) _ _ = tt
-      -- > case⊎D (forM) blocksToReexecute (executeBlockE bs0 ∘ (_^∙ ebBlock)) of λ where
+      -- if executeBlockE returns Left (ErrECCBlockNotFound parentBlockId), then we have two casesdue to
+      -- eitherSD (pathFromRoot parentBlockId bs0) LeftD λ blocksToReexecute →
+      -- in the first case, we have a Left, so it's easy
+      proj₁        (proj₁ contract₂ (ErrECCBlockNotFound parentBlockId) executeBlockE≡Left) _ _ = tt
+      -- in the second case, we have
+      -- case⊎D (forM) blocksToReexecute (executeBlockE bs0 ∘ (_^∙ ebBlock)) of λ where
+      -- and therefore two more cases; if the case⊎D returns Left, it's easy again
       proj₁ (proj₂ (proj₁ contract₂ (ErrECCBlockNotFound parentBlockId) executeBlockE≡Left) blocksToReexecute btr≡) _ _ = tt
+      -- if the case⊎D returns a Right, we call executeBlockE₀ (the EitherD variant).  We use executeBlockE≡ to handle case
+      -- analysis on the result of calling the abstract executeBlockE variant, ensuring we must use the contract for
+      -- executeBlockE because the proof cannot "look into" the implementation of executeBlockE, which makes the proof
+      -- more resilient in case of changes in its implementation.
+      -- TODO-2: clean this up by writing a general version of the contract for executeBlockE
       proj₂ (proj₂ (proj₁ contract₂ (ErrECCBlockNotFound parentBlockId) executeBlockE≡Left) blocksToReexecute btr≡) _ _
         with  executeBlockE bs0  block | inspect
              (executeBlockE bs0) block
       ... | Left  x | [ R ] rewrite executeBlockE≡ R = tt
       ... | Right y | [ R ] rewrite executeBlockE≡ R =
         λ where c refl ._ refl →
-                  contract₃ c (EB.ContractOk.ebBlock≡ (EB.contract (c , R)))
+                  let con = EB.contract (c , R) in
+                  contract₃ c
+                            (ebBlock≡ con)
                             _ refl
 
       contract₃ eb refl _ _ = contract₄
@@ -136,8 +140,6 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
         contract₄ : EitherD-weakestPre (step₄ eb) Contract
         contract₄
            with insertBlockESpec.contract eb (bs0 ^∙ bsInner)
-                  (insertBlockESpec.mkRequirements (reqNewBlock reqs)   -- TODO: make these requirements explicitly the same?
-                                                   (reqPreBlock reqs))
         ...| con
            with BlockTree.insertBlockE.E eb (bs0 ^∙ bsInner)
         ...| Left _ = tt
@@ -154,25 +156,26 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
            bss≡x : bs0 ≡ (bs0 & bsInner ∙~ bt' & bsInner ∙ btIdToBlock ∙~ (bs0 ^∙ (bsInner ∙ btIdToBlock)))
            bss≡x rewrite sym IBE.bt≡x = refl
 
-  contract : Requirements → Contract (executeAndInsertBlockE bs0 block)
-  contract reqs = EitherD-contract (executeAndInsertBlockE.step₀ bs0 block) Contract $ contract' reqs
+  contract : Contract (executeAndInsertBlockE bs0 block)
+  contract = EitherD-contract (executeAndInsertBlockE.step₀ bs0 block) Contract contract'
 
-module executeAndInsertBlockMSpec (b : Block) where
+module executeAndInsertBlockMSpec (vb : ValidBlock) where
+  b = vbBlock vb
+
   -- NOTE: This function returns any errors, rather than producing them as output.
   module _ (pre : RoundManager) where
-
-    bs = pre ^∙ rmBlockStore
+    bs = pre ^∙ lBlockStore
 
     contract
       : ∀ Post
         → (∀ e → {- At the moment we do not need to know why it failed -} Post (Left e) pre [])
-        → ((isOk : executeAndInsertBlockESpec.Ok bs b) → let (bs' , eb , _) = isOk in
-             executeAndInsertBlockESpec.ContractOk bs b bs' eb
+        → ((isOk : executeAndInsertBlockESpec.Ok bs vb) → let (bs' , eb , _) = isOk in
+             executeAndInsertBlockESpec.ContractOk bs vb bs' eb
            → Post (Right eb) (pre & rmBlockStore ∙~ bs') [])
         → LBFT-weakestPre (executeAndInsertBlockM b) Post pre
     proj₁ (contract Post pfBail pfOk ._ refl) e ≡left = pfBail e
     proj₂ (contract Post pfBail pfOk ._ refl) (bs' , eb) ≡right ._ refl unit refl
-       with executeAndInsertBlockESpec.contract bs b (obm-dangerous-magic' "propagate requirements up")
+       with executeAndInsertBlockESpec.contract bs vb
     ...| con rewrite ≡right = pfOk (bs' , eb , refl) con
 
 module insertSingleQuorumCertMSpec

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -28,8 +28,9 @@ open Invariants
 module LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockTree where
 
 module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
-
   eb0Id = eb0 ^∙ ebId
+
+  open Reqs (eb0 ^∙ ebBlock) eb0Id bt
 
   -- This is not quite right.  It does not yet account for the updating of the parent Block
   -- Is it needed (see below)?
@@ -40,12 +41,12 @@ module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
   record ContractOk (bt“ : BlockTree) (eb : ExecutedBlock) : Set where
     constructor mkContractOk
     field
-      bt≡x       : bt ≡ (bt“ & btIdToBlock ∙~ (bt ^∙ btIdToBlock))
-      blocks≈    : eb [ _≈Block_ ]L eb0 at ebBlock
+      bt≡x    : bt ≡ (bt“ & btIdToBlock ∙~ (bt ^∙ btIdToBlock))
       -- The following two fields are not used, but something like this will be useful in proving
       -- btiPres and may provide value in their own right
       ¬upd    : ∀ {eb'} → btGetBlock eb0Id bt ≡ just eb' → bt ≡ bt“
       upd     :           btGetBlock eb0Id bt ≡ nothing  →  Updated eb0Id bt bt“ eb
+      blocks≈ : AllValidBlocks bt → NoHC1 → eb [ _≈Block_ ]L eb0 at ebBlock
       btiPres : ∀ {eci} → Preserves BlockTreeInv (bt , eci) (bt“ , eci)
 
   Contract : Either ErrLog (BlockTree × ExecutedBlock) → Set
@@ -54,18 +55,12 @@ module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
 
   open insertBlockE
 
-  record Requirements : Set where
-    constructor mkRequirements
-    field
-      reqNewBlock : ExecutedBlockHash-correct eb0 eb0Id
-      reqPreBlock : ∀ {eb} → btGetBlock eb0Id bt ≡ just eb → ExecutedBlockHash-correct eb eb0Id
-
   postulate -- TODO-1: prove using hash≡⇒≈Block; note that the contract is stronger than we need
             -- because insertBlockE is called only when btGetBlock eb0Id bt ≡ nothing in LibraBFT
-    contract' : Requirements → EitherD-weakestPre (step₀ eb0 bt) Contract
+    contract' : EitherD-weakestPre (step₀ eb0 bt) Contract
 
-  contract : Requirements → Contract (insertBlockE.E eb0 bt)
-  contract reqs = EitherD-contract (step₀ eb0 bt) Contract $ contract' reqs
+  contract : Contract (insertBlockE.E eb0 bt)
+  contract = EitherD-contract (step₀ eb0 bt) Contract contract'
 
 module insertQuorumCertESpec
   (qc : QuorumCert) (bt0  : BlockTree) where

--- a/LibraBFT/Impl/Consensus/EpochManager.agda
+++ b/LibraBFT/Impl/Consensus/EpochManager.agda
@@ -83,9 +83,9 @@ startRoundManager'
 ------------------------------------------------------------------------------
 
 new
-  : NodeConfig → {-StateComputer →-} PersistentLivenessStorage → Author → SK
+  : NodeConfig → StateComputer → PersistentLivenessStorage → Author → SK
   → Either ErrLog EpochManager
-new nodeConfig {-stateComputer-} persistentLivenessStorage obmAuthor obmSK = do
+new nodeConfig stateComputer persistentLivenessStorage obmAuthor obmSK = do
   let -- author = node_config.validator_network.as_ref().unwrap().peer_id();
       config = nodeConfig ^∙ ncConsensus
   safetyRulesManager ← SafetyRulesManager.new (config ^∙ ccSafetyRules) obmAuthor obmSK

--- a/LibraBFT/Impl/Consensus/Network/Properties.agda
+++ b/LibraBFT/Impl/Consensus/Network/Properties.agda
@@ -10,10 +10,13 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.NetworkMsg
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.Network
+open import LibraBFT.Impl.Properties.Util
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Consensus.Network.Properties where
+
+open Invariants
 
 module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : ValidatorVerifier) where
   postulate -- TODO-2: Refine contract
@@ -23,5 +26,5 @@ module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : Vali
       : case (processProposal proposal myEpoch vv) of λ where
           (Left _) → Unit
           (Right _) → proposal ^∙ pmProposal ∙ bEpoch ≡ myEpoch
-                      × hashBD (proposal ^∙ pmProposal ∙ bBlockData) ≡ proposal ^∙ pmProposal ∙ bId
+                      × BlockId-correct (proposal ^∙ pmProposal)
 

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -206,7 +206,7 @@ module executeAndVoteMSpec (b : Block) where
 
     contract
       : ∀ Post
-        → (∀ r st outs → Contract r st outs → Post r st outs)
+        → RWS-Post-⇒ Contract Post
         → LBFT-weakestPre (executeAndVoteM b) Post pre
     contract Post pf =
       RWS-⇒ Contract Post pf (executeAndVoteM b) unit pre contract'

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -183,7 +183,7 @@ module executeAndVoteMSpec (b : Block) where
                 vgc₃ bid≡ =
                   Voting.glue-VoteNotGenerated-VoteGeneratedCorrect
                     (mkVoteNotGenerated refl refl)
-                    (Voting.substVoteGeneratedCorrect proposedBlock b (EAIBECon.ebBlock≈ bid≡) vrc)
+                    (Voting.substVoteGeneratedCorrect proposedBlock b EAIBECon.ebBlock≈ vrc)
 
                 noMsgOutsBail₃ : ∀ outs → NoMsgs outs → NoMsgs (CASVouts ++ outs)
                 noMsgOutsBail₃ outs noMsgs = ++-NoMsgs CASVouts outs CASVCon.noMsgOuts noMsgs

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -637,7 +637,7 @@ module processProposalMsgMSpec
           contract-step₁ =
             ensureRoundAndSyncUpMSpec.contract now (pm ^∙ pmProposal ∙ bRound) (pm ^∙ pmSyncInfo) pAuthor true vrm
             (RWS-weakestPre-bindPost unit step₂ Contract)
-            (RWS-Post-⇒-trans pf-step₂ λ where r st outs → proj₁)
+            (RWS-Post-⇒-trans pf-step₂ λ r st outs → proj₁)
 
           -- Need to know roundManagerInv st,
           pf-step₂ r st outs con = (pf-step₂' r , vrmPost)

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -282,8 +282,8 @@ module constructAndSignVoteMSpec where
 
         -- State invariants
         module _ where
-          btip₁ : Preserves BlockTreeInv (rm→BlockTree-EC pre) (rm→BlockTree-EC preUpdatedSD)
-          btip₁ = id
+          bsip₁ : Preserves BlockStoreInv (rm→BlockStore-EC pre) (rm→BlockStore-EC preUpdatedSD)
+          bsip₁ = id
 
           emP : Preserves EpochsMatch pre preUpdatedSD
           emP eq = trans eq (Requirements.es≡₁ reqs)
@@ -313,7 +313,7 @@ module constructAndSignVoteMSpec where
               ≤-trans round≤ (≤-trans (≡⇒≤ (Requirements.lvr≡ reqs)) (<⇒≤ r>lvr))
 
           invP₁ : Preserves RoundManagerInv pre preUpdatedSD
-          invP₁ = mkPreservesRoundManagerInv id emP btip₁ srP
+          invP₁ = mkPreservesRoundManagerInv id emP bsip₁ srP
 
         -- Some lemmas
         module _ where
@@ -366,15 +366,15 @@ module constructAndSignVoteMSpec where
 
             -- State invariants
             module _ where
-              btiP₂ : Preserves BlockTreeInv (rm→BlockTree-EC pre) (rm→BlockTree-EC preUpdatedSD₂)
-              btiP₂ = id
+              bsiP₂ : Preserves BlockStoreInv (rm→BlockStore-EC pre) (rm→BlockStore-EC preUpdatedSD₂)
+              bsiP₂ = id
 
               srP₂ : Preserves SafetyRulesInv (pre ^∙ lSafetyRules) (preUpdatedSD₂ ^∙ lSafetyRules)
               srP₂ = mkPreservesSafetyRulesInv
                        (const $ mkSafetyDataInv (Requirements.es≡₂ reqs) (≡⇒≤ (cong (_^∙ bRound) pb≡vpb)))
 
               invP₂ : Preserves RoundManagerInv pre preUpdatedSD₂
-              invP₂ = mkPreservesRoundManagerInv id emP btiP₂ srP₂
+              invP₂ = mkPreservesRoundManagerInv id emP bsiP₂ srP₂
 
     contract
       : ∀ pre Post

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -42,12 +42,12 @@ module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
   initRM-correct : ValidatorVerifier-correct (initRM ^∙ rmValidatorVerifer)
-  initRM-btInv   : BlockTreeInv (rm→BlockTree-EC initRM)
+  initRM-bsInv   : BlockStoreInv (rm→BlockStore-EC initRM)
   initRM-qcs     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM
 
 initRMSatisfiesInv : RoundManagerInv initRM
 initRMSatisfiesInv =
-  mkRoundManagerInv initRM-correct refl initRM-btInv
+  mkRoundManagerInv initRM-correct refl initRM-bsInv
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
 
 invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in an `Properties.Invariants` module

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -69,7 +69,7 @@ invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest 
    = initRMSatisfiesInv
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , P pm} m∈pool ini))))
    | yes refl
-   with handleProposalSpec.Contract.rmInv $ handleProposalSpec.contract! 0 pm (msgPool pre') (peerStates pre' pid)
+   with handleProposalSpec.Contract.rmInv $ handleProposalSpec.contract! 0 pm (msgPool pre') (peerStates pre' pid , invariantsCorrect pid pre' preach)
 ...| invPres
   rewrite override-target-≡{a = pid}{b = LBFT-post (handleProposal 0 pm) (peerStates pre' pid)}{f = peerStates pre'}
   = invPres (invariantsCorrect pid pre' preach)
@@ -104,7 +104,7 @@ handlePreservesSigsB4 {nm} {pid} {pre} {sndr} preach m∈pool {qc} {v} {pk} = hy
 
    qcPost' : (nm' : NetworkMsg) → nm' ≡ nm → QCProps.∈Post⇒∈PreOr (_QC∈NM nm) hPre hPost
    qcPost' (P pm) refl = qcPost
-      where open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hPool hPre)
+      where open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hPool (hPre , invariantsCorrect pid pre preach))
    qcPost' (V vm) refl = qcPost
       where open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hPool hPre)
    qcPost' (C cm) refl qc qc∈pre = Left qc∈pre
@@ -157,7 +157,7 @@ qcVoteSigsSentB4-sps pid pre rss (step-msg{sndr , m} m∈pool ini) {qc}{v}{pk} q
    -- TODO-2: refactor for DRY
 ...| P pm = help
    where
-   hpPre = peerStates pre pid
+   hpPre = (peerStates pre pid , invariantsCorrect pid pre rss)
    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm (msgPool pre) hpPre)
 
    help : MsgWithSig∈ pk (proj₂ vs) (msgPool pre)
@@ -200,7 +200,7 @@ lastVotedRound-mono pid pre{ppost} preach ini (step-msg{_ , m} m∈pool ini₁) 
   hpPst  = LBFT-post (handleProposal 0 pm) hpPre
   hpOut  = LBFT-outs (handleProposal 0 pm) hpPre
 
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre {- hpReq -} )
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool (hpPre , invariantsCorrect pid pre preach) {- hpReq -} )
   open RoundManagerInv (invariantsCorrect pid pre preach)
 
   module VoteOld (lv≡ : hpPre ≡L hpPst at pssSafetyData-rm ∙ sdLastVote) where
@@ -268,6 +268,6 @@ qcVoteSigsSentB4-handle pid {pre} {m} {s} {acts} preach sps@(step-msg {_ , nm} m
       where
         outQcs∈RM1 : (nm' : NetworkMsg) → nm ≡ nm' → QCProps.OutputQc∈RoundManager hdOut hdPst
         outQcs∈RM1 (P pm) refl = outQcs∈RM
-          where open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hdPool hdPre)
+          where open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hdPool (hdPre , invariantsCorrect pid pre preach))
         outQcs∈RM1 (V vm) refl = outQcs∈RM
           where open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm hdPool hdPre)

--- a/LibraBFT/Impl/Properties/Common.agda
+++ b/LibraBFT/Impl/Properties/Common.agda
@@ -202,7 +202,7 @@ module ReachableSystemStateProps where
     hpPre  = peerStates st pid
     hpPos  = LBFT-post (handleProposal 0 pm) hpPre
 
-    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
+    open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool (hpPre , invariantsCorrect pid st rss))
     open ≡-Reasoning
 
   mws∈pool⇒epoch≡{pid}{v}{st = st} rss (step-msg{sndr , V vm} _ _) pcsfpk hpk sig ¬gen mws∈pool epoch≡ = begin

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -260,9 +260,15 @@ module Invariants where
   AllValidQCs : (𝓔 : EpochConfig) (bt : BlockTree) → Set
   AllValidQCs 𝓔 bt = (hash : HashValue) → maybe (WithEC.MetaIsValidQC 𝓔) ⊤ (lookup hash (bt ^∙ btIdToQuorumCert))
 
+  BlockHash-correct : Block → HashValue → Set
+  BlockHash-correct b bid = hashBD (b ^∙ bBlockData) ≡ bid
+
+
+  ExecutedBlockHash-correct : ExecutedBlock → HashValue → Set
+  ExecutedBlockHash-correct = BlockHash-correct ∘ (_^∙ ebBlock)
   ValidBlock : HashValue → ExecutedBlock → Set
   ValidBlock bid eb = eb ^∙ ebBlock ∙ bId ≡ bid
-                    × hashBD (eb ^∙ ebBlock ∙ bBlockData) ≡ bid
+                    × ExecutedBlockHash-correct eb bid
 
   AllValidBlocks : BlockTree → Set
   AllValidBlocks bt = ∀ {bid eb}

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -263,6 +263,11 @@ module Invariants where
   BlockHash-correct : Block → HashValue → Set
   BlockHash-correct b bid = hashBD (b ^∙ bBlockData) ≡ bid
 
+  postulate -- TODO-2: move somewhere sensible and prove
+    hash≡⇒≈Block : ∀ {b1 b2 : Block} {bid : HashValue}
+                   → BlockHash-correct b1 bid
+                   → BlockHash-correct b2 bid
+                   → b1 ≈Block b2
 
   ExecutedBlockHash-correct : ExecutedBlock → HashValue → Set
   ExecutedBlockHash-correct = BlockHash-correct ∘ (_^∙ ebBlock)

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -58,7 +58,7 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach sps@(step-msg{sndr , nm} m∈
 ...| refl = ⊥-elim ∘′ ¬msb4 $ qcVoteSigsSentB4-handle pid preach sps m∈acts qc∈m sig vs∈qc v≈rbld ¬gen
 
 newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vote∈vm m∈outs sig hpk ¬gen ¬msb4
-  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid)
+  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid , invariantsCorrect pid pre preach)
 ...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , voteUnsent)) sdEpoch≡?) _ _ =
   ⊥-elim (¬voteUnsent voteUnsent)
   where
@@ -247,7 +247,7 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss step@(step-peer{pre = pre} sp@(st
    rewrite sym (StepPeer-post-lemma sp)
    = absurd just v ≡ nothing case ≡pidLV of λ ()
 
-sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-honest{pid“} sps@(step-msg{sndr , m} m∈pool ini)))) {v}{v'} hpk ≡pidLV pcsfpk v'⊂m' m'∈pool sig' ¬gen ≡epoch ≡round
+sameERasLV⇒sameId{pid}{pid'}{pk}{st} (step-s rss (step-peer{pre = pre} sp@(step-honest{pid“} sps@(step-msg{sndr , m} m∈pool ini)))) {v}{v'} hpk ≡pidLV pcsfpk v'⊂m' m'∈pool sig' ¬gen ≡epoch ≡round
    with newMsg⊎msgSentB4 rss sps hpk sig' ¬gen v'⊂m' m'∈pool
 -- The message has been sent before
 ...| Right mws'
@@ -286,7 +286,7 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-ho
       hpPre  = peerStates pre pid“
       hpPos  = LBFT-post (handleProposal 0 pm) hpPre
 
-      open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm (msgPool pre) hpPre)
+      open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm (msgPool pre) (hpPre , invariantsCorrect pid“ pre rss))
         renaming (rmInv to rmInvP)
       open Invariants.RoundManagerInv (invariantsCorrect pid“ pre rss)
 
@@ -367,7 +367,7 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-ho
          ⊥-elim (<⇒≢ (NewVote.rv'<rv (vm ^∙ vmVote) lv≡v lvr< lvr≡ sdEpoch≡? blockTriggered) (sym ≡round))
 
 -- This is the origin of the message
-sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-honest{pid“} sps@(step-msg{sndr , m} m∈pool ini)))) {v}{v'} hpk ≡pidLV pcsfpk v'⊂m' m'∈pool sig' ¬gen ≡epoch ≡round
+sameERasLV⇒sameId{pid}{pid'}{pk}{st} (step-s rss (step-peer{pre = pre} sp@(step-honest{pid“} sps@(step-msg{sndr , m} m∈pool ini)))) {v}{v'} hpk ≡pidLV pcsfpk v'⊂m' m'∈pool sig' ¬gen ≡epoch ≡round
    | Left (m'∈acts , pcsfpk' , ¬msb4)
    -- So `pid“` must be `pid`
    with PeerCanSignForPKProps.pidInjective pcsfpk pcsfpk' ≡epoch
@@ -393,7 +393,7 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-ho
    sameId : ∀ m → send (V (VoteMsg∙new v' _)) ∈ outputsToActions{State = handlePre} (handleOuts m) → just v ≡ handlePst m ^∙ pssSafetyData-rm ∙ sdLastVote → v ≡L v' at vProposedId
    sameId (P pm) m'∈acts ≡pidLV = analyzeVoteAttempt
      where
-     open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm (msgPool pre) handlePre)
+     open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm (msgPool pre) (handlePre , invariantsCorrect pid pre rss))
 
      analyzeVoteAttempt : v ≡L v' at vProposedId
      analyzeVoteAttempt
@@ -431,7 +431,7 @@ votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr
 ...| refl = ⊥-elim ∘′ ¬msb $ qcVoteSigsSentB4-handle pid preach sps m∈acts qc∈m sig vs∈qc v≈rbld ¬gen
 
 votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈outs sig ¬gen ¬msb pcspkv v'⊂m' m'∈pool sig' ¬gen' eid≡
-  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid)
+  with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid , invariantsCorrect pid pre preach)
 ...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?) _ _ =
   ⊥-elim (sendVote∉actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym noVoteMsgOuts) m∈outs)
 ...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?) _ _
@@ -534,7 +534,7 @@ votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v
   hpPool = msgPool pre
   hpPre  = peerStates pre pid
   hpOut  = LBFT-outs (handleProposal 0 pm) hpPre
-  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool hpPre)
+  open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm hpPool (hpPre , invariantsCorrect pid pre rss))
 
   v≡v' : v ≡ v'
   v≡v'

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -548,9 +548,14 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   bPayload : Lens Block (Maybe TX)
   bPayload = bBlockData ∙ bdPayload
 
+  bdQcSigs : Lens Block (KVMap Author Signature)
+  bdQcSigs = bBlockData ∙ bdQuorumCert ∙ qcLedgerInfo ∙ liwsSignatures
+
+  -- Equivalence of Blocks modulo signatures (both on the Block and in the QuorumCert it contains)
   infix 4 _≈Block_
   _≈Block_ : (b₁ b₂ : Block) → Set
-  b₁ ≈Block b₂ = b₁ ≡ record b₂ { _bSignature = _bSignature b₁ }
+  b₁ ≈Block b₂ = b₁ ≡ (b₂ & bSignature ∙~ (b₁ ^∙ bSignature)
+                          & bdQcSigs   ∙~ (b₁ ^∙ bdQcSigs))
 
   sym≈Block : Symmetric _≈Block_
   sym≈Block refl = refl

--- a/LibraBFT/ImplShared/Util/Crypto.agda
+++ b/LibraBFT/ImplShared/Util/Crypto.agda
@@ -58,9 +58,16 @@ module LibraBFT.ImplShared.Util.Crypto where
       bdInjBTGen  : bd1 ^∙ bdBlockType ≡ Genesis  → bd2 ^∙ bdBlockType ≡ Genesis
       bdInjBTProp : ∀ {tx}{auth} → bd1 ^∙ bdBlockType ≡ Proposal tx auth
                                  → bd1 ^∙ bdBlockType ≡ bd2 ^∙ bdBlockType
+  postulate
+    hashBD-bs  : BlockData → BitString
+
+  hashBD : BlockData → HashValue
+  hashBD = sha256 ∘ hashBD-bs
+
+  _hasSameHashInput-BD_ : BlockData → BlockData → Set
+  bd1 hasSameHashInput-BD bd2 = hashBD-bs bd1 ≡ hashBD-bs bd2
 
   postulate
-    hashBD     : BlockData → HashValue
     hashBD-inj : ∀ {bd1 bd2}
                → hashBD bd1 ≡ hashBD bd2
                → NonInjective-≡ sha256 ⊎ BlockDataInjectivityProps bd1 bd2

--- a/LibraBFT/ImplShared/Util/Dijkstra/EitherD.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/EitherD.agda
@@ -49,6 +49,9 @@ EitherD-Pre E A = Set
 EitherD-Post : (E A : Set) → Set₁
 EitherD-Post E A = Either E A → Set
 
+EitherD-Post-⇒ : ∀ {E A : Set} → (P Q : EitherD-Post E A) → Set
+EitherD-Post-⇒ P Q = ∀ r → P r → Q r
+
 EitherD-PredTrans : (E A : Set) → Set₁
 EitherD-PredTrans E A = EitherD-Post E A → EitherD-Pre E A
 
@@ -107,3 +110,11 @@ EitherD-contract (EitherD-maybe nothing f₁ f₂) P wp =
   EitherD-contract f₁ P (proj₁ wp refl)
 EitherD-contract (EitherD-maybe (just x) f₁ f₂) P wp =
   EitherD-contract (f₂ x) P (proj₂ wp x refl)
+
+postulate -- TODO-2: prove
+  EitherD-⇒
+    : (P Q : EitherD-Post E A)
+      → (EitherD-Post-⇒ P Q)
+      → ∀ m
+      → EitherD-weakestPre m P
+      → EitherD-weakestPre m Q

--- a/LibraBFT/ImplShared/Util/Dijkstra/RWS.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/RWS.agda
@@ -104,6 +104,10 @@ RWS-Post Wr St A = (x : A) (post : St) (outs : List Wr) → Set
 RWS-Post-⇒ : (P Q : RWS-Post Wr St A) → Set
 RWS-Post-⇒ P Q = ∀ r st outs → P r st outs → Q r st outs
 
+RWS-Post-⇒-trans : {P Q R : RWS-Post Wr St A}
+                 → RWS-Post-⇒ P Q → RWS-Post-⇒ Q R → RWS-Post-⇒ P R
+RWS-Post-⇒-trans p⇒q q⇒r r st outs p = q⇒r _ _ _ (p⇒q _ _ _ p)
+
 -- RWS-weakestPre computes a predicate transformer: it maps a RWS
 -- computation `m` and desired postcondition `Post` to the weakest precondition
 -- needed to prove `P` holds after running `m`.

--- a/Optics/Functorial.agda
+++ b/Optics/Functorial.agda
@@ -72,10 +72,21 @@ module Optics.Functorial where
   _∙_ : ∀{S A B} → Lens S A → Lens A B → Lens S B
   (lens p) ∙ (lens q) = lens (λ F rf x x₁ → p F rf (q F rf x) x₁)
 
-  -- Relation between the same field of two states
+  -- Relation between the same field of two states This most general form allows us to specify a
+  -- Lens S A, a function A → B, and a relation between two B's, and holds iff the relation holds
+  -- between the values yielded by applying the Lens to two S's and then applying the function to
+  -- the results; more specific variants are provided below
+  _[_]L_f=_at_ : ∀ {ℓ} {S A B : Set} → S → (B → B → Set ℓ) → S → (A → B) → Lens S A → Set ℓ
+  s₁ [ _~_ ]L s₂ f= f at l = f (s₁ ^∙ l) ~ f (s₂ ^∙ l)
+
   _[_]L_at_ : ∀ {ℓ} {S A} → S → (A → A → Set ℓ) → S → Lens S A → Set ℓ
-  s₁ [ _~_ ]L s₂ at l = (s₁ ^∙ l) ~ (s₂ ^∙ l)
+  s₁ [ _~_ ]L s₂ at l = _[_]L_f=_at_ s₁ _~_ s₂ id l
+
+  infix 4 _≡L_f=_at_
+  _≡L_f=_at_ : ∀ {S A B : Set} → (s₁ s₂ : S) → (A → B) → Lens S A → Set
+  s₁ ≡L s₂ f= f at l = _[_]L_f=_at_ s₁ _≡_ s₂ f l
 
   infix 4 _≡L_at_
   _≡L_at_ : ∀ {S A} → (s₁ s₂ : S) → Lens S A → Set
-  _≡L_at_ = _[ _≡_ ]L_at_
+  s₁ ≡L s₂ at l = _[_]L_f=_at_ s₁ _≡_ s₂ id l
+

--- a/docs/PeerHandlerContracts.org
+++ b/docs/PeerHandlerContracts.org
@@ -473,12 +473,17 @@ abstract
     general) behaves in Agda.
 
     At the time of writing, there is no set discipline for when to use
-    =abstract= blocks. Conceivably, they could be used for *every* function,
-    since this would greatly improve the readability of the proof state for any
+    =abstract= blocks. Arguably, they should be used for *every* nontrivial function,
+    for several reasons.  First, it significantly improves the readability of the proof state for any
     peer handler contract proof. This is especially true in the instances where
     =with= or =rewrite= are used, which irrevocably normalize the proof state in
     an attempt to abstract over the given expression in both the goal type and
-    the type of (non-parameter) variables in context.
+    the type of (non-parameter) variables in context.  Second, it enforces
+    abstraction boundaries between functions, ensuring that changing the
+    implementation of a function doesn't change the shape of proofs of
+    functions that call it.  The overhead of this is that we must state and prove
+    explicit contracts for each function, but it is worth it for the sake of
+    sustainability.  For an example, see ~executeBlockESpec~ in 
 
 
 * Peer handler code


### PR DESCRIPTION
This replaces #147 and #148, connecting information validated at the network layer all the way down to the leaves of the call tree where it is needed.  This is now achieved via dependent module parameters, rather than explicitly in `Contract`s as in previous experiments; this is more readable and useable.  More specifically, we need to relate a `Block` to be inserted to its ID (specifically, a `Block`s ID should be the hash of its `BlockData`).

Other requirements concern similar properties for `Block`s stored in the `BlockTree` and the beginning of propagating assumptions about hash collisions towards a context in which they can be tied to a specific reachable system state.  A start has been made by feeding `RoundManagerInv` down the stack but this is not yet connected to assumptions about hash collisions, and is postulated (via `obm-dangerous-magic'`) for now.

This PR also:
* reinstates `stateComputeResult` and fixes and documents the proof that it previously broke.
* refines `≈Block` to also ignore differences in signatures included in `QC`s, not just the `Block` signature
* organises LibraBFT.Impl.Properties.Util` somewhat better