### PR TITLE
initialization

### DIFF
--- a/LibraBFT/Base/KVMap.agda
+++ b/LibraBFT/Base/KVMap.agda
@@ -59,6 +59,8 @@ module LibraBFT.Base.KVMap  where
    elems          : KVMap Key Val → List Val
    delete         : Key → KVMap Key Val → KVMap Key Val
    singleton      : Key → Val → KVMap Key Val
+   fromList       : List (Key × Val) → KVMap Key Val
+   toList         : KVMap Key Val    → List (Key × Val)
 
    -- TODO-3: update properties to reflect kvm-update, consider combining insert/update
    kvm-update     : (k : Key)(v : Val)(kvm : KVMap Key Val)

--- a/LibraBFT/Impl/Consensus/EpochManager.agda
+++ b/LibraBFT/Impl/Consensus/EpochManager.agda
@@ -283,19 +283,19 @@ startRoundManager' self now recoveryData epochState0 obmNeedFetch obmProposalGen
     findFirstErr : List Output → Maybe ErrLog
     findFirstErr = λ where
       []              → nothing
-      (LogErr e ∷ xs) → just e
+      (LogErr e ∷  _) → just e
       (_        ∷ xs) → findFirstErr xs
 
 startProcessor self now payload obmNeedFetch obmProposalGenerator obmLedgerInfoWithSignatures = do
   let validatorSet = payload ^∙ occpObmValidatorSet
-      epochState0  = EpochState∙new (payload ^∙ occpEpoch) (ValidatorVerifier.from validatorSet)
+  vv               ← ValidatorVerifier.from validatorSet
+  let epochState0  = EpochState∙new (payload ^∙ occpEpoch) vv
       -- OBM TODO case storage.start of RecoveryData | LedgerRecoveryData
   (initialData , _pls)
                    ← MockStorage.startForTesting validatorSet
                                                  (just obmLedgerInfoWithSignatures)
   startRoundManager self now initialData epochState0 obmNeedFetch obmProposalGenerator
                     (obmLedgerInfoWithSignatures ^∙ liwsLedgerInfo ∙ liVersion)
-
 
 processMessage
   : EpochManager → Instant → Input

--- a/LibraBFT/Impl/Consensus/EpochManager.agda
+++ b/LibraBFT/Impl/Consensus/EpochManager.agda
@@ -117,8 +117,8 @@ createRoundState self now =
 
 createProposerElection : EpochState → ProposerElection
 createProposerElection epochState0 =
-  ProposerElection∙new -- TODO-1
-  -- (ValidatorVerifier.getOrderedAccountAddressesObmTODO (epochState0 ^∙ esVerifier))
+  ProposerElection∙new
+  (ValidatorVerifier.getOrderedAccountAddressesObmTODO (epochState0 ^∙ esVerifier))
 
 processEpochRetrieval
   : EpochManager {-Text-} → EpRRqWire → AccountAddress → EM ProcessMessageAction

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -16,7 +16,7 @@ open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Hash
 import      LibraBFT.Impl.Consensus.Liveness.RoundState as RoundState
 open import LibraBFT.Impl.IO.OBM.InputOutputHandlers
-open import LibraBFT.Impl.OBM.Init
+import      LibraBFT.Impl.OBM.Init                      as Init
 open import LibraBFT.Impl.OBM.Time
 open import LibraBFT.Impl.Consensus.RoundManager
 open import LibraBFT.ImplShared.Consensus.Types
@@ -61,12 +61,12 @@ initSR =
 initPG : ProposalGenerator
 initPG = ProposalGenerator∙new 0
 
-postulate -- TODO-1: Implement initPe, initBS
+postulate -- TODO-1: Implement initPE, initBS
   initPE : ProposerElection
   initBS : BlockStore
 
 initRS : RoundState
-initRS = RoundState.new etiT timeT
+initRS = Init.rsT
 
 initRM : RoundManager
 initRM = RoundManager∙new
@@ -74,10 +74,11 @@ initRM = RoundManager∙new
            (EpochState∙new 1 (initVV genesisInfo))
            initBS initRS initPE initPG initSR false
 
--- Eventually, the initialization should establish some properties we care about, but for now we
--- just initialise again to fakeRM, which means we cannot prove the base case for various
--- properties, e.g., in Impl.Properties.VotesOnce
--- TODO: create real RoundManager using GenesisInfo
+-- Eventually, the initialization should establish properties we care about.
+-- For now we just initialise to fakeRM.
+-- That means we cannot prove the base case for various properties,
+-- e.g., in Impl.Properties.VotesOnce
+-- TODO: create real RoundManager using LibraBFT.Impl.IO.OBM.Start
 initialRoundManagerAndMessages
   : (a : Author) → GenesisInfo
   → RoundManager × List NetworkMsg

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -75,15 +75,16 @@ initRM = RoundManager∙new
            initBS initRS initPE initPG initSR false
 
 postulate
-  nfLiwsVssVvPe : GenKeyFile.NfLiwsVssVvPe
   now           : Instant
   pg            : ProposalGenerator
