### PR TITLE
Start towards properties depending on *specific* hash collisions found by peers vs. mere *existence* of hash collisions

### DIFF
--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -28,8 +28,9 @@ open Invariants
 module LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockTree where
 
 module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
-
   eb0Id = eb0 ^∙ ebId
+
+  open Reqs (eb0 ^∙ ebBlock) bt
 
   -- This is not quite right.  It does not yet account for the updating of the parent Block
   -- Is it needed (see below)?
@@ -40,12 +41,12 @@ module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
   record ContractOk (bt“ : BlockTree) (eb : ExecutedBlock) : Set where
     constructor mkContractOk
     field
-      bt≡x       : bt ≡ (bt“ & btIdToBlock ∙~ (bt ^∙ btIdToBlock))
-      blocks≈    : eb [ _≈Block_ ]L eb0 at ebBlock
+      bt≡x    : bt ≡ (bt“ & btIdToBlock ∙~ (bt ^∙ btIdToBlock))
       -- The following two fields are not used, but something like this will be useful in proving
       -- btiPres and may provide value in their own right
       ¬upd    : ∀ {eb'} → btGetBlock eb0Id bt ≡ just eb' → bt ≡ bt“
       upd     :           btGetBlock eb0Id bt ≡ nothing  →  Updated eb0Id bt bt“ eb
+      blocks≈ : NoHC1 → eb [ _≈Block_ ]L eb0 at ebBlock
       btiPres : ∀ {eci} → Preserves BlockTreeInv (bt , eci) (bt“ , eci)
 
   Contract : Either ErrLog (BlockTree × ExecutedBlock) → Set
@@ -54,18 +55,12 @@ module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
 
   open insertBlockE
 
-  record Requirements : Set where
-    constructor mkRequirements
-    field
-      reqNewBlock : ExecutedBlockHash-correct eb0 eb0Id
-      reqPreBlock : ∀ {eb} → btGetBlock eb0Id bt ≡ just eb → ExecutedBlockHash-correct eb eb0Id
+  postulate -- TODO-1: prove; note that the contract is stronger than we need because insertBlockE
+            -- is called only when btGetBlock eb0Id bt ≡ nothing in LibraBFT
+    contract' : EitherD-weakestPre (step₀ eb0 bt) Contract
 
-  postulate -- TODO-1: prove using hash≡⇒≈Block; note that the contract is stronger than we need
-            -- because insertBlockE is called only when btGetBlock eb0Id bt ≡ nothing in LibraBFT
-    contract' : Requirements → EitherD-weakestPre (step₀ eb0 bt) Contract
-
-  contract : Requirements → Contract (insertBlockE.E eb0 bt)
-  contract reqs = EitherD-contract (step₀ eb0 bt) Contract $ contract' reqs
+  contract : Contract (insertBlockE.E eb0 bt)
+  contract = EitherD-contract (step₀ eb0 bt) Contract contract'
 
 module insertQuorumCertESpec
   (qc : QuorumCert) (bt0  : BlockTree) where

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
@@ -123,6 +123,7 @@ module addCertsMSpec
       field
         -- General invariants / properties
         rmInv         : Preserves RoundManagerInv pre post
+        dnmBtIdToBlk  : post ≡L pre at (lBlockTree ∙ btIdToBlock)
         noEpochChange : NoEpochChange pre post
         noVoteOuts    : OutputProps.NoVotes outs
         -- Voting

--- a/LibraBFT/Impl/Consensus/Network/Properties.agda
+++ b/LibraBFT/Impl/Consensus/Network/Properties.agda
@@ -10,10 +10,13 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.NetworkMsg
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.Network
+open import LibraBFT.Impl.Properties.Util
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Consensus.Network.Properties where
+
+open Invariants
 
 module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : ValidatorVerifier) where
   postulate -- TODO-2: Refine contract
@@ -23,5 +26,5 @@ module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : Vali
       : case (processProposal proposal myEpoch vv) of λ where
           (Left _) → Unit
           (Right _) → proposal ^∙ pmProposal ∙ bEpoch ≡ myEpoch
-                      × hashBD (proposal ^∙ pmProposal ∙ bBlockData) ≡ proposal ^∙ pmProposal ∙ bId
+                      × BlockId-correct (proposal ^∙ pmProposal)
 

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -282,8 +282,8 @@ module constructAndSignVoteMSpec where
 
         -- State invariants
         module _ where
