### PR TITLE
Streamline `EitherD` variants for `DiemDB.saveTransactions`

### DIFF
--- a/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
@@ -95,16 +95,14 @@ module saveTransactions (self  : DiemDB)
   VariantFor : ∀ {ℓ} EL → EL-func {ℓ} EL
   VariantFor EL = EL ErrLog DiemDB
 
-  step₁ : LedgerInfoWithSignatures               → VariantFor EitherD
-  step₂ : LedgerInfoWithSignatures → LedgerStore → VariantFor EitherD
+  step₁ : LedgerInfoWithSignatures → VariantFor EitherD
 
   step₀ : VariantFor EitherD
   step₀ = maybeSD mliws (LeftD fakeErr) step₁
 
-  step₁ liws =
-    eitherSD (LedgerStore.putLedgerInfo (self ^∙ ddbLedgerStore) liws) LeftD (step₂ liws)
-
-  step₂ liws ls =
+  step₁ liws = do
+         -- TODO-2: Make an EitherD variant of putLedgerInfo and make D version default
+    ls ← fromEither $ LedgerStore.putLedgerInfo (self ^∙ ddbLedgerStore) liws
     RightD (self & ddbLedgerStore ∙~ (ls & lsLatestLedgerInfo ?~ liws))
 
   E : VariantFor Either

--- a/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
@@ -98,9 +98,8 @@ module saveTransactions (self  : DiemDB)
   step₁ : LedgerInfoWithSignatures               → VariantFor EitherD
   step₂ : LedgerInfoWithSignatures → LedgerStore → VariantFor EitherD
 
-  step₀ : (mliws' : Maybe LedgerInfoWithSignatures) → mliws' ≡ mliws → VariantFor EitherD
-  step₀ nothing     refl = RightD self
-  step₀ (just liws) refl = step₁ liws
+  step₀ : VariantFor EitherD
+  step₀ = maybeSD mliws (LeftD fakeErr) step₁
 
   step₁ liws =
     eitherSD (LedgerStore.putLedgerInfo (self ^∙ ddbLedgerStore) liws) LeftD (step₂ liws)
@@ -109,7 +108,7 @@ module saveTransactions (self  : DiemDB)
     RightD (self & ddbLedgerStore ∙~ (ls & lsLatestLedgerInfo ?~ liws))
 
   E : VariantFor Either
-  E = toEither $ step₀ mliws refl
+  E = toEither step₀
 
   D : VariantFor EitherD
   D = fromEither E

--- a/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
+++ b/LibraBFT/Impl/Storage/DiemDB/DiemDB.agda
@@ -98,9 +98,9 @@ module saveTransactions (self  : DiemDB)
   step₁ : LedgerInfoWithSignatures               → VariantFor EitherD
   step₂ : LedgerInfoWithSignatures → LedgerStore → VariantFor EitherD
 
-  step₀ : VariantFor EitherD
-  step₀ =
-    maybeSD mliws (RightD self) step₁
+  step₀ : (mliws' : Maybe LedgerInfoWithSignatures) → mliws' ≡ mliws → VariantFor EitherD
+  step₀ nothing     refl = RightD self
+  step₀ (just liws) refl = step₁ liws
 
   step₁ liws =
     eitherSD (LedgerStore.putLedgerInfo (self ^∙ ddbLedgerStore) liws) LeftD (step₂ liws)
@@ -109,7 +109,7 @@ module saveTransactions (self  : DiemDB)
     RightD (self & ddbLedgerStore ∙~ (ls & lsLatestLedgerInfo ?~ liws))
 
   E : VariantFor Either
-  E = toEither step₀
+  E = toEither $ step₀ mliws refl
 
   D : VariantFor EitherD
   D = fromEither E


### PR DESCRIPTION
Modified the Haskell code for `DiemDB.saveTransactions` so we could make the Agda align better and more conveniently, then combined steps not needed because only one contains a conditional branch.