-  me            : AuthorName
 
 initRMWithOutput : Either ErrLog (RoundManager × List Output)
 initRMWithOutput = do
-  (em , out) ← Init.initialize me nfLiwsVssVvPe now ObmNeedFetch∙new pg
-  rm         ← em ^∙ emObmRoundManager
+  (nf , _ , vss , vv , pe , liws) ← GenKeyFile.create 1 (0 ∷ 1 ∷ 2 ∷ 3 ∷ [])
+  let nfLiwsVssVvPe               = (nf , liws , vss , vv , pe)
+      me                          = 0
+  (em , out)                      ← Init.initialize me nfLiwsVssVvPe now ObmNeedFetch∙new pg
+  rm                              ← em ^∙ emObmRoundManager
   pure (rm , out)
 
 initRM' : RoundManager

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -80,20 +80,19 @@ postulate
   pg            : ProposalGenerator
   me            : AuthorName
 
-initRMWithOutput : RoundManager × List Output
-initRMWithOutput =
-  case Init.initialize me nfLiwsVssVvPe now ObmNeedFetch∙new pg of λ where
-    (Left  _)          → err
-    (Right (em , out)) →
-      case em ^∙ emObmRoundManager of λ where
-        (Left   _) → err
-        (Right rm) → (rm , out)
- where
-  err : RoundManager × List Output
-  err = (fakeRM , [])
+initRMWithOutput : Either ErrLog (RoundManager × List Output)
+initRMWithOutput = do
+  (em , out) ← Init.initialize me nfLiwsVssVvPe now ObmNeedFetch∙new pg
+  rm         ← em ^∙ emObmRoundManager
+  pure (rm , out)
 
 initRM' : RoundManager
-initRM' = fst initRMWithOutput
+initRM' = case initRMWithOutput of λ where
+  (Left _)         → initRM
+  (Right (rm , _)) → rm
+
+genQC : QuorumCert
+genQC = initRM' ^∙ rmBlockStore ∙ bsInner ∙ btHighestQuorumCert
 
 -- Eventually, the initialization should establish properties we care about.
 -- For now we just initialise to fakeRM.

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -38,25 +38,19 @@ open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHan
 open Invariants
 open RoundManagerTransProps
 
+-- TODO-2 : pass in RoundManager (instead of using 'initRM')
+-- and the proof that the RoundManager is valid.
 module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
   initRM-correct  : ValidatorVerifier-correct (initRM  ^∙ rmValidatorVerifer)
-  initRM-correct' : ValidatorVerifier-correct (initRM' ^∙ rmValidatorVerifer)
   initRM-btInv    : BlockTreeInv (rm→BlockTree-EC initRM)
-  initRM-btInv'   : BlockTreeInv (rm→BlockTree-EC initRM')
   initRM-qcs      : QCProps.SigsForVotes∈Rm-SentB4 [] initRM
-  initRM-qcs'     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM'
 
 initRMSatisfiesInv : RoundManagerInv initRM
 initRMSatisfiesInv =
   mkRoundManagerInv initRM-correct refl initRM-btInv
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
-
--- initRMSatisfiesInv' : RoundManagerInv initRM'
--- initRMSatisfiesInv' =
---   mkRoundManagerInv initRM-correct' {!!} initRM-btInv'
---     (mkSafetyRulesInv (mkSafetyDataInv {!!} {!!}))
 
 invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in an `Properties.Invariants` module
   : ∀ pid (pre : SystemState)

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -41,14 +41,22 @@ open RoundManagerTransProps
 module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
-  initRM-correct : ValidatorVerifier-correct (initRM ^∙ rmValidatorVerifer)
-  initRM-btInv   : BlockTreeInv (rm→BlockTree-EC initRM)
-  initRM-qcs     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM
+  initRM-correct  : ValidatorVerifier-correct (initRM  ^∙ rmValidatorVerifer)
+  initRM-correct' : ValidatorVerifier-correct (initRM' ^∙ rmValidatorVerifer)
+  initRM-btInv    : BlockTreeInv (rm→BlockTree-EC initRM)
+  initRM-btInv'   : BlockTreeInv (rm→BlockTree-EC initRM')
+  initRM-qcs      : QCProps.SigsForVotes∈Rm-SentB4 [] initRM
+  initRM-qcs'     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM'
 
 initRMSatisfiesInv : RoundManagerInv initRM
 initRMSatisfiesInv =
   mkRoundManagerInv initRM-correct refl initRM-btInv
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
+
+-- initRMSatisfiesInv' : RoundManagerInv initRM'
+-- initRMSatisfiesInv' =
+--   mkRoundManagerInv initRM-correct' {!!} initRM-btInv'
+--     (mkSafetyRulesInv (mkSafetyDataInv {!!} {!!}))
 
 invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in an `Properties.Invariants` module
   : ∀ pid (pre : SystemState)