-          btip₁ : Preserves BlockTreeInv (rm→BlockTree-EC pre) (rm→BlockTree-EC preUpdatedSD)
-          btip₁ = id
+          bsip₁ : Preserves BlockStoreInv (rm→BlockStore-EC pre) (rm→BlockStore-EC preUpdatedSD)
+          bsip₁ = id
 
           emP : Preserves EpochsMatch pre preUpdatedSD
           emP eq = trans eq (Requirements.es≡₁ reqs)
@@ -313,7 +313,7 @@ module constructAndSignVoteMSpec where
               ≤-trans round≤ (≤-trans (≡⇒≤ (Requirements.lvr≡ reqs)) (<⇒≤ r>lvr))
 
           invP₁ : Preserves RoundManagerInv pre preUpdatedSD
-          invP₁ = mkPreservesRoundManagerInv id emP btip₁ srP
+          invP₁ = mkPreservesRoundManagerInv id emP bsip₁ srP
 
         -- Some lemmas
         module _ where
@@ -366,15 +366,15 @@ module constructAndSignVoteMSpec where
 
             -- State invariants
             module _ where
-              btiP₂ : Preserves BlockTreeInv (rm→BlockTree-EC pre) (rm→BlockTree-EC preUpdatedSD₂)
-              btiP₂ = id
+              bsiP₂ : Preserves BlockStoreInv (rm→BlockStore-EC pre) (rm→BlockStore-EC preUpdatedSD₂)
+              bsiP₂ = id
 
               srP₂ : Preserves SafetyRulesInv (pre ^∙ lSafetyRules) (preUpdatedSD₂ ^∙ lSafetyRules)
               srP₂ = mkPreservesSafetyRulesInv
                        (const $ mkSafetyDataInv (Requirements.es≡₂ reqs) (≡⇒≤ (cong (_^∙ bRound) pb≡vpb)))
 
               invP₂ : Preserves RoundManagerInv pre preUpdatedSD₂
-              invP₂ = mkPreservesRoundManagerInv id emP btiP₂ srP₂
+              invP₂ = mkPreservesRoundManagerInv id emP bsiP₂ srP₂
 
     contract
       : ∀ pre Post

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -42,12 +42,12 @@ module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
   initRM-correct : ValidatorVerifier-correct (initRM ^∙ rmValidatorVerifer)
-  initRM-btInv   : BlockTreeInv (rm→BlockTree-EC initRM)
+  initRM-bsInv   : BlockStoreInv (rm→BlockStore-EC initRM)
   initRM-qcs     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM
 
 initRMSatisfiesInv : RoundManagerInv initRM
 initRMSatisfiesInv =
-  mkRoundManagerInv initRM-correct refl initRM-btInv
+  mkRoundManagerInv initRM-correct refl initRM-bsInv
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
 
 invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in an `Properties.Invariants` module
@@ -215,9 +215,21 @@ lastVotedRound-mono pid pre{ppost} preach ini (step-msg{_ , m} m∈pool ini₁) 
     help : Meta.getLastVoteRound (hpPre ^∙ pssSafetyData-rm) ≤ Meta.getLastVoteRound (hpPst ^∙ pssSafetyData-rm)
     help = ≤-trans (SafetyDataInv.lvRound≤ ∘ SafetyRulesInv.sdInv $ rmSafetyRulesInv ) (≤-trans (<⇒≤ lvr<) (≡⇒≤ (trans (sym lvr≡) $ cong (maybe {B = const ℕ} (_^∙ vRound) 0) lv≡v)))
 
+  open Invariants
+  open Reqs (pm ^∙ pmProposal) (hpPre ^∙ lBlockTree)
+  open BlockTreeInv
+  open BlockStoreInv
+  open RoundManagerInv
+
+  rmi : _
+  rmi = invariantsCorrect pid pre preach
+
   help : Meta.getLastVoteRound (hpPre ^∙ pssSafetyData-rm) ≤ Meta.getLastVoteRound (hpPst ^∙ pssSafetyData-rm)
   help