--- a/LibraBFT/Impl/IO/OBM/GenKeyFile.agda
+++ b/LibraBFT/Impl/IO/OBM/GenKeyFile.agda
@@ -4,11 +4,65 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import LibraBFT.Base.PKCS
 open import LibraBFT.Impl.OBM.Rust.RustTypes
+open import LibraBFT.Impl.OBM.Util
+open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 
 module LibraBFT.Impl.IO.OBM.GenKeyFile where
 
+EndpointAddress           = NodeId
+AddressToSkAndPkAssocList = List (EndpointAddress × (SK × PK))
+
+------------------------------------------------------------------------------
+genKeys   : {-Crypto.SystemDRG →-} ℕ   → List (SK × PK)
+mkAuthors : {-Crypto.SystemDRG →-} U64 → List EndpointAddress
+          → Either ErrLog AddressToSkAndPkAssocList
+-- mkValidatorSignersAndVerifierAndProposerElection
+--           : U64 → AddressToSkAndAuthorAssocList
+--           → (List ValidatorSigner × ValidatorVerifier × ProposerElection)
+------------------------------------------------------------------------------
+
 NfLiwsVssVvPe =
   (U64 × LedgerInfoWithSignatures × List ValidatorSigner × ValidatorVerifier × ProposerElection)
+
+-- create
+--   : U64 → List EndpointAddress {-→ SystemDRG-}
+--   → Either ErrLog -- IMPL-DIFF : Haskell does errorExit
+--     ( U64 × AddressToSkAndPkAssocList
+--     × List ValidatorSigner × ValidatorVerifier × ProposerElection × LedgerInfoWithSignatures )
+-- create numFailures addresses {-drg-} = do
+--    let authors     = mkAuthors {-drg-} numFailures addresses
+--    {!!}
+--       (s ,vv ,pe) = mkValidatorSignersAndVerifierAndProposerElection
+--                       numFailures
+--                       (convertSkPkToSkAuthorAssocList authors)
+--     -------------------------
+--    in case Genesis.obmMkGenesisLedgerInfoWithSignatures s (ValidatorSet.obmFromVV vv) of
+--         Left err   → errorExit (errText err)
+--         Right liws → (numFailures , authors , s , vv , pe , liws)
+
+mkAuthors {-drg-} numFailures0 addresses0 = do
+  addrs <- checkAddresses
+  checkBftAndRun numFailures0 addrs f
+ where
+  f : ℕ → List EndpointAddress → AddressToSkAndPkAssocList
+  f _numFailures addresses = zip addresses (genKeys {-drg-} (length addresses))
+  checkAddresses : Either ErrLog (List EndpointAddress)
+  checkAddresses = pure addresses0
+
+postulate
+  mkSK : NodeId → SK
+  mkPK : NodeId → PK
+genKeys    zero   = []
+genKeys x@(suc n) = (mkSK x , mkPK x) ∷ genKeys n
+
+-- mkValidatorSignersAndVerifierAndProposerElection numFaults ks =
+--   let allAuthors          = fmap (snd . snd) ks
+--       validatorVerifier   = ValidatorVerifier.initValidatorVerifier numFaults allAuthors
+--       authorKeyPairs      = fmap (\(_, (sk, a)) → (a, sk)) ks
+--       go acc (author, sk) = ValidatorSigner.new author sk : acc
+--       validatorSigners    = foldl' go [] authorKeyPairs
+--    in (validatorSigners, validatorVerifier, ProposerElection.new allAuthors)

--- a/LibraBFT/Impl/IO/OBM/Start.agda
+++ b/LibraBFT/Impl/IO/OBM/Start.agda
@@ -43,12 +43,12 @@ startViaConsensusProvider
   : Instant
   → AuthorName
   → GenKeyFile.NfLiwsVssVvPe