-    with voteAttemptCorrect
+    with BlockId-correct? (pm ^∙ pmProposal)
+  ...| no ¬validProposal = VoteOld.help (cong (_^∙ pssSafetyData-rm ∙ sdLastVote) (proj₁ $ invalidProposal ¬validProposal))
+  ...| yes pmIdCorr
+       with voteAttemptCorrect pmIdCorr (nohc preach m∈pool pid ini rmi refl pmIdCorr)
   ...| Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?
     with nvg⊎vgusc
   ...| inj₁ (mkVoteNotGenerated lv≡ lvr≤) = VoteOld.help lv≡
@@ -226,6 +238,7 @@ lastVotedRound-mono pid pre{ppost} preach ini (step-msg{_ , m} m∈pool ini₁) 
   ...| inj₁ (mkVoteOldGenerated lvr≡ lv≡) = VoteOld.help lv≡
   ...| inj₂ (mkVoteNewGenerated lvr< lvr≡) = VoteNew.help lv≡v lvr< lvr≡
   help
+     | yes refl
      | Voting.mkVoteAttemptCorrectWithEpochReq (Right (Voting.mkVoteSentCorrect vm _ _ (Voting.mkVoteGeneratedCorrect (mkVoteGenerated lv≡v voteSrc) _))) sdEpoch≡?
     with voteSrc
   ...| Left (mkVoteOldGenerated lvr≡ lv≡) = VoteOld.help lv≡

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -44,14 +44,18 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
 
   module _ (pool : SentMessages) (pre : RoundManager) where
 
+    open Invariants.Reqs (pm ^∙ pmProposal) (pre ^∙ lBlockTree)
+
     record Contract (_ : Unit) (post : RoundManager) (outs : List Output) : Set where
       constructor mkContract
       field
         -- General properties / invariants
         rmInv              : Preserves RoundManagerInv pre post
+        invalidProposal    : ¬ (BlockId-correct (pm ^∙ pmProposal)) → pre ≡ post × OutputProps.NoVotes outs
         noEpochChange      : NoEpochChange pre post
         -- Voting
-        voteAttemptCorrect : Voting.VoteAttemptCorrectWithEpochReq pre post outs (pm ^∙ pmProposal)
+        voteAttemptCorrect : BlockId-correct (pm ^∙ pmProposal)
+                           → NoHC1 → Voting.VoteAttemptCorrectWithEpochReq pre post outs (pm ^∙ pmProposal)
         -- QCs
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
         qcPost    : QCProps.∈Post⇒∈PreOr (_QC∈NM (P pm)) pre post
@@ -68,12 +72,12 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
 
       contractBail : ∀ outs → OutputProps.NoMsgs outs → Contract unit pre outs
       contractBail outs noMsgs =
-        mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
+        mkContract reflPreservesRoundManagerInv (const $ refl , OutputProps.NoMsgs⇒NoVotes outs noMsgs) (reflNoEpochChange{pre})
           vac outQcs∈RM qcPost
         where
-        vac : Voting.VoteAttemptCorrectWithEpochReq pre pre outs (pm ^∙ pmProposal)
-        vac = Voting.mkVoteAttemptCorrectWithEpochReq
-                (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs noMsgs)) tt
+        vac : BlockId-correct (pm ^∙ pmProposal) → NoHC1 → Voting.VoteAttemptCorrectWithEpochReq pre pre outs (pm ^∙ pmProposal)
+        vac _ _ = Voting.mkVoteAttemptCorrectWithEpochReq
+                    (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs noMsgs)) tt
 
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs pre
         outQcs∈RM = QCProps.NoMsgs⇒OutputQc∈RoundManager outs pre noMsgs
@@ -87,30 +91,32 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
       proj₁ (contract-step₁ (myEpoch@._ , vv@._) refl) (inj₂ i) pp≡Left =
         contractBail _ refl
       proj₂ (contract-step₁ (myEpoch@._ , vv@._) refl) unit pp≡Right =
-        processProposalMsgMSpec.contract now pm pre Contract pf
+        processProposalMsgMSpec.contract now pm proposalId≡ pre Contract pf
         where
-        module PPM = processProposalMsgMSpec now pm
 
         sdEpoch≡ : pre ^∙ pssSafetyData-rm ∙ sdEpoch ≡ pm ^∙ pmProposal ∙ bEpoch
         sdEpoch≡
           with processProposalSpec.contract pm myEpoch vv
         ...| con rewrite pp≡Right = sym (proj₁ con)
 
-        proposalId≡ : hashBD (pm ^∙ pmProposal ∙ bBlockData) ≡ pm ^∙ pmProposal ∙ bId
+        proposalId≡ : BlockId-correct (pm ^∙ pmProposal)
         proposalId≡
            with processProposalSpec.contract pm myEpoch vv
         ...| con rewrite pp≡Right = proj₂ con
 
+        module PPM = processProposalMsgMSpec now pm proposalId≡
+
         pf : RWS-Post-⇒ (PPM.Contract pre) Contract
         pf unit st outs con =
-          mkContract PPMSpec.rmInv PPMSpec.noEpochChange
+          mkContract PPMSpec.rmInv (λ x → ⊥-elim (x proposalId≡)) PPMSpec.noEpochChange
             vac PPMSpec.outQcs∈RM PPMSpec.qcPost
           where
           module PPMSpec = processProposalMsgMSpec.Contract con
 
-          vac : Voting.VoteAttemptCorrectWithEpochReq pre st outs (pm ^∙ pmProposal)
-          vac = Voting.mkVoteAttemptCorrectWithEpochReq (PPMSpec.voteAttemptCorrect proposalId≡)
-                  (Voting.voteAttemptEpochReq! (PPMSpec.voteAttemptCorrect proposalId≡) sdEpoch≡)
+          vac : BlockId-correct (pm ^∙ pmProposal) → NoHC1
+              → Voting.VoteAttemptCorrectWithEpochReq pre st outs (pm ^∙ pmProposal)
+          vac _ nohc = Voting.mkVoteAttemptCorrectWithEpochReq (PPMSpec.voteAttemptCorrect nohc)
+                         (Voting.voteAttemptEpochReq! (PPMSpec.voteAttemptCorrect nohc) sdEpoch≡)
 
     contract! : LBFT-Post-True Contract (handleProposal now pm) pre
     contract! = LBFT-contract (handleProposal now pm) Contract pre contract

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -359,6 +359,14 @@ module Invariants where
       rmSafetyRulesInv : SafetyRulesInv (rm ^∙ lSafetyRules)
   open RoundManagerInv
 
+  module Reqs (b : Block) (bt : BlockTree) where
+    -- TODO: State and use assumptions about hash collisions.  The following is one example that will
+    -- likely need to be refined.
+    NoHC1 = ∀ {eb}
+            → btGetBlock (b ^∙ bId) bt ≡ just eb
+            → BlockId-correct b
+            → (eb ^∙ ebBlock) ≈Block b
+
 
   -- Valid blocks have IDs computed by the hash of their BlockData
   -- These are passed as module parameters through the proofs

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -24,6 +24,7 @@ open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
 open import Optics.All
 
+open import LibraBFT.ImplShared.Util.HashCollisions InitAndHandlers
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open        ParamsWithInitAndHandlers InitAndHandlers
 open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers PeerCanSignForPK PeerCanSignForPK-stable
@@ -38,6 +39,9 @@ module Meta where
   getLastVoteRound : SafetyData → Round
   getLastVoteRound = (maybe{B = const Round} (_^∙ vRound) 0) ∘ (_^∙ sdLastVote)
   -- getLastVoteRound = maybe{B = const Round} (_^∙ vRound) 0 ∘ (_^∙ pssSafetyData-rm ∙ sdLastVote)
+
+  subst-getLastVoteRound : ∀ {sd1 sd2} → sd1 ≡ sd2 → getLastVoteRound sd1 ≡ getLastVoteRound sd2
+  subst-getLastVoteRound refl = refl
 
 module OutputProps where
   module _ (outs : List Output) where
@@ -90,33 +94,18 @@ module OutputProps where
     |       nv
     |       ov = refl
 
+
+module BlockProps (b : Block) where
+  ∈BlockTree_      : BlockTree → Set
+  ∈BlockTree bt    = ∃[ eb ] (btGetBlock (b ^∙ bId) bt ≡ just eb)
+
+  ∈BlockStore_     : BlockStore → Set
+  ∈BlockStore bs   = ∈BlockTree (bs ^∙ bsInner)
+
+  ∈RoundManager_   : RoundManager → Set
+  ∈RoundManager rm = ∈BlockStore (rm ^∙ lBlockStore)
+
 module QCProps where