-  → TxTypeDependentStuff
+  → TxTypeDependentStuffForNetwork
   → Either ErrLog (EpochManager × List Output)
 startViaConsensusProvider now me nfLiwsVssVvPe txTDS = do
   let onf                       = ObmNeedFetch.newNetwork {-stps'-}
   (nc , occp , liws , sk , _pe) ← ConsensusProvider.obmInitialData me nfLiwsVssVvPe
   ConsensusProvider.startConsensus
     nc now occp liws sk onf
-    (txTDS ^∙ ttdsProposalGenerator) (txTDS ^∙ ttdsStateComputer)
+    (txTDS ^∙ ttdsnProposalGenerator) (txTDS ^∙ ttdsnStateComputer)
 

--- a/LibraBFT/Impl/OBM/Genesis.agda
+++ b/LibraBFT/Impl/OBM/Genesis.agda
@@ -1,0 +1,39 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+import      LibraBFT.Impl.Types.CryptoProxies              as CryptoProxies
+import      LibraBFT.Impl.Types.LedgerInfo                 as LedgerInfo
+import      LibraBFT.Impl.Types.LedgerInfoWithSignatures   as LedgerInfoWithSignatures
+import      LibraBFT.Impl.Types.ValidatorSigner            as ValidatorSigner
+import      LibraBFT.Impl.Types.ValidatorVerifier          as ValidatorVerifier
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
+open import LibraBFT.Prelude
+open import Optics.All
+
+module LibraBFT.Impl.OBM.Genesis where
+
+------------------------------------------------------------------------------
+
+obmMkLedgerInfoWithEpochState : ValidatorSet → Either ErrLog LedgerInfo
+
+------------------------------------------------------------------------------
+
+obmMkGenesisLedgerInfoWithSignatures
+  : List ValidatorSigner → ValidatorSet → Either ErrLog LedgerInfoWithSignatures
+obmMkGenesisLedgerInfoWithSignatures vss0 vs0 = do
+  liwes    ← obmMkLedgerInfoWithEpochState vs0
+  let sigs = fmap (λ vs → (vs ^∙ vsAuthor , ValidatorSigner.sign vs liwes)) vss0
+  pure $ foldl' (λ acc (a , sig) → CryptoProxies.addToLi a sig acc)
+                (LedgerInfoWithSignatures.obmNewNoSigs liwes)
+                sigs
+
+obmMkLedgerInfoWithEpochState vs = do
+  li ← LedgerInfo.mockGenesis (just vs)
+  vv ← ValidatorVerifier.from vs
+  pure (li
+         & liCommitInfo ∙ biNextEpochState
+        ?~ EpochState∙new (li ^∙ liEpoch) vv)

--- a/LibraBFT/Impl/OBM/Init.agda
+++ b/LibraBFT/Impl/OBM/Init.agda
@@ -4,25 +4,32 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+import      LibraBFT.Impl.Consensus.ConsensusProvider                as ConsensusProvider
+open import LibraBFT.Impl.Consensus.EpochManagerTypes
 import      LibraBFT.Impl.Consensus.Liveness.RoundState              as RoundState
 import      LibraBFT.Impl.Consensus.Liveness.ExponentialTimeInterval as ExponentialTimeInterval
+import      LibraBFT.Impl.IO.OBM.GenKeyFile                          as GenKeyFile
 import      LibraBFT.Impl.OBM.ConfigHardCoded                        as ConfigHardCoded
 open import LibraBFT.Impl.OBM.Rust.Duration                          as Duration
 open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.Impl.OBM.Time
+import      LibraBFT.Impl.Types.BlockInfo                            as BlockInfo
 open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
+open import LibraBFT.ImplShared.Interface.Output
+open import LibraBFT.Prelude
 
 module LibraBFT.Impl.OBM.Init where
 
 ------------------------------------------------------------------------------
+-- Everything below is specific to Agda.
 
--- TODO : get numbers from config
-
-dT : Duration
-dT = Duration.fromMillis ConfigHardCoded.roundInitialTimeoutMS
-
-etiT : ExponentialTimeInterval
-etiT = ExponentialTimeInterval.new dT 1.2 6
-
-rsT : RoundState
-rsT = RoundState.new etiT timeT
+initialize
+  : AuthorName → GenKeyFile.NfLiwsVssVvPe → Instant → ObmNeedFetch → ProposalGenerator
+  → Either ErrLog (EpochManager × List Output)
+initialize me nfLiwsVssVvPe now obmNeedFetch proposalGenerator = do
+  (nc , occp , liws , sk , pe) ← ConsensusProvider.obmInitialData me nfLiwsVssVvPe
+  ConsensusProvider.startConsensus
+    nc now occp liws sk
+    obmNeedFetch proposalGenerator
+    (StateComputer∙new BlockInfo.gENESIS_VERSION)

--- a/LibraBFT/Impl/OBM/Util.agda
+++ b/LibraBFT/Impl/OBM/Util.agda
@@ -11,8 +11,10 @@ open import LibraBFT.Prelude
 
 module LibraBFT.Impl.OBM.Util where
 
--- to tolerate f failures, cluster must contain at least n ≥ 3f + 1 nodes,
--- where n − f nodes form a quorum
+-- To tolerate f failures, cluster must contain at least n ≥ 3f + 1 nodes,
+-- where n − f nodes form a quorum, assuming 1 vote per node.
+-- Note: our Haskell implementation and our model of it support non-uniform voting power,
+-- that is NOT reflected in these functions, but is reflected in functions in ValidatorVerifier.
 
 numNodesNeededForNFailures : U64 -> U64
 numNodesNeededForNFailures numFaultsAllowed = 3 * numFaultsAllowed + 1

--- a/LibraBFT/Impl/OBM/Util.agda
+++ b/LibraBFT/Impl/OBM/Util.agda
@@ -1,0 +1,27 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.Impl.OBM.Rust.RustTypes
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochIndep
+open import LibraBFT.Prelude
+
+module LibraBFT.Impl.OBM.Util where
+
+-- to tolerate f failures, cluster must contain at least n ≥ 3f + 1 nodes,
+-- where n − f nodes form a quorum
+
+numNodesNeededForNFailures : U64 -> U64
+numNodesNeededForNFailures numFaultsAllowed = 3 * numFaultsAllowed + 1
+
+checkBftAndRun : ∀ {names : Set} {b : Set}
+               → U64 → List names → (U64 → List names → b)
+               → Either ErrLog b
+checkBftAndRun numFailures authors f =
+  if-dec length authors <? numNodesNeededForNFailures numFailures
+  then Left fakeErr --(ErrL [ "checkBftAndRun: not enough authors for given number of failures"
+                    --      , show numFailures, show (length authors) ])
+  else pure (f numFailures authors)

--- a/LibraBFT/Impl/Types/BlockInfo.agda
+++ b/LibraBFT/Impl/Types/BlockInfo.agda
@@ -33,18 +33,19 @@ empty = BlockInfo∙new
   gENESIS_VERSION
   nothing
 
-genesis : HashValue → ValidatorSet → BlockInfo
-genesis genesisStateRootHash validatorSet = BlockInfo∙new
-  gENESIS_EPOCH
-  gENESIS_ROUND
-  Hash.valueZero
-  genesisStateRootHash
-  gENESIS_VERSION
---gENESIS_TIMESTAMP_USECS
-  (just (EpochState∙new {-Epoch-} 1 (ValidatorVerifier.from validatorSet)))
-{-# INLINE genesis #-}
+genesis : HashValue → ValidatorSet → Either ErrLog BlockInfo
+genesis genesisStateRootHash validatorSet = do
+  vv ← ValidatorVerifier.from validatorSet
+  pure $ BlockInfo∙new
+    gENESIS_EPOCH
+    gENESIS_ROUND
+    Hash.valueZero
+    genesisStateRootHash
+    gENESIS_VERSION
+  --gENESIS_TIMESTAMP_USECS
+    (just (EpochState∙new {-Epoch-} 1 vv))
 
-mockGenesis : Maybe ValidatorSet → BlockInfo
+mockGenesis : Maybe ValidatorSet → Either ErrLog BlockInfo
 mockGenesis
   = genesis
     (Crypto.obmHashVersion gENESIS_VERSION) -- OBM-LBFT-DIFF : Crypto.aCCUMULATOR_PLACEHOLDER_HASH

--- a/LibraBFT/Impl/Types/LedgerInfo.agda
+++ b/LibraBFT/Impl/Types/LedgerInfo.agda
@@ -11,5 +11,5 @@ open import LibraBFT.Prelude
 
 module LibraBFT.Impl.Types.LedgerInfo where
 
-mockGenesis : Maybe ValidatorSet → LedgerInfo
-mockGenesis mvs = LedgerInfo∙new (BlockInfo.mockGenesis mvs) Hash.valueZero
+mockGenesis : Maybe ValidatorSet → Either ErrLog LedgerInfo
+mockGenesis mvs = LedgerInfo∙new <$> BlockInfo.mockGenesis mvs <*> pure Hash.valueZero

--- a/LibraBFT/Impl/Types/LedgerInfoWithSignatures.agda
+++ b/LibraBFT/Impl/Types/LedgerInfoWithSignatures.agda
@@ -15,6 +15,9 @@ open import Optics.All
 
 module LibraBFT.Impl.Types.LedgerInfoWithSignatures where
 
+obmNewNoSigs : LedgerInfo → LedgerInfoWithSignatures
+obmNewNoSigs li = LedgerInfoWithSignatures∙new li Map.empty
+
 -- HC-TODO : refactor this and TimeoutCertificate
 addSignature : AccountAddress → Signature → LedgerInfoWithSignatures → LedgerInfoWithSignatures
 addSignature validator sig liws =

--- a/LibraBFT/Impl/Types/OnChainConfig/ValidatorSet.agda
+++ b/LibraBFT/Impl/Types/OnChainConfig/ValidatorSet.agda
@@ -4,8 +4,10 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import LibraBFT.Base.KVMap                 as Map hiding (empty)
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
+open import Optics.All
 
 module LibraBFT.Impl.Types.OnChainConfig.ValidatorSet where
 
@@ -15,6 +17,24 @@ new = ValidatorSet∙new ConsensusScheme∙new
 empty : ValidatorSet
 empty = new []
 
-postulate -- TODO-1 obmFromVV, obmGetValidatorInfo
-  obmFromVV : ValidatorVerifier → ValidatorSet
-  obmGetValidatorInfo : AuthorName → ValidatorSet → Either ErrLog ValidatorInfo
+obmFromVV : ValidatorVerifier → ValidatorSet
+obmFromVV vv0 = record -- ValidatorSet
+  { _vsScheme  = ConsensusScheme∙new -- TODO
+  ; _vsPayload = fmap go (Map.toList (vv0 ^∙ vvAddressToValidatorInfo))
+  }
+ where
+  go : (Author × ValidatorConsensusInfo) → ValidatorInfo
+  go (address , ValidatorConsensusInfo∙new pk vp) =
+    record -- ValidatorInfo
+    { _viAccountAddress = address
+    ; _viConsensusVotingPower = vp
+    ; _viConfig = record -- ValidatorConfig
+                  { _vcConsensusPublicKey      = pk
+                  ; _vcValidatorNetworkAddress = address ^∙ aAuthorName } }
+
+obmGetValidatorInfo : AuthorName → ValidatorSet → Either ErrLog ValidatorInfo
+obmGetValidatorInfo name vs = go (vs ^∙ vsPayload)
+ where
+  go : List ValidatorInfo → Either ErrLog ValidatorInfo
+  go        []  = Left fakeErr -- ["ValidatorSet", "obmGetValidatorInfo", "TODO better err msg"]
+  go (vi ∷ vis) = if-dec vi ^∙ viAccountAddress ∙ aAuthorName ≟ name then pure vi else go vis

--- a/LibraBFT/Impl/Types/OnChainConfig/ValidatorSet.agda
+++ b/LibraBFT/Impl/Types/OnChainConfig/ValidatorSet.agda
@@ -33,8 +33,7 @@ obmFromVV vv0 = record -- ValidatorSet
                   ; _vcValidatorNetworkAddress = address ^∙ aAuthorName } }
 
 obmGetValidatorInfo : AuthorName → ValidatorSet → Either ErrLog ValidatorInfo
-obmGetValidatorInfo name vs = go (vs ^∙ vsPayload)
- where
-  go : List ValidatorInfo → Either ErrLog ValidatorInfo
-  go        []  = Left fakeErr -- ["ValidatorSet", "obmGetValidatorInfo", "TODO better err msg"]
-  go (vi ∷ vis) = if-dec vi ^∙ viAccountAddress ∙ aAuthorName ≟ name then pure vi else go vis
+obmGetValidatorInfo name vs =
+  case List-filter (λ vi → vi ^∙ viAccountAddress ∙ aAuthorName ≟ name) (vs ^∙ vsPayload) of λ where
+    (vi ∷ []) → pure vi
+    _         → Left fakeErr  -- ["ValidatorSet", "obmGetValidatorInfo", "TODO better err msg"]

--- a/LibraBFT/Impl/Types/ValidatorVerifier.agda
+++ b/LibraBFT/Impl/Types/ValidatorVerifier.agda
@@ -11,13 +11,36 @@ open import LibraBFT.Impl.OBM.Rust.RustTypes
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.Prelude
 open import Optics.All
+------------------------------------------------------------------------------
+open import Data.String                                    using (String)
 
 module LibraBFT.Impl.Types.ValidatorVerifier where
 
-checkNumOfSignatures : ValidatorVerifier → Map.KVMap AccountAddress Signature → Either ErrLog Unit
-checkVotingPower     : ValidatorVerifier → List AccountAddress → Either ErrLog Unit
-getPublicKey         : ValidatorVerifier → AccountAddress → Maybe PK
-getVotingPower       : ValidatorVerifier → AccountAddress → Maybe U64
+------------------------------------------------------------------------------
+calculateQuorumVotingPower : U64 -> U64
+checkNumOfSignatures       : ValidatorVerifier → Map.KVMap AccountAddress Signature
+                           → Either ErrLog Unit
+checkVotingPower           : ValidatorVerifier → List AccountAddress → Either ErrLog Unit
+getPublicKey               : ValidatorVerifier → AccountAddress → Maybe PK
+getVotingPower             : ValidatorVerifier → AccountAddress → Maybe U64
+sumVotingPower             : (List String → List String)
+                           → Map.KVMap AccountAddress ValidatorConsensusInfo
+                           → Either ErrLog U64
+------------------------------------------------------------------------------
+
+new : Map.KVMap AccountAddress ValidatorConsensusInfo → Either ErrLog ValidatorVerifier
+new addressToValidatorInfo = do
+  totalVotingPower      ← sumVotingPower here' addressToValidatorInfo
+  let quorumVotingPower = if Map.kvm-size addressToValidatorInfo == 0 then 0
+                          else calculateQuorumVotingPower totalVotingPower
+  pure (mkValidatorVerifier addressToValidatorInfo quorumVotingPower totalVotingPower)
+ where
+  here' : List String → List String
+  here' t = "ValidatorVerifier" ∷ "new" ∷ t
+
+-- This scales up the number of faults tolerated with the number of votes.
+-- see TestValidatorVerifier in Haskell
+calculateQuorumVotingPower totalVotingPower = (div (totalVotingPower * 2) 3) + 1
 
 verifyIfAuthor
   : {V : Set} ⦃ _ : Crypto.CryptoHash V ⦄