-
-  record MsgRequirements (pool : SentMessages) (msg : NetworkMsg) : Set where
-    constructor mkMsgRequirements
-    field
-      mSndr  : NodeId
-      m∈pool : (mSndr , msg) ∈ pool
-
-  record SyncInfoRequirements (pool : SentMessages) (syncInfo : SyncInfo) : Set where
-    constructor mkSyncInfoRequirements
-    field
-      msg     : NetworkMsg
-      msgReqs : MsgRequirements pool msg
-      syncInfo∈msg : syncInfo SyncInfo∈NM msg
-    open MsgRequirements msgReqs
-
-  record BlockRequirements (pool : SentMessages) (block : Block) : Set where
-    constructor mkBlockRequirements
-    field
-      msg       : NetworkMsg
-      msgReqs   : MsgRequirements pool msg
-      block∈msg : block Block∈Msg msg
-
-  QCRequirements : (pool : SentMessages) (qc : QuorumCert) → Set
-  QCRequirements pool qc =
-    ∃[ si ] (qc QC∈SyncInfo si × SyncInfoRequirements pool si)
-    ⊎ ⊥ -- TODO: qc came from aggregated votes received by proposer
 
   data _∈BlockTree_ (qc : QuorumCert) (bt : BlockTree) : Set where
     inHQC : qc ≡ bt ^∙ btHighestQuorumCert → qc ∈BlockTree bt
@@ -256,29 +245,36 @@ module QCProps where
     MsgWithSig∈-++ʳ{ms = msgs} (sfvb4 qc∈rm sig vs∈qc rbld≈v ¬gen)
 
 module Invariants where
+
+  ------------ properties relating the ids of (Executed)Blocks to hashes of their BlockData
+
+  BlockHash≡ : Block → HashValue → Set
+  BlockHash≡ b hv =  hashBlock b ≡ hv
+
+  BlockId-correct : Block → Set
+  BlockId-correct b = BlockHash≡ b (b ^∙ bId)
+
+  BlockId-correct? : (b : Block) → Dec (BlockId-correct b)
+  BlockId-correct? b = hashBlock b ≟Hash (b ^∙ bId)
+
+  ExecutedBlockId-correct : ExecutedBlock → Set
+  ExecutedBlockId-correct = BlockId-correct ∘ (_^∙ ebBlock)
+
+  ------------ properties for BlockTree validity
+
   -- The property that a block tree `bt` has only valid QCs with respect to epoch config `𝓔`
   AllValidQCs : (𝓔 : EpochConfig) (bt : BlockTree) → Set
   AllValidQCs 𝓔 bt = (hash : HashValue) → maybe (WithEC.MetaIsValidQC 𝓔) ⊤ (lookup hash (bt ^∙ btIdToQuorumCert))
 
-  BlockHash-correct : Block → HashValue → Set
-  BlockHash-correct b bid = hashBD (b ^∙ bBlockData) ≡ bid
-
-  postulate -- TODO-2: move somewhere sensible and prove
-    hash≡⇒≈Block : ∀ {b1 b2 : Block} {bid : HashValue}
-                   → BlockHash-correct b1 bid
-                   → BlockHash-correct b2 bid
-                   → b1 ≈Block b2
-
-  ExecutedBlockHash-correct : ExecutedBlock → HashValue → Set
-  ExecutedBlockHash-correct = BlockHash-correct ∘ (_^∙ ebBlock)
-  ValidBlock : HashValue → ExecutedBlock → Set
-  ValidBlock bid eb = eb ^∙ ebBlock ∙ bId ≡ bid
-                    × ExecutedBlockHash-correct eb bid
+  -- TODO: define a record?
+  ValidEValidBlock         = Σ Block         BlockId-correct
 
   AllValidBlocks : BlockTree → Set
   AllValidBlocks bt = ∀ {bid eb}
                     → btGetBlock bid bt ≡ just eb
-                    → ValidBlock bid eb
+                    → BlockId-correct (eb ^∙ ebBlock) × BlockHash≡ (eb ^∙ ebBlock)  bid
+
+  ------------ types for and definitions of invariants for BlockTree, BlockStore, SafetyData, SafetyRules
 
   record ECinfo : Set where
     constructor mkECinfo