@@ -73,10 +96,32 @@ checkVotingPower self authors = do
     else Right unit
 
 getPublicKey self author =
-  (_^∙ vciPublicKey) <$> Map.lookup author (self ^∙ vvAddressToValidatorInfo)
+  (_^∙ vciPublicKey)   <$> Map.lookup author (self ^∙ vvAddressToValidatorInfo)
 
 getVotingPower self author =
   (_^∙ vciVotingPower) <$> Map.lookup author (self ^∙ vvAddressToValidatorInfo)
 
-postulate -- TODO-1: from
-  from : ValidatorSet → ValidatorVerifier
+sumVotingPower here' addressToValidatorInfo =
+  foldr go (Right 0) (Map.elems addressToValidatorInfo)
+ where
+  maxBoundU64 : U64
+  maxBoundU64 = 18446744073709551615
+  go : ValidatorConsensusInfo → Either ErrLog U64 → Either ErrLog U64
+  go x (Right sum') =
+    if-dec sum' ≤? maxBoundU64 ∸ (x ^∙ vciVotingPower)
+    then Right (sum' + x ^∙ vciVotingPower)
+    else Left fakeErr -- (ErrL (here' ("sum too big" ∷ [])))
+  go _ (Left err) = Left err
+
+from : ValidatorSet → Either ErrLog ValidatorVerifier
+from validatorSet =
+  new (foldl' go Map.empty (validatorSet ^∙ vsPayload))
+ where
+  go : Map.KVMap AccountAddress ValidatorConsensusInfo → ValidatorInfo
+     → Map.KVMap AccountAddress ValidatorConsensusInfo
+  go map0 validator =
+    Map.insert (validator ^∙ viAccountAddress)
+               (ValidatorConsensusInfo∙new
+                 (validator ^∙ viConsensusPublicKey)
+                 (validator ^∙ viConsensusVotingPower))
+                map0

--- a/LibraBFT/ImplFake/Handle.agda
+++ b/LibraBFT/ImplFake/Handle.agda
@@ -10,8 +10,11 @@ open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System
 open import LibraBFT.Concrete.System.Parameters
 open import LibraBFT.Hash
-import      LibraBFT.Impl.Consensus.Liveness.RoundState as RoundState
+import      LibraBFT.Impl.Consensus.Liveness.ExponentialTimeInterval as ExponentialTimeInterval
+import      LibraBFT.Impl.Consensus.Liveness.RoundState              as RoundState
+import      LibraBFT.Impl.OBM.ConfigHardCoded                        as ConfigHardCoded
 open import LibraBFT.Impl.OBM.Init
+open import LibraBFT.Impl.OBM.Rust.Duration                          as Duration
 open import LibraBFT.Impl.OBM.Time
 open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
@@ -55,7 +58,12 @@ module LibraBFT.ImplFake.Handle where
  initPE = obm-dangerous-magic!
 
  initRS : RoundState
- initRS = RoundState.new etiT timeT
+ initRS = RoundState.new
+            (ExponentialTimeInterval.new
+              (Duration.fromMillis ConfigHardCoded.roundInitialTimeoutMS)
+              1.2
+              6)
+            timeT
 
  initRM : RoundManager
  initRM = RoundManager∙new

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -232,16 +232,11 @@ module LibraBFT.ImplShared.Consensus.Types where
   postulate
     fakeErr : ErrLog
 
-  record TxTypeDependentStuff : Set where
-    constructor TxTypeDependentStuff∙new
+  record TxTypeDependentStuffForNetwork : Set where
+    constructor TxTypeDependentStuffForNetwork∙new
     field
-      _ttdsBlockStore        : BlockStore
-      _ttdsRoundState        : RoundState
-      _ttdsProposalGenerator : ProposalGenerator
-      _ttdsTime              : Instant
-      _ttdsStateComputer     : StateComputer
-  open TxTypeDependentStuff public
-  unquoteDecl ttdsBlockStore   ttdsRoundState   ttdsProposalGenerator
-              ttdsTime   ttdsStateComputer     = mkLens (quote TxTypeDependentStuff)
-             (ttdsBlockStore ∷ ttdsRoundState ∷ ttdsProposalGenerator ∷
-              ttdsTime ∷ ttdsStateComputer    ∷ [])
+      _ttdsnProposalGenerator : ProposalGenerator
+      _ttdsnStateComputer     : StateComputer
+  open TxTypeDependentStuffForNetwork public
+  unquoteDecl ttdsnProposalGenerator   ttdsnStateComputer = mkLens (quote TxTypeDependentStuffForNetwork)
+             (ttdsnProposalGenerator ∷ ttdsnStateComputer ∷ [])

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -164,7 +164,7 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   record ValidatorVerifier : Set where
     constructor mkValidatorVerifier
     field
-      _vvAddressToValidatorInfo : (KVMap AccountAddress ValidatorConsensusInfo)
+      _vvAddressToValidatorInfo : KVMap AccountAddress ValidatorConsensusInfo
       _vvQuorumVotingPower      : ℕ  -- TODO-2: see above; for now, this is QuorumSize
       _vvTotalVotingPower       : ℕ  -- TODO-2: see above; for now, this is number of peers in EpochConfig
   open ValidatorVerifier public

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -124,13 +124,18 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl  vsAuthor   vsPrivateKey = mkLens (quote ValidatorSigner)
               (vsAuthor ∷ vsPrivateKey ∷ [])
 
+  RawEncNetworkAddress = Author
+
+
+
   record ValidatorConfig : Set where
     constructor ValidatorConfig∙new
     field
-      _vcConsensusPublicKey : PK
+      _vcConsensusPublicKey      : PK
+      _vcValidatorNetworkAddress : RawEncNetworkAddress
   open ValidatorConfig public
-  unquoteDecl vcConsensusPublicKey = mkLens (quote ValidatorConfig)
-    (vcConsensusPublicKey ∷ [])
+  unquoteDecl vcConsensusPublicKey   vcValidatorNetworkAddress = mkLens (quote ValidatorConfig)
+             (vcConsensusPublicKey ∷ vcValidatorNetworkAddress ∷ [])
 
   record ValidatorInfo : Set where
     constructor ValidatorInfo∙new
@@ -1019,8 +1024,8 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
 
   record ProposerElection : Set where
     constructor ProposerElection∙new
-    -- field
-      -- _peProposers : Set Author
+    field
+      _peProposers : List Author -- TODO-1 : this should be 'Set Author'
       -- _peObmLeaderOfRound : LeaderOfRoundFn
       -- _peObmNodesInOrder  : NodesInOrder
   open ProposerElection

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -142,6 +142,11 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   unquoteDecl viAccountAddress   viConsensusVotingPower   viConfig = mkLens (quote ValidatorInfo)
              (viAccountAddress ∷ viConsensusVotingPower ∷ viConfig ∷ [])
 
+  -- getter only in Haskell
+  -- key for validating signed messages from this validator
+  viConsensusPublicKey : Lens ValidatorInfo PK
+  viConsensusPublicKey = viConfig ∙ vcConsensusPublicKey
+
   record ValidatorConsensusInfo : Set where
     constructor ValidatorConsensusInfo∙new
     field
@@ -152,14 +157,14 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
              (vciPublicKey ∷ vciVotingPower ∷ [])
 
   record ValidatorVerifier : Set where
-    constructor ValidatorVerifier∙new
+    constructor mkValidatorVerifier
     field
       _vvAddressToValidatorInfo : (KVMap AccountAddress ValidatorConsensusInfo)
       _vvQuorumVotingPower      : ℕ  -- TODO-2: see above; for now, this is QuorumSize
-      -- :vvTotalVotingPower    : ℕ  -- TODO-2: see above; for now, this is number of peers in EpochConfig
+      _vvTotalVotingPower       : ℕ  -- TODO-2: see above; for now, this is number of peers in EpochConfig
   open ValidatorVerifier public
-  unquoteDecl vvAddressToValidatorInfo   vvQuorumVotingPower = mkLens (quote ValidatorVerifier)
-             (vvAddressToValidatorInfo ∷ vvQuorumVotingPower ∷ [])
+  unquoteDecl vvAddressToValidatorInfo   vvQuorumVotingPower   vvTotalVotingPower = mkLens (quote ValidatorVerifier)
+             (vvAddressToValidatorInfo ∷ vvQuorumVotingPower ∷ vvTotalVotingPower ∷ [])
 
   -- getter only in Haskell
   vvObmAuthors : Lens ValidatorVerifier (List AccountAddress)
@@ -179,6 +184,9 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
       _vsScheme  : ConsensusScheme
       _vsPayload : List ValidatorInfo
   -- instance S.Serialize ValidatorSet
+  open ValidatorSet public
+  unquoteDecl vsScheme   vsPayload = mkLens (quote ValidatorSet)
+             (vsScheme ∷ vsPayload ∷ [])
 
   record EpochState : Set where
     constructor EpochState∙new

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -47,6 +47,9 @@ module LibraBFT.Prelude where
   max = _⊔_
   min = _⊓_
 
+  open import Data.Nat.DivMod using (_/_)
+  div = _/_
+
   open import Data.Nat.Properties
     hiding (≡-irrelevant ; _≟_)
     public


### PR DESCRIPTION
Besides the following specific changes, many functions were changed
in Haskell and Agda to return Either ErrLog * instead of using errorExit

Impl/Handle
- initEMWithOutput
- initRMWithOutput

Impl/OBM/Init : new file
- initialize : top level bootstrap initialization entry point (calls the following):

ConsensusProvider : new file
- top level bootstrap initialization entry point called by OBM.Init

GenKeyFile : new file
- generates keys
- creates ValidatorVerifier (i.e., other node's public keys)
- create  ValidatorSigner   (i.e., this node's secret keys)

Genesis : new file : used during initialization
- obmMkGenesisLedgerInfoWithSignatures
- obmMkLedgerInfoWithEpochState vs = do

Impl/OBM/Util : new file
- checkBftAndRun : checks given number of nodes can handle given number of failures (1 vote per node)

BlockInfo
- genesis

ValidatorSet
- obmFromVV
- obmGetValidatorInfo

ValidatorVerifier
- initValidatorVerifier
- new
- sumVotingPower
- from

ImplShared/Consensus/Types
- record TxTypeDependentStuffForNetwork

ImplShared/Consensus/Types/EpochIndep
- record ValidatorConfig : added fields
- viConsensusPublicKey : new getter
- record ValidatorVerifier : added field
- record ProposerElection : added field