@@ -287,20 +283,11 @@ module Invariants where
       ecEP : Epoch
   open ECinfo
 
-  rm→ECinfo : RoundManager → ECinfo
-  rm→ECinfo rm = mkECinfo (rm ^∙ rmEpochState ∙ esVerifier) (rm ^∙ rmEpoch)
-
   WithECinfo : Set → Set
   WithECinfo A = A × ECinfo
 
   BlockTree-EC  = WithECinfo BlockTree
   BlockStore-EC = WithECinfo BlockStore
-
-  rm→BlockTree-EC : RoundManager → BlockTree-EC
-  rm→BlockTree-EC rm = (rm ^∙ lBlockStore ∙ bsInner , rm→ECinfo rm)
-
-  rm→BlockStore-EC : RoundManager → BlockStore-EC
-  rm→BlockStore-EC rm = (rm ^∙ lBlockStore , rm→ECinfo rm)
 
   module _ (btEC : BlockTree-EC) where
     private
@@ -314,7 +301,7 @@ module Invariants where
       field
         allValidQCs    : (vvC : ValidatorVerifier-correct $ vv) → AllValidQCs (α-EC-VV (vv , vvC) ep) bt
         allValidBlocks : AllValidBlocks bt
-    open BlockTreeInv
+  open BlockTreeInv
 
   module _ (bsEC : BlockStore-EC) where
     private
@@ -325,7 +312,7 @@ module Invariants where
       constructor mkBlockStoreInv
       field
         blockTreeValid : BlockTreeInv (bs ^∙ bsInner , eci)
-    open BlockTreeInv
+  open BlockStoreInv
 
   module _ (sd : SafetyData) where
     -- SafetyRules invariants
@@ -343,24 +330,48 @@ module Invariants where
         sdInv : SafetyDataInv (sr ^∙ srPersistentStorage ∙ pssSafetyData)
   open SafetyRulesInv
 
-  module _ (rm : RoundManager) where
+  ------------ types for and definition of RoundManagerInv
 
-    EpochsMatch : Set
-    EpochsMatch = rm ^∙ rmEpochState ∙ esEpoch ≡ rm ^∙ pssSafetyData-rm ∙ sdEpoch
+  EpochsMatch : RoundManager → Set
+  EpochsMatch rm = rm ^∙ rmEpochState ∙ esEpoch ≡ rm ^∙ pssSafetyData-rm ∙ sdEpoch
 
-    -- NOTE: This will be proved by induction on reachable states using the
-    -- property that peer handlers preserve invariants. That is to say, many of
-    -- these cannot be proven as a post-condition of the peer handler: one can
-    -- only prove of the handler that if the invariant holds for the prestate,
-    -- then it holds for the poststate.
+  rm→ECinfo : RoundManager → ECinfo
+  rm→ECinfo rm = mkECinfo (rm ^∙ rmEpochState ∙ esVerifier) (rm ^∙ rmEpoch)
 
-    record RoundManagerInv : Set where
-      constructor mkRoundManagerInv
-      field
-        rmCorrect        : ValidatorVerifier-correct (rm ^∙ rmValidatorVerifer)
-        rmEpochsMatch    : EpochsMatch
-        rmBlockTreeInv   : BlockTreeInv (rm→BlockTree-EC rm)
-        rmSafetyRulesInv : SafetyRulesInv (rm ^∙ lSafetyRules)
+  rm→BlockTree-EC : RoundManager → BlockTree-EC
+  rm→BlockTree-EC rm = (rm ^∙ lBlockStore ∙ bsInner , rm→ECinfo rm)
+
+  rm→BlockStore-EC : RoundManager → BlockStore-EC
+  rm→BlockStore-EC rm = (rm ^∙ lBlockStore , rm→ECinfo rm)
+
+  -- NOTE: This will be proved by induction on reachable states using the
+  -- property that peer handlers preserve invariants. That is to say, many of
+  -- these cannot be proven as a post-condition of the peer handler: one can
+  -- only prove of the handler that if the invariant holds for the prestate,
+  -- then it holds for the poststate.
+
+  record RoundManagerInv (rm : RoundManager) : Set where
+    constructor mkRoundManagerInv
+    field
+      rmCorrect        : ValidatorVerifier-correct (rm ^∙ rmValidatorVerifer)
+      rmEpochsMatch    : EpochsMatch rm
+      rmBlockStoreInv  : BlockStoreInv  (rm→BlockStore-EC rm)
+      rmSafetyRulesInv : SafetyRulesInv (rm ^∙ lSafetyRules)
+  open RoundManagerInv
+
+
+  -- Valid blocks have IDs computed by the hash of their BlockData
+  -- These are passed as module parameters through the proofs
+
+  ValidBlock = Σ Block BlockId-correct
+
+  vbBlock : ValidBlock → Block
+  vbBlock = proj₁
+
+  vbValid : (vb : ValidBlock) → BlockId-correct (vbBlock vb)
+  vbValid = proj₂
+
+  ------------ Preserves and related definitions and utilities
 
   Preserves : ∀ {ℓ} {A : Set} → (P : A → Set ℓ) (pre post : A) → Set ℓ
   Preserves Pred pre post = Pred pre → Pred post
@@ -405,7 +416,7 @@ module Invariants where
     : ∀ {pre post}
       → Preserves ValidatorVerifier-correct (pre ^∙ rmValidatorVerifer) (post ^∙ rmValidatorVerifer)
       → Preserves EpochsMatch                pre                         post
-      → Preserves BlockTreeInv              (rm→BlockTree-EC pre)       (rm→BlockTree-EC post)
+      → Preserves BlockStoreInv             (rm→BlockStore-EC pre)      (rm→BlockStore-EC post)
       → Preserves SafetyRulesInv            (pre ^∙ rmSafetyRules)      (post ^∙ rmSafetyRules)
       → Preserves RoundManagerInv            pre                         post
   mkPreservesRoundManagerInv rmP emP bsP srP (mkRoundManagerInv rmCorrect epochsMatch bsInv srInv) =
@@ -533,6 +544,8 @@ module RoundManagerTransProps where
 
 -- Properties for voting
 module Voting where
+
+  open Invariants
 
   VoteEpochIs : (vote : Vote) (e : Epoch) → Set
   VoteEpochIs vote e = vote ^∙ vEpoch ≡ e

--- a/LibraBFT/ImplShared/Util/Dijkstra/RWS.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/RWS.agda
@@ -104,6 +104,10 @@ RWS-Post Wr St A = (x : A) (post : St) (outs : List Wr) → Set
 RWS-Post-⇒ : (P Q : RWS-Post Wr St A) → Set
 RWS-Post-⇒ P Q = ∀ r st outs → P r st outs → Q r st outs
 
+RWS-Post-⇒-trans : {P Q R : RWS-Post Wr St A}
+                 → RWS-Post-⇒ P Q → RWS-Post-⇒ Q R → RWS-Post-⇒ P R
+RWS-Post-⇒-trans p⇒q q⇒r r st outs p = q⇒r _ _ _ (p⇒q _ _ _ p)
+
 -- RWS-weakestPre computes a predicate transformer: it maps a RWS
 -- computation `m` and desired postcondition `Post` to the weakest precondition
 -- needed to prove `P` holds after running `m`.

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -300,7 +300,26 @@ module LibraBFT.Prelude where
     using (_∪?_)
     public
 
-  -- Evidence that a function is not injective
+  -- Injectivity for a function of two potentially different types (A and B) via functions to a
+  -- common type (C).
+
+  Injective' : ∀ {b c d e}{B : Set b}{C : Set c}{D : Set d} → (hB : B → D) → (hC : C → D) → (_≈_ : B → C → Set e) → Set _
+  Injective' {C = C} hB hC _≈_ = ∀ {b c} → hB b ≡ hC c → b ≈ c
+
+  Injective  : ∀ {c d e}{C : Set c}{D : Set d} → (h : C → D) → (_≈_ : Rel C e) → Set _
+  Injective h _≈_ = Injective' h h _≈_
+
+  Injective-≡ : ∀ {c d}{C : Set c}{D : Set d} → (h : C → D) → Set _
+  Injective-≡ h = Injective h _≡_
+
+  Injective-int : ∀{a b c d e}{A : Set a}{B : Set b}{C : Set c}{D : Set d}
+                → (_≈_ : A → B → Set e)
+                → (h  : C → D)
+                → (f₁ : A → C)
+                → (f₂ : B → C)
+                → Set (a ℓ⊔ b ℓ⊔ d ℓ⊔ e)
+  Injective-int _≈_ h f₁ f₂ = ∀ {a₁} {b₁} → h (f₁ a₁) ≡ h (f₂ b₁) → a₁ ≈ b₁
+
   NonInjective : ∀{a b c}{A : Set a}{B : Set b}
                → (_≈_ : Rel A c)
                → (A → B) → Set (a ℓ⊔ b ℓ⊔ c)

--- a/Optics/Functorial.agda
+++ b/Optics/Functorial.agda
@@ -72,10 +72,21 @@ module Optics.Functorial where
   _∙_ : ∀{S A B} → Lens S A → Lens A B → Lens S B
   (lens p) ∙ (lens q) = lens (λ F rf x x₁ → p F rf (q F rf x) x₁)
 
-  -- Relation between the same field of two states
+  -- Relation between the same field of two states This most general form allows us to specify a
+  -- Lens S A, a function A → B, and a relation between two B's, and holds iff the relation holds
+  -- between the values yielded by applying the Lens to two S's and then applying the function to
+  -- the results; more specific variants are provided below
+  _[_]L_f=_at_ : ∀ {ℓ} {S A B : Set} → S → (B → B → Set ℓ) → S → (A → B) → Lens S A → Set ℓ
+  s₁ [ _~_ ]L s₂ f= f at l = f (s₁ ^∙ l) ~ f (s₂ ^∙ l)
+
   _[_]L_at_ : ∀ {ℓ} {S A} → S → (A → A → Set ℓ) → S → Lens S A → Set ℓ
-  s₁ [ _~_ ]L s₂ at l = (s₁ ^∙ l) ~ (s₂ ^∙ l)
+  s₁ [ _~_ ]L s₂ at l = _[_]L_f=_at_ s₁ _~_ s₂ id l
+
+  infix 4 _≡L_f=_at_
+  _≡L_f=_at_ : ∀ {S A B : Set} → (s₁ s₂ : S) → (A → B) → Lens S A → Set
+  s₁ ≡L s₂ f= f at l = _[_]L_f=_at_ s₁ _≡_ s₂ f l
 
   infix 4 _≡L_at_
   _≡L_at_ : ∀ {S A} → (s₁ s₂ : S) → Lens S A → Set
-  _≡L_at_ = _[ _≡_ ]L_at_
+  s₁ ≡L s₂ at l = _[_]L_f=_at_ s₁ _≡_ s₂ id l
+


### PR DESCRIPTION
So far, our proofs depend on an assumption that hash collisions don't exist.  But they do!  We have required hash collisions to be put in context of a `ReachableSystemState` just to remind ourselves that we cannot assume lack of hash collisions "for free".  But this did not mean much because nothing connected the specific hash collisions to that `ReachableSystemState`.

This PR makes the first steps towards doing so, dealing with one important class of potential hash collisions: those on `BlockId`s, requiring properties to depend only on the assumption that these hash collisions do not exist in the specific state for which a property is proved.  This is achieved by defining a notion of a hash being in the state (e.g., a `Proposal` that has the same hash as a `Block` already stored in the `BlockTree`, but with different `BlockData`.  See `LibraBFT.ImplShared.Util.HashCollisions.HashCollisionFound`.

This requires us to capture the fact that we validate new `Proposal`s "off the wire" before handling them, and propagate this information "down the stack" in order to connect it with an assumption that a hash collision does not exist *in the `ReachableSystemState` in which the `Proposal` is handled.  This validity of `Proposal`s is propagated down via module parameters, and the lack of hash collisions is propagated through arguments to the specific contract properties that require them.

There is room for improvement streamlining this, especially in `LibraBFT.Impl.Properties.VotesOnce`.  There are also still a number of uses of `meta-sha256-cr`, which does not tie the hash collision to the `ReachableSystemState`.  Addressing these will likely require the addition of more kinds of specific hash collision.  When we have eliminated all uses of `meta-sha256-cr`, and proved all properties, we will then know that we have a precise and narrow summary of the possible hash collisions, the absence of which our proofs require.