### PR TITLE
Connect injectivity failures to data "in the system" 

### DIFF
--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -83,7 +83,7 @@ module LibraBFT.Abstract.Properties
       → Σ (RecordChain (Q q')) ((B b)  ∈RC_)
       ⊎ Σ (RecordChain (Q q))  ((B b') ∈RC_)
     CommitsDoNotConflict' {cb} {q = q} {q'} {rcf} rcfAll∈sys {rcf'} rcf'All∈sys crf crf'
-       with bft-assumption (qVotes-C1 q) (qVotes-C1 q')
+       with bft-property (qVotes-C1 q) (qVotes-C1 q')
     ...| α , α∈qmem , α∈q'mem , hα
        with Any-sym (Any-map⁻ α∈qmem) | Any-sym (Any-map⁻ α∈q'mem)
     ...| α∈q | α∈q'

--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -69,17 +69,15 @@ module LibraBFT.Abstract.Properties
     -- are based are All-InSys.
     CommitsDoNotConflict'
       : ∀{o o' q q'}
-      → {rcf  : RecordChainFrom o  (Q q)}
-      → {rcf' : RecordChainFrom o' (Q q')}
+      → {rcf  : RecordChainFrom o  (Q q)}  → All-InSys rcf
+      → {rcf' : RecordChainFrom o' (Q q')} → All-InSys rcf'
       → {b b' : Block}
-      → All-InSys rcf
-      → All-InSys rcf'
       → CommitRuleFrom rcf  b
       → CommitRuleFrom rcf' b'
       → NonInjective-≡-pred (InSys ∘ B) bId
       ⊎ Σ (RecordChain (Q q')) ((B b)  ∈RC_)
       ⊎ Σ (RecordChain (Q q))  ((B b') ∈RC_)
-    CommitsDoNotConflict' {cb} {q = q} {q'} {rcf} {rcf'} rcfAll∈sys rcf'All∈sys crf crf'
+    CommitsDoNotConflict' {cb} {q = q} {q'} {rcf} rcfAll∈sys {rcf'} rcf'All∈sys crf crf'
        with bft-assumption (qVotes-C1 q) (qVotes-C1 q')
     ...| α , α∈qmem , α∈q'mem , hα
        with Any-sym (Any-map⁻ α∈qmem) | Any-sym (Any-map⁻ α∈q'mem)
@@ -92,5 +90,5 @@ module LibraBFT.Abstract.Properties
     ...| inj₂ cr               | inj₂ cr'
       with CommitsDoNotConflict (All-InSys-step ais ab←q (rcfAll∈sys here)) (All-InSys-step ais' ab←q' (rcf'All∈sys here)) cr cr'
     ...| inj₁ (hb , (p1 , p2)) = inj₁ (hb , (p1 , p2))
-    ...| inj₂ (inj₁ b∈arc') = inj₂ (inj₁ ((step arc' ab←q') , b∈arc'))
-    ...| inj₂ (inj₂ b'∈arc) = inj₂ (inj₂ (step arc ab←q , b'∈arc))
+    ...| inj₂ (inj₁ b∈arc') = inj₂ (inj₁ (step arc' ab←q' , b∈arc'))
+    ...| inj₂ (inj₂ b'∈arc) = inj₂ (inj₂ (step arc  ab←q  , b'∈arc))

--- a/LibraBFT/Abstract/Properties.agda
+++ b/LibraBFT/Abstract/Properties.agda
@@ -37,10 +37,10 @@ module LibraBFT.Abstract.Properties
  open        EpochConfig 𝓔
 
  module WithAssumptions {ℓ}
-   (InSys                 : Record → Set ℓ)
-   (no-collisions-InSys   : NoCollisions InSys)
-   (votes-only-once       : VotesOnlyOnceRule InSys)
-   (preferred-round-rule  : PreferredRoundRule InSys)
+   (InSys               : Record → Set ℓ)
+   (no-collisions-InSys : NoCollisions InSys)
+   (votes-once          : VotesOnlyOnceRule InSys)
+   (preferred-round     : PreferredRoundRule InSys)
   where
 
    open All-InSys-props InSys
@@ -53,7 +53,7 @@ module LibraBFT.Abstract.Properties
         → CommitRule rc' b'
         → (B b) ∈RC rc' ⊎ (B b') ∈RC rc
    CommitsDoNotConflict ais ais' cr cr'
-      with WithInvariants.thmS5 InSys votes-only-once preferred-round-rule ais ais' cr cr'
+      with WithInvariants.thmS5 InSys votes-once preferred-round ais ais' cr cr'
        -- We use the implementation-provided evidence that Block ids are injective among
        -- Block actually in the system to dismiss the first possibility
    ...| inj₁ ((_ , neq , h≡) , (is1 , is2)) = ⊥-elim (neq (no-collisions-InSys is1 is2 h≡))

--- a/LibraBFT/Abstract/RecordChain.agda
+++ b/LibraBFT/Abstract/RecordChain.agda
@@ -180,7 +180,7 @@ module LibraBFT.Abstract.RecordChain
  -- propositional non-injectivity of block ids.
  ≈RC-refl : ∀{r₀ r₁}(rc₀ : RecordChain r₀)(rc₁ : RecordChain r₁)
           → r₀ ≈Rec r₁
-          → NonInjective-≡-preds ((_∈RC-simple rc₀) ∘ B) ((_∈RC-simple rc₁) ∘ B) bId ⊎ (rc₀ ≈RC rc₁)
+          → NonInjective-≡-preds (_∈RC-simple rc₀ ∘ B) (_∈RC-simple rc₁ ∘ B) bId ⊎ (rc₀ ≈RC rc₁)
  ≈RC-refl empty empty hyp
     = inj₂ (eq-empty hyp)
  ≈RC-refl (step r0 x) (step r1 x₁) hyp
@@ -200,7 +200,7 @@ module LibraBFT.Abstract.RecordChain
  -- Heterogeneous irrelevance proves that two record chains that end at the same record
  -- have the same blocks and equivalent QCs.
  RecordChain-irrelevant : ∀{r}(rc₀ : RecordChain r)(rc₁ : RecordChain r)
-                        → NonInjective-≡-preds _ _ bId ⊎ rc₀ ≈RC rc₁
+                        → NonInjective-≡-preds (_∈RC-simple rc₀ ∘ B) (_∈RC-simple rc₁ ∘ B) bId ⊎ rc₀ ≈RC rc₁
  RecordChain-irrelevant rc0 rc1 = ≈RC-refl rc0 rc1 ≈Rec-refl
 
  -------------------------------------------------

--- a/LibraBFT/Abstract/RecordChain.agda
+++ b/LibraBFT/Abstract/RecordChain.agda
@@ -134,6 +134,17 @@ module LibraBFT.Abstract.RecordChain
           → r₀ ∈RC-simple rc
           → r₀ ∈RC-simple (step rc p)
 
+ ∈RC-simple-¬here : ∀ {o r r₀ r₁}
+                    → (rcf : RecordChainFrom o r₀)
+                    → (ext : r₀ ← r₁)
+                    → ¬( r ≡ r₁ )
+                    → r ∈RC-simple (step rcf ext)
+                    → r ∈RC-simple rcf
+ ∈RC-simple-¬here _ _ r≢r₁ r∈rcf+
+    with r∈rcf+
+ ... | here = ⊥-elim (r≢r₁ refl)
+ ... | there _ xxx = xxx
+
   -- States that a given record belongs in a record chain.
  data _∈RC_ {o : Record}(r₀ : Record) : ∀{r₁} → RecordChainFrom o r₁ → Set where
    here   : ∀{rc : RecordChainFrom o r₀} → r₀ ∈RC rc

--- a/LibraBFT/Abstract/RecordChain.agda
+++ b/LibraBFT/Abstract/RecordChain.agda
@@ -113,6 +113,53 @@ module LibraBFT.Abstract.RecordChain
  _≈RC_ : ∀{o₀ o₁ r₀ r₁} → RecordChainFrom o₀ r₀ → RecordChainFrom o₁ r₁ → Set
  _≈RC_ = ≈RC-pw _≈Rec_
 
+ ≈RC-sym : ∀{o₀ o₁ r₀ r₁}{rc₀ : RecordChainFrom o₀ r₀}{rc₁ : RecordChainFrom o₁ r₁}
+         → rc₀ ≈RC rc₁ → rc₁ ≈RC rc₀
+ ≈RC-sym (eq-empty x) = eq-empty (≈Rec-sym x)
+ ≈RC-sym (eq-step rc₀ rc₁ x ext₀ ext₁ hyp) = eq-step rc₁ rc₀ (≈Rec-sym x) ext₁ ext₀ (≈RC-sym hyp)
+
+ ≈RC-trans : ∀ {r₀ r₁ r₂}
+           → {rc₀ : RecordChain r₀}{rc₁ : RecordChain r₁}{rc₂ : RecordChain r₂}
+           → rc₀ ≈RC rc₁ → rc₁ ≈RC rc₂ → rc₀ ≈RC rc₂
+ ≈RC-trans (eq-empty x) q = q
+ ≈RC-trans (eq-step rc₀ rc₁ x ext₀ ext₁ p) (eq-step .rc₁ rc₂ x₁ .ext₁ ext₂ q)
+    = eq-step rc₀ rc₂ (≈Rec-trans x x₁) ext₀ ext₂ (≈RC-trans p q)
+
+ --------------------------
+ -- RecordChain elements
+
+ data _∈RC-simple_ {o : Record}(r₀ : Record) : ∀{r₁} → RecordChainFrom o r₁ → Set where
+   here   : ∀{rc : RecordChainFrom o r₀} → r₀ ∈RC-simple rc
+   there  : ∀{r₁ r₂}{rc : RecordChainFrom o r₁}(p : r₁ ← r₂)
+          → r₀ ∈RC-simple rc
+          → r₀ ∈RC-simple (step rc p)
+
+  -- States that a given record belongs in a record chain.
+ data _∈RC_ {o : Record}(r₀ : Record) : ∀{r₁} → RecordChainFrom o r₁ → Set where
+   here   : ∀{rc : RecordChainFrom o r₀} → r₀ ∈RC rc
+   there  : ∀{r₁ r₂}{rc : RecordChainFrom o r₁}(p : r₁ ← r₂)
+          → r₀ ∈RC rc
+          → r₀ ∈RC (step rc p)
+   -- This is an important rule. It is the equivalent of a
+   -- /congruence/ on record chains and enables us to prove
+   -- the 𝕂-chain-∈RC property.
+   transp : ∀{r}{rc₀ : RecordChainFrom o r}{rc₁ : RecordChainFrom o r}
+          → r₀ ∈RC rc₀ → rc₀ ≈RC rc₁ → r₀ ∈RC rc₁
+
+ ∈RC-empty-I : ∀{r} → r ∈RC (empty {o = I}) → r ≡ I
+ ∈RC-empty-I here                      = refl
+ ∈RC-empty-I (transp old (eq-empty x)) = ∈RC-empty-I old
+
+ b∉RCempty : ∀ {b} → B b ∈RC empty → ⊥
+ b∉RCempty xx with ∈RC-empty-I xx
+ ...| ()
+
+ transp-B∈RC : ∀{r r' b}{rc : RecordChain r}{rc' : RecordChain r'}
+             → rc ≈RC rc' → B b ∈RC rc → B b ∈RC rc'
+ transp-B∈RC rc≈rc' (transp b∈rc x) = transp-B∈RC (≈RC-trans x rc≈rc') b∈rc
+ transp-B∈RC (eq-step rc₀ rc₁ (eq-B refl) ext₀ ext₁ rc≈rc') here = here
+ transp-B∈RC (eq-step rc₀ rc₁ x .p ext₁ rc≈rc') (there p b∈rc) = there ext₁ (transp-B∈RC rc≈rc' b∈rc)
+
  ≈RC-head : ∀{o₀ o₁ r₀ r₁}{rc₀ : RecordChainFrom o₀ r₀}{rc₁ : RecordChainFrom o₁ r₁}
           → rc₀ ≈RC rc₁ → o₀ ≈Rec o₁
  ≈RC-head (eq-empty x)          = x
@@ -138,18 +185,6 @@ module LibraBFT.Abstract.RecordChain
  ≈RC-refl (step r0 (I←B x x₁)) empty ()
  ≈RC-refl (step r0 (Q←B x x₁)) empty ()
  ≈RC-refl (step r0 (B←Q x x₁)) empty ()
-
- ≈RC-sym : ∀{o₀ o₁ r₀ r₁}{rc₀ : RecordChainFrom o₀ r₀}{rc₁ : RecordChainFrom o₁ r₁}
-         → rc₀ ≈RC rc₁ → rc₁ ≈RC rc₀
- ≈RC-sym (eq-empty x) = eq-empty (≈Rec-sym x)
- ≈RC-sym (eq-step rc₀ rc₁ x ext₀ ext₁ hyp) = eq-step rc₁ rc₀ (≈Rec-sym x) ext₁ ext₀ (≈RC-sym hyp)
-
- ≈RC-trans : ∀ {r₀ r₁ r₂}
-           → {rc₀ : RecordChain r₀}{rc₁ : RecordChain r₁}{rc₂ : RecordChain r₂}
-           → rc₀ ≈RC rc₁ → rc₁ ≈RC rc₂ → rc₀ ≈RC rc₂
- ≈RC-trans (eq-empty x) q = q
- ≈RC-trans (eq-step rc₀ rc₁ x ext₀ ext₁ p) (eq-step .rc₁ rc₂ x₁ .ext₁ ext₂ q)
-    = eq-step rc₀ rc₂ (≈Rec-trans x x₁) ext₀ ext₂ (≈RC-trans p q)
 
  -- Heterogeneous irrelevance proves that two record chains that end at the same record
  -- have the same blocks and equivalent QCs.
@@ -209,41 +244,6 @@ module LibraBFT.Abstract.RecordChain
              → parentUID rc₀ ≡ parentUID rc₁
  parentUID-≈ _ _ (eq-step _ _ (eq-B refl) _ _ (eq-empty x)) = refl
  parentUID-≈ _ _ (eq-step _ _ (eq-B refl) _ _ (eq-step _ _ (eq-Q refl) _ _ _)) = refl
-
- --------------------------
- -- RecordChain elements
-
- data _∈RC-simple_ {o : Record}(r₀ : Record) : ∀{r₁} → RecordChainFrom o r₁ → Set where
-   here   : ∀{rc : RecordChainFrom o r₀} → r₀ ∈RC-simple rc
-   there  : ∀{r₁ r₂}{rc : RecordChainFrom o r₁}(p : r₁ ← r₂)
-          → r₀ ∈RC-simple rc
-          → r₀ ∈RC-simple (step rc p)
-
- -- States that a given record belongs in a record chain.
- data _∈RC_ {o : Record}(r₀ : Record) : ∀{r₁} → RecordChainFrom o r₁ → Set where
-   here   : ∀{rc : RecordChainFrom o r₀} → r₀ ∈RC rc
-   there  : ∀{r₁ r₂}{rc : RecordChainFrom o r₁}(p : r₁ ← r₂)
-          → r₀ ∈RC rc
-          → r₀ ∈RC (step rc p)
-   -- This is an important rule. It is the equivalent of a
-   -- /congruence/ on record chains and enables us to prove
-   -- the 𝕂-chain-∈RC property.
-   transp : ∀{r}{rc₀ : RecordChainFrom o r}{rc₁ : RecordChainFrom o r}
-          → r₀ ∈RC rc₀ → rc₀ ≈RC rc₁ → r₀ ∈RC rc₁
-
- ∈RC-empty-I : ∀{r} → r ∈RC (empty {o = I}) → r ≡ I
- ∈RC-empty-I here                      = refl
- ∈RC-empty-I (transp old (eq-empty x)) = ∈RC-empty-I old
-
- b∉RCempty : ∀ {b} → B b ∈RC empty → ⊥
- b∉RCempty xx with ∈RC-empty-I xx
- ...| ()
-
- transp-B∈RC : ∀{r r' b}{rc : RecordChain r}{rc' : RecordChain r'}
-             → rc ≈RC rc' → B b ∈RC rc → B b ∈RC rc'
- transp-B∈RC rc≈rc' (transp b∈rc x) = transp-B∈RC (≈RC-trans x rc≈rc') b∈rc
- transp-B∈RC (eq-step rc₀ rc₁ (eq-B refl) ext₀ ext₁ rc≈rc') here = here
- transp-B∈RC (eq-step rc₀ rc₁ x .p ext₁ rc≈rc') (there p b∈rc) = there ext₁ (transp-B∈RC rc≈rc' b∈rc)
 
  -- A k-chain (paper Section 5.2; see Abstract.Properties) is a sequence of
  -- blocks and quorum certificates for said blocks:

--- a/LibraBFT/Abstract/RecordChain/Assumptions.agda
+++ b/LibraBFT/Abstract/RecordChain/Assumptions.agda
@@ -103,7 +103,7 @@ module LibraBFT.Abstract.RecordChain.Assumptions
    -- checks have been performed and we can infer this information solely
    -- by seeing α has knowledge of the 2-chain in Fig2 above.
    --
-   PreferredRoundRule : Set ℓ
+   PreferredRoundRule : Set _
    PreferredRoundRule
      = ∀(α : Member) → Meta-Honest-Member α
      → ∀{q q'}(q∈𝓢 : InSys (Q q))(q'∈𝓢 : InSys (Q q'))
@@ -112,4 +112,4 @@ module LibraBFT.Abstract.RecordChain.Assumptions
      → (rc' : RecordChain (Q q'))
      → (v' : α ∈QC q')
      → abs-vRound (∈QC-Vote q v) < abs-vRound (∈QC-Vote q' v')
-     → NonInjective-≡ bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
+     → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -55,7 +55,7 @@ module LibraBFT.Abstract.RecordChain.Properties
            → (p₀ : B b₀ ← Q q₀)
            → (p₁ : B b₁ ← Q q₁)
            → getRound b₀ ≡ getRound b₁
-           → NonInjective-≡ bId ⊎ b₀ ≡ b₁
+           → b₀ ≢ b₁ × bId b₀ ≡ bId b₁ ⊎ b₀ ≡ b₁
    lemmaS2 {b₀} {b₁} {q₀} {q₁} ex₀ ex₁ (B←Q refl h₀) (B←Q refl h₁) refl
      with b₀ ≟Block b₁
    ...| yes done = inj₂ done
@@ -75,7 +75,7 @@ module LibraBFT.Abstract.RecordChain.Properties
          v₁∈q₁ = ∈QC-Vote-correct q₁ a∈q₁
          ppp   = trans h₀ (trans (vote≡⇒QPrevId≡ {q₀} {q₁} v₀∈q₀ v₁∈q₁ (votes-only-once a honest ex₀ ex₁ a∈q₀ a∈q₁ v₀≡v₁))
                                  (sym h₁))
-     in inj₁ ((b₀ , b₁) , (imp , ppp))
+     in inj₁ (imp , ppp)
 
    ----------------
    -- Lemma S3
@@ -85,7 +85,7 @@ module LibraBFT.Abstract.RecordChain.Properties
            → (rc' : RecordChain (Q q')) → InSys (Q q')  -- Immediately before a (Q q), we have the certified block (B b), which is the 'B' in S3
            → (c3 : 𝕂-chain Contig 3 rc)                 -- This is B₀ ← C₀ ← B₁ ← C₁ ← B₂ ← C₂ in S3
            → round r₂ < getRound q'
-           → NonInjective-≡ bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
+           → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
    lemmaS3 {r₂} {q'} ex₀ (step rc' b←q') ex₁ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ _ b₂←q₂ c2) hyp
      with bft-assumption (qVotes-C1 q₂) (qVotes-C1 q')
    ...| (a , (a∈q₂mem , a∈q'mem , honest))
@@ -161,47 +161,49 @@ module LibraBFT.Abstract.RecordChain.Properties
        {rc : RecordChain r} → All-InSys rc
      → (q' : QC) → InSys (Q q')
      → {b' : Block}
-     → (rc' : RecordChain (B b')) → (ext : (B b') ← (Q q'))
+     → (rc' : RecordChain (B b')) → All-InSys rc' → (ext : (B b') ← (Q q'))
      → (c  : 𝕂-chain Contig k rc)
      → (ix : Fin k)
      → getRound (kchainBlock ix c) ≡ getRound b'
-     → NonInjective-≡ bId ⊎ (kchainBlock ix c ≡ b')
-   propS4-base-lemma-2 {rc = rc} prev∈sys q' q'∈sys rc' ext (s-chain r←b prf b←q c) zero hyp
-     = lemmaS2 (All-InSys⇒last-InSys prev∈sys) q'∈sys b←q ext hyp
-   propS4-base-lemma-2 prev∈sys q' q'∈sys rc' ext (s-chain r←b prf b←q c) (suc ix)
-     = propS4-base-lemma-2 (All-InSys-unstep (All-InSys-unstep prev∈sys)) q' q'∈sys rc' ext c ix
+     → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (kchainBlock ix c ≡ b')
+   propS4-base-lemma-2 {rc = rc} prev∈sys q' q'∈sys {b'} rc' rc'All∈sys ext (s-chain {b = b} r←b prf b←q c) zero hyp
+      with lemmaS2 (All-InSys⇒last-InSys prev∈sys) q'∈sys b←q ext hyp
+   ... | Left  (b≢b' , bIds≡) = inj₁ (((b , b') , b≢b' , bIds≡) , All-InSys-unstep prev∈sys here , rc'All∈sys here)
+   ... | Right y = Right y
+   propS4-base-lemma-2 prev∈sys q' q'∈sys rc' rc'All∈sys ext (s-chain r←b prf b←q c) (suc ix)
+     = propS4-base-lemma-2 (All-InSys-unstep (All-InSys-unstep prev∈sys)) q' q'∈sys rc' rc'All∈sys ext c ix
 
    propS4-base : ∀{q q'}
                → {rc : RecordChain (Q q)}   → All-InSys rc
-               → (rc' : RecordChain (Q q')) → InSys (Q q')
+               → (rc' : RecordChain (Q q')) → All-InSys rc'
                → (c3 : 𝕂-chain Contig 3 rc) -- This is B₀ ← C₀ ← B₁ ← C₁ ← B₂ ← C₂ in S4
                → getRound (c3 b⟦ suc (suc zero) ⟧) ≤ getRound q'
                → getRound q' ≤ getRound (c3 b⟦ zero ⟧)
-               → NonInjective-≡ bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
-   propS4-base {q' = q'} prev∈sys (step {B b} rc'@(step rc'' q←b) b←q@(B←Q refl _)) q'∈sys c3 hyp0 hyp1
+               → NonInjective-≡-pred (InSys ∘ B) bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
+   propS4-base {q' = q'} prev∈sys rc0@(step {B b} rc'@(step rc'' q←b) b←q@(B←Q refl _)) rc'All∈sys c3 hyp0 hyp1
      with propS4-base-lemma-1 c3 (getRound b) hyp0 hyp1
    ...| here r
-     with propS4-base-lemma-2 prev∈sys q' q'∈sys rc' b←q c3 zero (sym r)
+     with propS4-base-lemma-2 prev∈sys q' (All-InSys⇒last-InSys rc'All∈sys) rc' (All-InSys-unstep rc'All∈sys) b←q c3 zero (sym r)
    ...| inj₁ hb = inj₁ hb
    ...| inj₂ res
      with 𝕂-chain-∈RC c3 zero (suc (suc zero)) z≤n res rc'
-   ...| inj₁ hb   = inj₁ hb
+   ...| inj₁ (hb , (p1 , p2))  = inj₁ (hb , (prev∈sys p1 , rc'All∈sys (there b←q p2)))
    ...| inj₂ res' = inj₂ (there b←q res')
-   propS4-base {q} {q'} prev∈sys (step rc' (B←Q refl x₀)) q'∈sys c3 hyp0 hyp1
+   propS4-base {q} {q'} prev∈sys rc0@(step rc' b←q@(B←Q refl x₀)) rc'All∈sys c3 hyp0 hyp1
       | there (here r)
-     with propS4-base-lemma-2 prev∈sys q' q'∈sys rc' (B←Q refl x₀) c3 (suc zero) (sym r)
+     with propS4-base-lemma-2 prev∈sys q' (All-InSys⇒last-InSys rc'All∈sys) rc' (All-InSys-unstep rc'All∈sys) (B←Q refl x₀) c3 (suc zero) (sym r)
    ...| inj₁ hb = inj₁ hb
    ...| inj₂ res
      with 𝕂-chain-∈RC c3 (suc zero) (suc (suc zero)) (s≤s z≤n) res rc'
-   ...| inj₁ hb   = inj₁ hb
+   ...| inj₁ (hb , (p1 , p2))  = inj₁ (hb , ((prev∈sys p1) , (rc'All∈sys (there b←q p2))))
    ...| inj₂ res' = inj₂ (there (B←Q refl x₀) res')
-   propS4-base {q' = q'} prev∈sys (step rc' (B←Q refl x₀)) q'∈sys c3 hyp0 hyp1
+   propS4-base {q' = q'} prev∈sys rc0@(step rc' (B←Q refl x₀)) rc'All∈sys c3 hyp0 hyp1
       | there (there (here r))
-     with propS4-base-lemma-2 prev∈sys q' q'∈sys rc' (B←Q refl x₀) c3 (suc (suc zero)) (sym r)
+     with propS4-base-lemma-2 prev∈sys q' (All-InSys⇒last-InSys rc'All∈sys) rc' (All-InSys-unstep rc'All∈sys) (B←Q refl x₀) c3 (suc (suc zero)) (sym r)
    ...| inj₁ hb = inj₁ hb
    ...| inj₂ res
      with 𝕂-chain-∈RC c3 (suc (suc zero)) (suc (suc zero)) (s≤s (s≤s z≤n)) res rc'
-   ...| inj₁ hb   = inj₁ hb
+   ...| inj₁ (hb , (p1 , p2))  = inj₁ (hb , (prev∈sys p1 , rc'All∈sys (there (B←Q refl x₀) p2)))
    ...| inj₂ res' = inj₂ (there (B←Q refl x₀) res')
 
    propS4 : ∀{q q'}
@@ -212,10 +214,10 @@ module LibraBFT.Abstract.RecordChain.Properties
           -- In the paper, the proposition states that B₀ ←⋆ B, yet, B is the block preceding
           -- C, which in our case is 'prevBlock rc''. Hence, to say that B₀ ←⋆ B is
           -- to say that B₀ is a block in the RecordChain that goes all the way to C.
-          → NonInjective-≡ bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
+          → NonInjective-≡-pred (InSys ∘ B) bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
    propS4 {q' = q'} {rc} prev∈sys (step rc' b←q') prev∈sys' c3 hyp
      with getRound q' ≤?ℕ getRound (c3 b⟦ zero ⟧)
-   ...| yes rq≤rb₂ = propS4-base {q' = q'} prev∈sys (step rc' b←q') (All-InSys⇒last-InSys prev∈sys') c3 hyp rq≤rb₂
+   ...| yes rq≤rb₂ = propS4-base {q' = q'} prev∈sys (step rc' b←q') prev∈sys' c3 hyp rq≤rb₂
    propS4 {q' = q'} prev∈sys (step rc' b←q') all∈sys c3 hyp
       | no  rb₂<rq
      with lemmaS3 (All-InSys⇒last-InSys prev∈sys) (step rc' b←q')
@@ -242,7 +244,7 @@ module LibraBFT.Abstract.RecordChain.Properties
          → {b b' : Block}
          → CommitRule rc  b
          → CommitRule rc' b'
-         → NonInjective-≡ bId ⊎ ((B b) ∈RC rc' ⊎ (B b') ∈RC rc) -- Not conflicting means one extends the other.
+         → NonInjective-≡-pred (InSys ∘ B) bId ⊎ ((B b) ∈RC rc' ⊎ (B b') ∈RC rc) -- Not conflicting means one extends the other.
    thmS5 {rc = rc} prev∈sys {rc'} prev∈sys' (commit-rule c3 refl) (commit-rule c3' refl)
      with <-cmp (getRound (c3 b⟦ suc (suc zero) ⟧)) (getRound (c3' b⟦ suc (suc zero) ⟧))
    ...| tri≈ _ r≡r' _ = inj₁ <⊎$> (propS4 prev∈sys  rc' prev∈sys' c3  (≤-trans (≡⇒≤ r≡r')      (kchain-round-≤-lemma' c3' (suc (suc zero)))))

--- a/LibraBFT/Abstract/Records/Extends.agda
+++ b/LibraBFT/Abstract/Records/Extends.agda
@@ -47,9 +47,9 @@ module LibraBFT.Abstract.Records.Extends
 
   -- Equivalent records extend equivalent records (modulo injectivity
   -- failure of bId).
-  ←-≈Rec : ∀{r₀ r₁ s₀ s₁} → s₀ ← r₀ → s₁ ← r₁
+  ←-≈Rec : ∀{r₀ r₁ s₀ s₁} → (ext₀ : s₀ ← r₀) → (ext₁ : s₁ ← r₁)
            → r₀ ≈Rec r₁
-           → NonInjective-≡ bId ⊎ (s₀ ≈Rec s₁)
+           → NonInjective-≡-preds ((s₀ ≡_) ∘ B) ((s₁ ≡_) ∘ B) bId ⊎ (s₀ ≈Rec s₁)
   ←-≈Rec (I←B x x₁) (I←B x₂ x₃) hyp = inj₂ eq-I
   ←-≈Rec (I←B x x₁) (Q←B x₂ x₃) (eq-B refl)
     = ⊥-elim (maybe-⊥ (sym x₃) x₁)
@@ -61,7 +61,7 @@ module LibraBFT.Abstract.Records.Extends
                        -- in eq-Q
   ←-≈Rec (B←Q {b₀} x refl) (B←Q {b₁} w refl) (eq-Q refl)
     with b₀ ≟Block b₁
-  ...| no  hb  = inj₁ ((b₀ , b₁) , (λ x → hb x) , refl)
+  ...| no  hb  = inj₁ (((b₀ , b₁) , (λ x → hb x) , refl) , refl , refl)
   ...| yes prf = inj₂ (eq-B prf)
 
   ←-irrelevant : Irrelevant _←_

--- a/LibraBFT/Abstract/System.agda
+++ b/LibraBFT/Abstract/System.agda
@@ -47,6 +47,12 @@ module LibraBFT.Abstract.System
     All-InSys-step hyp ext r here = r
     All-InSys-step hyp ext r (there .ext r∈rc) = hyp r∈rc
 
+
+  -- We say an InSys predicate has NoCollisions if there are no two different Blocks that satisfy
+  -- InSys and have different ids.
+  NoCollisions : ∀{ℓ} → (Record → Set ℓ) → Set ℓ
+  NoCollisions ∈sys = ∀ {b₀ b₁} → ∈sys (B b₀) → ∈sys (B b₁) → bId b₀ ≡ bId b₁ → b₀ ≡ b₁
+
   -- We say an InSys predicate is /Complete/ when we can construct a record chain
   -- from any vote by an honest participant. This essentially says that whenever
   -- an honest participant casts a vote, they have checked that the voted-for

--- a/LibraBFT/Base/KVMap.agda
+++ b/LibraBFT/Base/KVMap.agda
@@ -89,6 +89,11 @@ module LibraBFT.Base.KVMap  where
                   → (prf : lookup k kvm ≡ nothing)
                   → lookup k (kvm-insert k v kvm prf) ≡ just v
 
+   -- Haskell's insert updates the value even if the key is already in the map
+   lookup-correct-haskell
+                  : {kvm : KVMap Key Val}
+                  → lookup k (kvm-insert-Haskell k v kvm) ≡ just v
+
    lookup-correct-update
                   : {kvm : KVMap Key Val}
                   → (prf : lookup k kvm ≢ nothing)

--- a/LibraBFT/Concrete/Obligations/PreferredRound.agda
+++ b/LibraBFT/Concrete/Obligations/PreferredRound.agda
@@ -193,10 +193,10 @@ module LibraBFT.Concrete.Obligations.PreferredRound
            cand hyp
   ...| va'Par , res
     with vdParent-prevRound-lemma rc' va' va'Par
-  ...| inj₁ hb    = inj₁ hb
+  ...| inj₁ hb    = inj₁ (hb , obm-dangerous-magic' "TODO-3: connect to InSys")
   ...| inj₂ final
     with make-cand-3-chain-lemma c3 va
-  ...| inj₁ hb = inj₁ hb
+  ...| inj₁ hb = inj₁ (hb , obm-dangerous-magic' "TODO-3: connect to InSys")
   ...| inj₂ xx = inj₂ (subst₂ _≤_
           (cong bRound (trans (cong (kchainBlock (suc zero) ∘ is-2chain) (sym R)) xx))
           final

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -79,7 +79,7 @@ module LibraBFT.Concrete.Properties
        → {b b' : Abs.Block}
        → CommitRule rc  b
        → CommitRule rc' b'
-       → NonInjective-≡ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
+       → NonInjective-≡-preds _ _ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
     ConcCommitsDoNotConflict = CommitsDoNotConflict
            (VO-obl.proof intSystemState (vss-votes-once validState))
            (PR-obl.proof intSystemState (vss-preferred-round validState))
@@ -91,7 +91,7 @@ module LibraBFT.Concrete.Properties
         → InSys (Abs.Q q) → InSys (Abs.Q q')
         → CommitRule rc  b
         → CommitRule rc' b'
-        → NonInjective-≡ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
+        → NonInjective-≡-preds _ _ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
       ConcCommitsDoNotConflict' = CommitsDoNotConflict'
            (VO-obl.proof intSystemState (vss-votes-once validState))
            (PR-obl.proof intSystemState (vss-preferred-round validState))

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -79,7 +79,7 @@ module LibraBFT.Concrete.Properties
        → {b b' : Abs.Block}
        → CommitRule rc  b
        → CommitRule rc' b'
-       → NonInjective-≡-preds _ _ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
+       → NonInjective-≡-pred (InSys ∘ B) Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
     ConcCommitsDoNotConflict = CommitsDoNotConflict
            (VO-obl.proof intSystemState (vss-votes-once validState))
            (PR-obl.proof intSystemState (vss-preferred-round validState))
@@ -91,7 +91,7 @@ module LibraBFT.Concrete.Properties
         → InSys (Abs.Q q) → InSys (Abs.Q q')
         → CommitRule rc  b
         → CommitRule rc' b'
-        → NonInjective-≡-preds _ _ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
+        → NonInjective-≡-preds (InSys ∘ B) (const Unit) Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
       ConcCommitsDoNotConflict' = CommitsDoNotConflict'
            (VO-obl.proof intSystemState (vss-votes-once validState))
            (PR-obl.proof intSystemState (vss-preferred-round validState))

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -31,19 +31,24 @@ module LibraBFT.Concrete.Properties
          (impl-correct : ImplObligations iiah 𝓔)
          where
 
-    open WithEC
-    open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
-    open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
-    import      LibraBFT.Concrete.Obligations.VotesOnce          𝓔 (ConcreteVoteEvidence 𝓔) as VO-obl
-    import      LibraBFT.Concrete.Obligations.PreferredRound     𝓔 (ConcreteVoteEvidence 𝓔) as PR-obl
-    open import LibraBFT.Concrete.Properties.VotesOnce                                       as VO
-    open import LibraBFT.Concrete.Properties.PreferredRound                                  as PR
-    open import LibraBFT.ImplShared.Util.HashCollisions iiah
+  open WithEC
+  open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
+  open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
+  import      LibraBFT.Concrete.Obligations.VotesOnce          𝓔 (ConcreteVoteEvidence 𝓔) as VO-obl
+  import      LibraBFT.Concrete.Obligations.PreferredRound     𝓔 (ConcreteVoteEvidence 𝓔) as PR-obl
+  open import LibraBFT.Concrete.Properties.VotesOnce                                       as VO
+  open import LibraBFT.Concrete.Properties.PreferredRound                                  as PR
+  open import LibraBFT.ImplShared.Util.HashCollisions iiah
 
-    open        ImplObligations impl-correct
-    open        PerState st
-    open        PerReachableState r
-    open        PerEpoch 𝓔
+  open        ImplObligations impl-correct
+  open        PerState st
+  open        PerReachableState r
+  open        PerEpoch 𝓔
+  open        IntermediateSystemState intSystemState
+
+  -- This module parameter asserts that there are no hash collisions between Blocks *in the system*,
+  -- allowing us to eliminate that case when the abstract properties claim it is the case.
+  module _ (no-collisions-InSys : NoCollisions InSys) where
 
     --------------------------------------------------------------------------------------------
     -- * A /ValidSysState/ is one in which both peer obligations are obeyed by honest peers * --
@@ -61,10 +66,8 @@ module LibraBFT.Concrete.Properties
       ; vss-preferred-round = PR.Proof.prr iiah 𝓔 sps-cor gvr v≢0 ∈GI? iro pr₁ pr₂ st r
       }
 
-    open IntermediateSystemState intSystemState
-
     open All-InSys-props InSys
-    open WithAssumptions InSys
+    open WithAssumptions InSys no-collisions-InSys
 
     -- We can now invoke the various abstract correctness properties.  Note that the arguments are
     -- expressed in Abstract terms (RecordChain, CommitRule).  Proving the corresponding properties
@@ -79,37 +82,25 @@ module LibraBFT.Concrete.Properties
        → {b b' : Abs.Block}
        → CommitRule rc  b
        → CommitRule rc' b'
-       → NonInjective-≡-pred (InSys ∘ B) Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
-    ConcCommitsDoNotConflict = CommitsDoNotConflict
-           (VO-obl.proof intSystemState (vss-votes-once validState))
-           (PR-obl.proof intSystemState (vss-preferred-round validState))
+       → (Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc
+    ConcCommitsDoNotConflict =
+      CommitsDoNotConflict
+        (VO-obl.proof intSystemState (vss-votes-once validState))
+        (PR-obl.proof intSystemState (vss-preferred-round validState))
 
     module _ (∈QC⇒AllSent : Complete InSys) where
 
-      ConcCommitsDoNotConflict' :
-        ∀{q q'}{rc  : RecordChain (Abs.Q q)}{rc' : RecordChain (Abs.Q q')}{b b' : Abs.Block}
-        → InSys (Abs.Q q) → InSys (Abs.Q q')
-        → CommitRule rc  b
-        → CommitRule rc' b'
-        → NonInjective-≡-preds (InSys ∘ B) (const Unit) Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
-      ConcCommitsDoNotConflict' = CommitsDoNotConflict'
-           (VO-obl.proof intSystemState (vss-votes-once validState))
-           (PR-obl.proof intSystemState (vss-preferred-round validState))
-           ∈QC⇒AllSent
-
-      ConcCommitsDoNotConflict''
+      ConcCommitsDoNotConflict'
         : ∀{o o' q q'}
-        → {rcf  : RecordChainFrom o  (Abs.Q q)}
-        → {rcf' : RecordChainFrom o' (Abs.Q q')}
+        → {rcf  : RecordChainFrom o  (Abs.Q q)}  → All-InSys rcf
+        → {rcf' : RecordChainFrom o' (Abs.Q q')} → All-InSys rcf'
         → {b b' : Abs.Block}
-        → InSys (Abs.Q q)
-        → InSys (Abs.Q q')
         → CommitRuleFrom rcf  b
         → CommitRuleFrom rcf' b'
-        → NonInjective-≡ Abs.bId ⊎ Σ (RecordChain (Abs.Q q')) ((Abs.B b)  ∈RC_)
-                                 ⊎ Σ (RecordChain (Abs.Q q))  ((Abs.B b') ∈RC_)
-      ConcCommitsDoNotConflict'' = CommitsDoNotConflict''
-           (VO-obl.proof intSystemState (vss-votes-once validState))
-           (PR-obl.proof intSystemState (vss-preferred-round validState))
-           ∈QC⇒AllSent
-
+        →   Σ (RecordChain (Abs.Q q')) ((Abs.B b)  ∈RC_)
+          ⊎ Σ (RecordChain (Abs.Q q))  ((Abs.B b') ∈RC_)
+      ConcCommitsDoNotConflict' =
+        CommitsDoNotConflict'
+          (VO-obl.proof intSystemState (vss-votes-once validState))
+          (PR-obl.proof intSystemState (vss-preferred-round validState))
+          ∈QC⇒AllSent

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -197,9 +197,8 @@ module executeAndInsertBlockE (bs0 : BlockStore) (block : Block) where
       ifD btRound ≥?ℕ block ^∙ bRound
       then LeftD fakeErr -- block with old round
       else step₂ bsr
-      -- else step₂ bsr
 
-  step₂ bsr = do
+  step₂ _ = do
         eb ← case⊎D executeBlockE bs0 block of λ where
           (Right res) → RightD res
           -- OBM-LBFT-DIFF : This is never thrown in OBM.
@@ -236,7 +235,9 @@ module executeAndInsertBlockE (bs0 : BlockStore) (block : Block) where
 
 executeAndInsertBlockE = executeAndInsertBlockE.E
 
-executeBlockE bs block = do
+module executeBlockE (bs : BlockStore) (block : Block) where
+
+  step₀ = do
 -- TODO-3: hook up proper implementation (in comments below).  Requires addressing the issue that
 -- doing so breaks the existing proof of executeAndInsertBlockESpec.contract₂, which currently
 -- violates an abstraction boundary and looks into the implementation of this function, rather than
@@ -246,12 +247,15 @@ executeBlockE bs block = do
     (Right stateComputeResult) →
 -}
       pure (ExecutedBlock∙new block stateComputeResult)
- where
-  here' : List String → List String
-  here' t = "BlockStore" ∷ "executeBlockE" {-∷ lsB block-} ∷ t
+   where
+    here' : List String → List String
+    here' t = "BlockStore" ∷ "executeBlockE" {-∷ lsB block-} ∷ t
 
-executeBlockE₀ bs block = fromEither $ executeBlockE bs block
-
+abstract
+  executeBlockE = executeBlockE.step₀
+  executeBlockE₀ bs block = fromEither $ executeBlockE bs block
+  executeBlockE≡ : ∀ {bs block r} → executeBlockE bs block ≡ r → executeBlockE₀ bs block ≡ fromEither r
+  executeBlockE≡ refl = refl
 ------------------------------------------------------------------------------
 
 insertSingleQuorumCertM

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockStore.agda
@@ -238,15 +238,10 @@ executeAndInsertBlockE = executeAndInsertBlockE.E
 module executeBlockE (bs : BlockStore) (block : Block) where
 
   step₀ = do
--- TODO-3: hook up proper implementation (in comments below).  Requires addressing the issue that
--- doing so breaks the existing proof of executeAndInsertBlockESpec.contract₂, which currently
--- violates an abstraction boundary and looks into the implementation of this function, rather than
--- using its contract.
-{-  case SCBS.compute (bs ^∙ bsStateComputer) block (block ^∙ bParentId) of λ where
-    (Left e)                   → Left fakeErr -- (here' e)
-    (Right stateComputeResult) →
--}
-      pure (ExecutedBlock∙new block stateComputeResult)
+    case SCBS.compute (bs ^∙ bsStateComputer) block (block ^∙ bParentId) of λ where
+      (Left e)                   → Left fakeErr -- (here' e)
+      (Right stateComputeResult) →
+        pure (ExecutedBlock∙new block stateComputeResult)
    where
     here' : List String → List String
     here' t = "BlockStore" ∷ "executeBlockE" {-∷ lsB block-} ∷ t

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -91,8 +91,8 @@ module insertBlockE (block : ExecutedBlock)(bt : BlockTree) where
         nothing → LeftD fakeErr
         (just parentBlock) → (do
           parentBlock' ← addChild parentBlock blockId
-          let bt' = bt & btIdToBlock ∙~ Map.insert (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
-          pure (  (bt' & btIdToBlock ∙~ Map.insert blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
+          let bt' = bt & btIdToBlock ∙~ Map.kvm-insert-Haskell (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
+          pure (  (bt' & btIdToBlock ∙~ Map.kvm-insert-Haskell blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
                , block))
 
   E : VariantFor Either

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -28,8 +28,9 @@ open Invariants
 module LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockTree where
 
 module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
-
   eb0Id = eb0 ^∙ ebId
+
+  open Reqs (eb0 ^∙ ebBlock) bt
 
   -- This is not quite right.  It does not yet account for the updating of the parent Block
   -- Is it needed (see below)?
@@ -40,12 +41,12 @@ module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
   record ContractOk (bt“ : BlockTree) (eb : ExecutedBlock) : Set where
     constructor mkContractOk
     field
-      bt≡x       : bt ≡ (bt“ & btIdToBlock ∙~ (bt ^∙ btIdToBlock))
-      blocks≈    : eb [ _≈Block_ ]L eb0 at ebBlock
+      bt≡x    : bt ≡ (bt“ & btIdToBlock ∙~ (bt ^∙ btIdToBlock))
       -- The following two fields are not used, but something like this will be useful in proving
       -- btiPres and may provide value in their own right
       ¬upd    : ∀ {eb'} → btGetBlock eb0Id bt ≡ just eb' → bt ≡ bt“
       upd     :           btGetBlock eb0Id bt ≡ nothing  →  Updated eb0Id bt bt“ eb
+      blocks≈ : NoHC1 → eb [ _≈Block_ ]L eb0 at ebBlock
       btiPres : ∀ {eci} → Preserves BlockTreeInv (bt , eci) (bt“ , eci)
 
   Contract : Either ErrLog (BlockTree × ExecutedBlock) → Set
@@ -54,18 +55,12 @@ module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
 
   open insertBlockE
 
-  record Requirements : Set where
-    constructor mkRequirements
-    field
-      reqNewBlock : ExecutedBlockHash-correct eb0 eb0Id
-      reqPreBlock : ∀ {eb} → btGetBlock eb0Id bt ≡ just eb → ExecutedBlockHash-correct eb eb0Id
+  postulate -- TODO-1: prove; note that the contract is stronger than we need because insertBlockE
+            -- is called only when btGetBlock eb0Id bt ≡ nothing in LibraBFT
+    contract' : EitherD-weakestPre (step₀ eb0 bt) Contract
 
-  postulate -- TODO-1: prove using hash≡⇒≈Block; note that the contract is stronger than we need
-            -- because insertBlockE is called only when btGetBlock eb0Id bt ≡ nothing in LibraBFT
-    contract' : Requirements → EitherD-weakestPre (step₀ eb0 bt) Contract
-
-  contract : Requirements → Contract (insertBlockE.E eb0 bt)
-  contract reqs = EitherD-contract (step₀ eb0 bt) Contract $ contract' reqs
+  contract : Contract (insertBlockE.E eb0 bt)
+  contract = EitherD-contract (step₀ eb0 bt) Contract contract'
 
 module insertQuorumCertESpec
   (qc : QuorumCert) (bt0  : BlockTree) where

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
@@ -123,6 +123,7 @@ module addCertsMSpec
       field
         -- General invariants / properties
         rmInv         : Preserves RoundManagerInv pre post
+        dnmBtIdToBlk  : post ≡L pre at (lBlockTree ∙ btIdToBlock)
         noEpochChange : NoEpochChange pre post
         noVoteOuts    : OutputProps.NoVotes outs
         -- Voting

--- a/LibraBFT/Impl/Consensus/EpochManager.agda
+++ b/LibraBFT/Impl/Consensus/EpochManager.agda
@@ -83,9 +83,9 @@ startRoundManager'
 ------------------------------------------------------------------------------
 
 new
-  : NodeConfig → {-StateComputer →-} PersistentLivenessStorage → Author → SK
+  : NodeConfig → StateComputer → PersistentLivenessStorage → Author → SK
   → Either ErrLog EpochManager
-new nodeConfig {-stateComputer-} persistentLivenessStorage obmAuthor obmSK = do
+new nodeConfig stateComputer persistentLivenessStorage obmAuthor obmSK = do
   let -- author = node_config.validator_network.as_ref().unwrap().peer_id();
       config = nodeConfig ^∙ ncConsensus
   safetyRulesManager ← SafetyRulesManager.new (config ^∙ ccSafetyRules) obmAuthor obmSK

--- a/LibraBFT/Impl/Consensus/Network/Properties.agda
+++ b/LibraBFT/Impl/Consensus/Network/Properties.agda
@@ -10,10 +10,13 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.NetworkMsg
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.Network
+open import LibraBFT.Impl.Properties.Util
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Consensus.Network.Properties where
+
+open Invariants
 
 module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : ValidatorVerifier) where
   postulate -- TODO-2: Refine contract
@@ -23,5 +26,5 @@ module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : Vali
       : case (processProposal proposal myEpoch vv) of λ where
           (Left _) → Unit
           (Right _) → proposal ^∙ pmProposal ∙ bEpoch ≡ myEpoch
-                      × hashBD (proposal ^∙ pmProposal ∙ bBlockData) ≡ proposal ^∙ pmProposal ∙ bId
+                      × BlockId-correct (proposal ^∙ pmProposal)
 

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -206,7 +206,7 @@ module executeAndVoteMSpec (b : Block) where
 
     contract
       : ∀ Post
-        → (∀ r st outs → Contract r st outs → Post r st outs)
+        → RWS-Post-⇒ Contract Post
         → LBFT-weakestPre (executeAndVoteM b) Post pre
     contract Post pf =
       RWS-⇒ Contract Post pf (executeAndVoteM b) unit pre contract'

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -183,7 +183,7 @@ module executeAndVoteMSpec (b : Block) where
                 vgc₃ bid≡ =
                   Voting.glue-VoteNotGenerated-VoteGeneratedCorrect
                     (mkVoteNotGenerated refl refl)
-                    (Voting.substVoteGeneratedCorrect proposedBlock b (EAIBECon.ebBlock≈ bid≡) vrc)
+                    (Voting.substVoteGeneratedCorrect proposedBlock b EAIBECon.ebBlock≈ vrc)
 
                 noMsgOutsBail₃ : ∀ outs → NoMsgs outs → NoMsgs (CASVouts ++ outs)
                 noMsgOutsBail₃ outs noMsgs = ++-NoMsgs CASVouts outs CASVCon.noMsgOuts noMsgs

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -282,8 +282,8 @@ module constructAndSignVoteMSpec where
 
         -- State invariants
         module _ where
-          btip₁ : Preserves BlockTreeInv (rm→BlockTree-EC pre) (rm→BlockTree-EC preUpdatedSD)
-          btip₁ = id
+          bsip₁ : Preserves BlockStoreInv (rm→BlockStore-EC pre) (rm→BlockStore-EC preUpdatedSD)
+          bsip₁ = id
 
           emP : Preserves EpochsMatch pre preUpdatedSD
           emP eq = trans eq (Requirements.es≡₁ reqs)
@@ -313,7 +313,7 @@ module constructAndSignVoteMSpec where
               ≤-trans round≤ (≤-trans (≡⇒≤ (Requirements.lvr≡ reqs)) (<⇒≤ r>lvr))
 
           invP₁ : Preserves RoundManagerInv pre preUpdatedSD
-          invP₁ = mkPreservesRoundManagerInv id emP btip₁ srP
+          invP₁ = mkPreservesRoundManagerInv id emP bsip₁ srP
 
         -- Some lemmas
         module _ where
@@ -366,15 +366,15 @@ module constructAndSignVoteMSpec where
 
             -- State invariants
             module _ where
-              btiP₂ : Preserves BlockTreeInv (rm→BlockTree-EC pre) (rm→BlockTree-EC preUpdatedSD₂)
-              btiP₂ = id
+              bsiP₂ : Preserves BlockStoreInv (rm→BlockStore-EC pre) (rm→BlockStore-EC preUpdatedSD₂)
+              bsiP₂ = id
 
               srP₂ : Preserves SafetyRulesInv (pre ^∙ lSafetyRules) (preUpdatedSD₂ ^∙ lSafetyRules)
               srP₂ = mkPreservesSafetyRulesInv
                        (const $ mkSafetyDataInv (Requirements.es≡₂ reqs) (≡⇒≤ (cong (_^∙ bRound) pb≡vpb)))
 
               invP₂ : Preserves RoundManagerInv pre preUpdatedSD₂
-              invP₂ = mkPreservesRoundManagerInv id emP btiP₂ srP₂
+              invP₂ = mkPreservesRoundManagerInv id emP bsiP₂ srP₂
 
     contract
       : ∀ pre Post

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -44,7 +44,7 @@ module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
   initRM-correct  : ValidatorVerifier-correct (Handle.fakeInitRM  ^∙ rmValidatorVerifer)
-  initRM-bsInv    : BlockTStoreInv (rm→BlockTree-EC Handle.fakeInitRM)
+  initRM-bsInv    : BlockStoreInv (rm→BlockStore-EC Handle.fakeInitRM)
   initRM-qcs      : QCProps.SigsForVotes∈Rm-SentB4 [] Handle.fakeInitRM
 
 initRMSatisfiesInv : RoundManagerInv Handle.fakeInitRM

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -42,12 +42,12 @@ module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
   initRM-correct : ValidatorVerifier-correct (initRM ^∙ rmValidatorVerifer)
-  initRM-btInv   : BlockTreeInv (rm→BlockTree-EC initRM)
+  initRM-bsInv   : BlockStoreInv (rm→BlockStore-EC initRM)
   initRM-qcs     : QCProps.SigsForVotes∈Rm-SentB4 [] initRM
 
 initRMSatisfiesInv : RoundManagerInv initRM
 initRMSatisfiesInv =
-  mkRoundManagerInv initRM-correct refl initRM-btInv
+  mkRoundManagerInv initRM-correct refl initRM-bsInv
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
 
 invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in an `Properties.Invariants` module
@@ -215,9 +215,21 @@ lastVotedRound-mono pid pre{ppost} preach ini (step-msg{_ , m} m∈pool ini₁) 
     help : Meta.getLastVoteRound (hpPre ^∙ pssSafetyData-rm) ≤ Meta.getLastVoteRound (hpPst ^∙ pssSafetyData-rm)
     help = ≤-trans (SafetyDataInv.lvRound≤ ∘ SafetyRulesInv.sdInv $ rmSafetyRulesInv ) (≤-trans (<⇒≤ lvr<) (≡⇒≤ (trans (sym lvr≡) $ cong (maybe {B = const ℕ} (_^∙ vRound) 0) lv≡v)))
 
+  open Invariants
+  open Reqs (pm ^∙ pmProposal) (hpPre ^∙ lBlockTree)
+  open BlockTreeInv
+  open BlockStoreInv
+  open RoundManagerInv
+
+  rmi : _
+  rmi = invariantsCorrect pid pre preach
+
   help : Meta.getLastVoteRound (hpPre ^∙ pssSafetyData-rm) ≤ Meta.getLastVoteRound (hpPst ^∙ pssSafetyData-rm)
   help
-    with voteAttemptCorrect
+    with BlockId-correct? (pm ^∙ pmProposal)
+  ...| no ¬validProposal = VoteOld.help (cong (_^∙ pssSafetyData-rm ∙ sdLastVote) (proj₁ $ invalidProposal ¬validProposal))
+  ...| yes pmIdCorr
+       with voteAttemptCorrect pmIdCorr (nohc preach m∈pool pid ini rmi refl pmIdCorr)
   ...| Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?
     with nvg⊎vgusc
   ...| inj₁ (mkVoteNotGenerated lv≡ lvr≤) = VoteOld.help lv≡
@@ -226,6 +238,7 @@ lastVotedRound-mono pid pre{ppost} preach ini (step-msg{_ , m} m∈pool ini₁) 
   ...| inj₁ (mkVoteOldGenerated lvr≡ lv≡) = VoteOld.help lv≡
   ...| inj₂ (mkVoteNewGenerated lvr< lvr≡) = VoteNew.help lv≡v lvr< lvr≡
   help
+     | yes refl
      | Voting.mkVoteAttemptCorrectWithEpochReq (Right (Voting.mkVoteSentCorrect vm _ _ (Voting.mkVoteGeneratedCorrect (mkVoteGenerated lv≡v voteSrc) _))) sdEpoch≡?
     with voteSrc
   ...| Left (mkVoteOldGenerated lvr≡ lv≡) = VoteOld.help lv≡

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -44,14 +44,18 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
 
   module _ (pool : SentMessages) (pre : RoundManager) where
 
+    open Invariants.Reqs (pm ^∙ pmProposal) (pre ^∙ lBlockTree)
+
     record Contract (_ : Unit) (post : RoundManager) (outs : List Output) : Set where
       constructor mkContract
       field
         -- General properties / invariants
         rmInv              : Preserves RoundManagerInv pre post
+        invalidProposal    : ¬ (BlockId-correct (pm ^∙ pmProposal)) → pre ≡ post × OutputProps.NoVotes outs
         noEpochChange      : NoEpochChange pre post
         -- Voting
-        voteAttemptCorrect : Voting.VoteAttemptCorrectWithEpochReq pre post outs (pm ^∙ pmProposal)
+        voteAttemptCorrect : BlockId-correct (pm ^∙ pmProposal)
+                           → NoHC1 → Voting.VoteAttemptCorrectWithEpochReq pre post outs (pm ^∙ pmProposal)
         -- QCs
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
         qcPost    : QCProps.∈Post⇒∈PreOr (_QC∈NM (P pm)) pre post
@@ -68,12 +72,12 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
 
       contractBail : ∀ outs → OutputProps.NoMsgs outs → Contract unit pre outs
       contractBail outs noMsgs =
-        mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
+        mkContract reflPreservesRoundManagerInv (const $ refl , OutputProps.NoMsgs⇒NoVotes outs noMsgs) (reflNoEpochChange{pre})
           vac outQcs∈RM qcPost
         where
-        vac : Voting.VoteAttemptCorrectWithEpochReq pre pre outs (pm ^∙ pmProposal)
-        vac = Voting.mkVoteAttemptCorrectWithEpochReq
-                (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs noMsgs)) tt
+        vac : BlockId-correct (pm ^∙ pmProposal) → NoHC1 → Voting.VoteAttemptCorrectWithEpochReq pre pre outs (pm ^∙ pmProposal)
+        vac _ _ = Voting.mkVoteAttemptCorrectWithEpochReq
+                    (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs noMsgs)) tt
 
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs pre
         outQcs∈RM = QCProps.NoMsgs⇒OutputQc∈RoundManager outs pre noMsgs
@@ -87,30 +91,32 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
       proj₁ (contract-step₁ (myEpoch@._ , vv@._) refl) (inj₂ i) pp≡Left =
         contractBail _ refl
       proj₂ (contract-step₁ (myEpoch@._ , vv@._) refl) unit pp≡Right =
-        processProposalMsgMSpec.contract now pm pre Contract pf
+        processProposalMsgMSpec.contract now pm proposalId≡ pre Contract pf
         where
-        module PPM = processProposalMsgMSpec now pm
 
         sdEpoch≡ : pre ^∙ pssSafetyData-rm ∙ sdEpoch ≡ pm ^∙ pmProposal ∙ bEpoch
         sdEpoch≡
           with processProposalSpec.contract pm myEpoch vv
         ...| con rewrite pp≡Right = sym (proj₁ con)
 
-        proposalId≡ : hashBD (pm ^∙ pmProposal ∙ bBlockData) ≡ pm ^∙ pmProposal ∙ bId
+        proposalId≡ : BlockId-correct (pm ^∙ pmProposal)
         proposalId≡
            with processProposalSpec.contract pm myEpoch vv
         ...| con rewrite pp≡Right = proj₂ con
 
+        module PPM = processProposalMsgMSpec now pm proposalId≡
+
         pf : RWS-Post-⇒ (PPM.Contract pre) Contract
         pf unit st outs con =
-          mkContract PPMSpec.rmInv PPMSpec.noEpochChange
+          mkContract PPMSpec.rmInv (λ x → ⊥-elim (x proposalId≡)) PPMSpec.noEpochChange
             vac PPMSpec.outQcs∈RM PPMSpec.qcPost
           where
           module PPMSpec = processProposalMsgMSpec.Contract con
 
-          vac : Voting.VoteAttemptCorrectWithEpochReq pre st outs (pm ^∙ pmProposal)
-          vac = Voting.mkVoteAttemptCorrectWithEpochReq (PPMSpec.voteAttemptCorrect proposalId≡)
-                  (Voting.voteAttemptEpochReq! (PPMSpec.voteAttemptCorrect proposalId≡) sdEpoch≡)
+          vac : BlockId-correct (pm ^∙ pmProposal) → NoHC1
+              → Voting.VoteAttemptCorrectWithEpochReq pre st outs (pm ^∙ pmProposal)
+          vac _ nohc = Voting.mkVoteAttemptCorrectWithEpochReq (PPMSpec.voteAttemptCorrect nohc)
+                         (Voting.voteAttemptEpochReq! (PPMSpec.voteAttemptCorrect nohc) sdEpoch≡)
 
     contract! : LBFT-Post-True Contract (handleProposal now pm) pre
     contract! = LBFT-contract (handleProposal now pm) Contract pre contract

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -359,6 +359,14 @@ module Invariants where
       rmSafetyRulesInv : SafetyRulesInv (rm ^∙ lSafetyRules)
   open RoundManagerInv
 
+  module Reqs (b : Block) (bt : BlockTree) where
+    -- TODO: State and use assumptions about hash collisions.  The following is one example that will
+    -- likely need to be refined.
+    NoHC1 = ∀ {eb}
+            → btGetBlock (b ^∙ bId) bt ≡ just eb
+            → BlockId-correct b
+            → (eb ^∙ ebBlock) ≈Block b
+
 
   -- Valid blocks have IDs computed by the hash of their BlockData
   -- These are passed as module parameters through the proofs

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -24,7 +24,7 @@ open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
 open import Optics.All
 
-open import LibraBFT.ImplShared.Util.HashCollisions InitAndHandlers
+open import LibraBFT.ImplShared.Util.HashCollisions Handle.fakeInitAndHandlers
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open        ParamsWithInitAndHandlers Handle.fakeInitAndHandlers
 open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms Handle.fakeInitAndHandlers PeerCanSignForPK PeerCanSignForPK-stable

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -260,9 +260,15 @@ module Invariants where
   AllValidQCs : (𝓔 : EpochConfig) (bt : BlockTree) → Set
   AllValidQCs 𝓔 bt = (hash : HashValue) → maybe (WithEC.MetaIsValidQC 𝓔) ⊤ (lookup hash (bt ^∙ btIdToQuorumCert))
 
+  BlockHash-correct : Block → HashValue → Set
+  BlockHash-correct b bid = hashBD (b ^∙ bBlockData) ≡ bid
+
+
+  ExecutedBlockHash-correct : ExecutedBlock → HashValue → Set
+  ExecutedBlockHash-correct = BlockHash-correct ∘ (_^∙ ebBlock)
   ValidBlock : HashValue → ExecutedBlock → Set
   ValidBlock bid eb = eb ^∙ ebBlock ∙ bId ≡ bid
-                    × hashBD (eb ^∙ ebBlock ∙ bBlockData) ≡ bid
+                    × ExecutedBlockHash-correct eb bid
 
   AllValidBlocks : BlockTree → Set
   AllValidBlocks bt = ∀ {bid eb}

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -24,6 +24,7 @@ open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
 open import Optics.All
 
+open import LibraBFT.ImplShared.Util.HashCollisions InitAndHandlers
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open        ParamsWithInitAndHandlers InitAndHandlers
 open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers PeerCanSignForPK PeerCanSignForPK-stable
@@ -38,6 +39,9 @@ module Meta where
   getLastVoteRound : SafetyData → Round
   getLastVoteRound = (maybe{B = const Round} (_^∙ vRound) 0) ∘ (_^∙ sdLastVote)
   -- getLastVoteRound = maybe{B = const Round} (_^∙ vRound) 0 ∘ (_^∙ pssSafetyData-rm ∙ sdLastVote)
+
+  subst-getLastVoteRound : ∀ {sd1 sd2} → sd1 ≡ sd2 → getLastVoteRound sd1 ≡ getLastVoteRound sd2
+  subst-getLastVoteRound refl = refl
 
 module OutputProps where
   module _ (outs : List Output) where
@@ -90,33 +94,18 @@ module OutputProps where
     |       nv
     |       ov = refl
 
+
+module BlockProps (b : Block) where
+  ∈BlockTree_      : BlockTree → Set
+  ∈BlockTree bt    = ∃[ eb ] (btGetBlock (b ^∙ bId) bt ≡ just eb)
+
+  ∈BlockStore_     : BlockStore → Set
+  ∈BlockStore bs   = ∈BlockTree (bs ^∙ bsInner)
+
+  ∈RoundManager_   : RoundManager → Set
+  ∈RoundManager rm = ∈BlockStore (rm ^∙ lBlockStore)
+
 module QCProps where
-
-  record MsgRequirements (pool : SentMessages) (msg : NetworkMsg) : Set where
-    constructor mkMsgRequirements
-    field
-      mSndr  : NodeId
-      m∈pool : (mSndr , msg) ∈ pool
-
-  record SyncInfoRequirements (pool : SentMessages) (syncInfo : SyncInfo) : Set where
-    constructor mkSyncInfoRequirements
-    field
-      msg     : NetworkMsg
-      msgReqs : MsgRequirements pool msg
-      syncInfo∈msg : syncInfo SyncInfo∈NM msg
-    open MsgRequirements msgReqs
-
-  record BlockRequirements (pool : SentMessages) (block : Block) : Set where
-    constructor mkBlockRequirements
-    field
-      msg       : NetworkMsg
-      msgReqs   : MsgRequirements pool msg
-      block∈msg : block Block∈Msg msg
-
-  QCRequirements : (pool : SentMessages) (qc : QuorumCert) → Set
-  QCRequirements pool qc =
-    ∃[ si ] (qc QC∈SyncInfo si × SyncInfoRequirements pool si)
-    ⊎ ⊥ -- TODO: qc came from aggregated votes received by proposer
 
   data _∈BlockTree_ (qc : QuorumCert) (bt : BlockTree) : Set where
     inHQC : qc ≡ bt ^∙ btHighestQuorumCert → qc ∈BlockTree bt
@@ -256,29 +245,36 @@ module QCProps where
     MsgWithSig∈-++ʳ{ms = msgs} (sfvb4 qc∈rm sig vs∈qc rbld≈v ¬gen)
 
 module Invariants where
+
+  ------------ properties relating the ids of (Executed)Blocks to hashes of their BlockData
+
+  BlockHash≡ : Block → HashValue → Set
+  BlockHash≡ b hv =  hashBlock b ≡ hv
+
+  BlockId-correct : Block → Set
+  BlockId-correct b = BlockHash≡ b (b ^∙ bId)
+
+  BlockId-correct? : (b : Block) → Dec (BlockId-correct b)
+  BlockId-correct? b = hashBlock b ≟Hash (b ^∙ bId)
+
+  ExecutedBlockId-correct : ExecutedBlock → Set
+  ExecutedBlockId-correct = BlockId-correct ∘ (_^∙ ebBlock)
+
+  ------------ properties for BlockTree validity
+
   -- The property that a block tree `bt` has only valid QCs with respect to epoch config `𝓔`
   AllValidQCs : (𝓔 : EpochConfig) (bt : BlockTree) → Set
   AllValidQCs 𝓔 bt = (hash : HashValue) → maybe (WithEC.MetaIsValidQC 𝓔) ⊤ (lookup hash (bt ^∙ btIdToQuorumCert))
 
-  BlockHash-correct : Block → HashValue → Set
-  BlockHash-correct b bid = hashBD (b ^∙ bBlockData) ≡ bid
-
-  postulate -- TODO-2: move somewhere sensible and prove
-    hash≡⇒≈Block : ∀ {b1 b2 : Block} {bid : HashValue}
-                   → BlockHash-correct b1 bid
-                   → BlockHash-correct b2 bid
-                   → b1 ≈Block b2
-
-  ExecutedBlockHash-correct : ExecutedBlock → HashValue → Set
-  ExecutedBlockHash-correct = BlockHash-correct ∘ (_^∙ ebBlock)
-  ValidBlock : HashValue → ExecutedBlock → Set
-  ValidBlock bid eb = eb ^∙ ebBlock ∙ bId ≡ bid
-                    × ExecutedBlockHash-correct eb bid
+  -- TODO: define a record?
+  ValidEValidBlock         = Σ Block         BlockId-correct
 
   AllValidBlocks : BlockTree → Set
   AllValidBlocks bt = ∀ {bid eb}
                     → btGetBlock bid bt ≡ just eb
-                    → ValidBlock bid eb
+                    → BlockId-correct (eb ^∙ ebBlock) × BlockHash≡ (eb ^∙ ebBlock)  bid
+
+  ------------ types for and definitions of invariants for BlockTree, BlockStore, SafetyData, SafetyRules
 
   record ECinfo : Set where
     constructor mkECinfo
@@ -287,20 +283,11 @@ module Invariants where
       ecEP : Epoch
   open ECinfo
 
-  rm→ECinfo : RoundManager → ECinfo
-  rm→ECinfo rm = mkECinfo (rm ^∙ rmEpochState ∙ esVerifier) (rm ^∙ rmEpoch)
-
   WithECinfo : Set → Set
   WithECinfo A = A × ECinfo
 
   BlockTree-EC  = WithECinfo BlockTree
   BlockStore-EC = WithECinfo BlockStore
-
-  rm→BlockTree-EC : RoundManager → BlockTree-EC
-  rm→BlockTree-EC rm = (rm ^∙ lBlockStore ∙ bsInner , rm→ECinfo rm)
-
-  rm→BlockStore-EC : RoundManager → BlockStore-EC
-  rm→BlockStore-EC rm = (rm ^∙ lBlockStore , rm→ECinfo rm)
 
   module _ (btEC : BlockTree-EC) where
     private
@@ -314,7 +301,7 @@ module Invariants where
       field
         allValidQCs    : (vvC : ValidatorVerifier-correct $ vv) → AllValidQCs (α-EC-VV (vv , vvC) ep) bt
         allValidBlocks : AllValidBlocks bt
-    open BlockTreeInv
+  open BlockTreeInv
 
   module _ (bsEC : BlockStore-EC) where
     private
@@ -325,7 +312,7 @@ module Invariants where
       constructor mkBlockStoreInv
       field
         blockTreeValid : BlockTreeInv (bs ^∙ bsInner , eci)
-    open BlockTreeInv
+  open BlockStoreInv
 
   module _ (sd : SafetyData) where
     -- SafetyRules invariants
@@ -343,24 +330,48 @@ module Invariants where
         sdInv : SafetyDataInv (sr ^∙ srPersistentStorage ∙ pssSafetyData)
   open SafetyRulesInv
 
-  module _ (rm : RoundManager) where
+  ------------ types for and definition of RoundManagerInv
 
-    EpochsMatch : Set
-    EpochsMatch = rm ^∙ rmEpochState ∙ esEpoch ≡ rm ^∙ pssSafetyData-rm ∙ sdEpoch
+  EpochsMatch : RoundManager → Set
+  EpochsMatch rm = rm ^∙ rmEpochState ∙ esEpoch ≡ rm ^∙ pssSafetyData-rm ∙ sdEpoch
 
-    -- NOTE: This will be proved by induction on reachable states using the
-    -- property that peer handlers preserve invariants. That is to say, many of
-    -- these cannot be proven as a post-condition of the peer handler: one can
-    -- only prove of the handler that if the invariant holds for the prestate,
-    -- then it holds for the poststate.
+  rm→ECinfo : RoundManager → ECinfo
+  rm→ECinfo rm = mkECinfo (rm ^∙ rmEpochState ∙ esVerifier) (rm ^∙ rmEpoch)
 
-    record RoundManagerInv : Set where
-      constructor mkRoundManagerInv
-      field
-        rmCorrect        : ValidatorVerifier-correct (rm ^∙ rmValidatorVerifer)
-        rmEpochsMatch    : EpochsMatch
-        rmBlockTreeInv   : BlockTreeInv (rm→BlockTree-EC rm)
-        rmSafetyRulesInv : SafetyRulesInv (rm ^∙ lSafetyRules)
+  rm→BlockTree-EC : RoundManager → BlockTree-EC
+  rm→BlockTree-EC rm = (rm ^∙ lBlockStore ∙ bsInner , rm→ECinfo rm)
+
+  rm→BlockStore-EC : RoundManager → BlockStore-EC
+  rm→BlockStore-EC rm = (rm ^∙ lBlockStore , rm→ECinfo rm)
+
+  -- NOTE: This will be proved by induction on reachable states using the
+  -- property that peer handlers preserve invariants. That is to say, many of
+  -- these cannot be proven as a post-condition of the peer handler: one can
+  -- only prove of the handler that if the invariant holds for the prestate,
+  -- then it holds for the poststate.
+
+  record RoundManagerInv (rm : RoundManager) : Set where
+    constructor mkRoundManagerInv
+    field
+      rmCorrect        : ValidatorVerifier-correct (rm ^∙ rmValidatorVerifer)
+      rmEpochsMatch    : EpochsMatch rm
+      rmBlockStoreInv  : BlockStoreInv  (rm→BlockStore-EC rm)
+      rmSafetyRulesInv : SafetyRulesInv (rm ^∙ lSafetyRules)
+  open RoundManagerInv
+
+
+  -- Valid blocks have IDs computed by the hash of their BlockData
+  -- These are passed as module parameters through the proofs
+
+  ValidBlock = Σ Block BlockId-correct
+
+  vbBlock : ValidBlock → Block
+  vbBlock = proj₁
+
+  vbValid : (vb : ValidBlock) → BlockId-correct (vbBlock vb)
+  vbValid = proj₂
+
+  ------------ Preserves and related definitions and utilities
 
   Preserves : ∀ {ℓ} {A : Set} → (P : A → Set ℓ) (pre post : A) → Set ℓ
   Preserves Pred pre post = Pred pre → Pred post
@@ -405,7 +416,7 @@ module Invariants where
     : ∀ {pre post}
       → Preserves ValidatorVerifier-correct (pre ^∙ rmValidatorVerifer) (post ^∙ rmValidatorVerifer)
       → Preserves EpochsMatch                pre                         post
-      → Preserves BlockTreeInv              (rm→BlockTree-EC pre)       (rm→BlockTree-EC post)
+      → Preserves BlockStoreInv             (rm→BlockStore-EC pre)      (rm→BlockStore-EC post)
       → Preserves SafetyRulesInv            (pre ^∙ rmSafetyRules)      (post ^∙ rmSafetyRules)
       → Preserves RoundManagerInv            pre                         post
   mkPreservesRoundManagerInv rmP emP bsP srP (mkRoundManagerInv rmCorrect epochsMatch bsInv srInv) =
@@ -533,6 +544,8 @@ module RoundManagerTransProps where
 
 -- Properties for voting
 module Voting where
+
+  open Invariants
 
   VoteEpochIs : (vote : Vote) (e : Epoch) → Set
   VoteEpochIs vote e = vote ^∙ vEpoch ≡ e

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -263,6 +263,11 @@ module Invariants where
   BlockHash-correct : Block → HashValue → Set
   BlockHash-correct b bid = hashBD (b ^∙ bBlockData) ≡ bid
 
+  postulate -- TODO-2: move somewhere sensible and prove
+    hash≡⇒≈Block : ∀ {b1 b2 : Block} {bid : HashValue}
+                   → BlockHash-correct b1 bid
+                   → BlockHash-correct b2 bid
+                   → b1 ≈Block b2
 
   ExecutedBlockHash-correct : ExecutedBlock → HashValue → Set
   ExecutedBlockHash-correct = BlockHash-correct ∘ (_^∙ ebBlock)

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -451,7 +451,7 @@ votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr
    with cong _vSignature v≈rbld
 ...| refl = ⊥-elim ∘′ ¬msb $ qcVoteSigsSentB4-handle pid preach sps m∈acts qc∈m sig vs∈qc v≈rbld ¬bootstrap
 
-votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈outs sig ¬bootstrap ¬msb pcspkv v'⊂m' m'∈pool sig' ¬bootstrap' eid≡
+votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈acts sig ¬bootstrap ¬msb pcspkv v'⊂m' m'∈pool sig' ¬bootstrap' eid≡
   with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid)
 ...| handleProposalSpec.mkContract _ invProp noEpochChange vac _ _
    with BlockId-correct? (pm ^∙ pmProposal)

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -548,9 +548,14 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   bPayload : Lens Block (Maybe TX)
   bPayload = bBlockData ∙ bdPayload
 
+  bdQcSigs : Lens Block (KVMap Author Signature)
+  bdQcSigs = bBlockData ∙ bdQuorumCert ∙ qcLedgerInfo ∙ liwsSignatures
+
+  -- Equivalence of Blocks modulo signatures (both on the Block and in the QuorumCert it contains)
   infix 4 _≈Block_
   _≈Block_ : (b₁ b₂ : Block) → Set
-  b₁ ≈Block b₂ = b₁ ≡ record b₂ { _bSignature = _bSignature b₁ }
+  b₁ ≈Block b₂ = b₁ ≡ (b₂ & bSignature ∙~ (b₁ ^∙ bSignature)
+                          & bdQcSigs   ∙~ (b₁ ^∙ bdQcSigs))
 
   sym≈Block : Symmetric _≈Block_
   sym≈Block refl = refl

--- a/LibraBFT/ImplShared/Util/Crypto.agda
+++ b/LibraBFT/ImplShared/Util/Crypto.agda
@@ -58,9 +58,16 @@ module LibraBFT.ImplShared.Util.Crypto where
       bdInjBTGen  : bd1 ^∙ bdBlockType ≡ Genesis  → bd2 ^∙ bdBlockType ≡ Genesis
       bdInjBTProp : ∀ {tx}{auth} → bd1 ^∙ bdBlockType ≡ Proposal tx auth
                                  → bd1 ^∙ bdBlockType ≡ bd2 ^∙ bdBlockType
+  postulate
+    hashBD-bs  : BlockData → BitString
+
+  hashBD : BlockData → HashValue
+  hashBD = sha256 ∘ hashBD-bs
+
+  _hasSameHashInput-BD_ : BlockData → BlockData → Set
+  bd1 hasSameHashInput-BD bd2 = hashBD-bs bd1 ≡ hashBD-bs bd2
 
   postulate
-    hashBD     : BlockData → HashValue
     hashBD-inj : ∀ {bd1 bd2}
                → hashBD bd1 ≡ hashBD bd2
                → NonInjective-≡ sha256 ⊎ BlockDataInjectivityProps bd1 bd2

--- a/LibraBFT/ImplShared/Util/Dijkstra/EitherD.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/EitherD.agda
@@ -49,6 +49,9 @@ EitherD-Pre E A = Set
 EitherD-Post : (E A : Set) → Set₁
 EitherD-Post E A = Either E A → Set
 
+EitherD-Post-⇒ : ∀ {E A : Set} → (P Q : EitherD-Post E A) → Set
+EitherD-Post-⇒ P Q = ∀ r → P r → Q r
+
 EitherD-PredTrans : (E A : Set) → Set₁
 EitherD-PredTrans E A = EitherD-Post E A → EitherD-Pre E A
 
@@ -107,3 +110,11 @@ EitherD-contract (EitherD-maybe nothing f₁ f₂) P wp =
   EitherD-contract f₁ P (proj₁ wp refl)
 EitherD-contract (EitherD-maybe (just x) f₁ f₂) P wp =
   EitherD-contract (f₂ x) P (proj₂ wp x refl)
+
+postulate -- TODO-2: prove
+  EitherD-⇒
+    : (P Q : EitherD-Post E A)
+      → (EitherD-Post-⇒ P Q)
+      → ∀ m
+      → EitherD-weakestPre m P
+      → EitherD-weakestPre m Q

--- a/LibraBFT/ImplShared/Util/Dijkstra/RWS.agda
+++ b/LibraBFT/ImplShared/Util/Dijkstra/RWS.agda
@@ -104,6 +104,10 @@ RWS-Post Wr St A = (x : A) (post : St) (outs : List Wr) → Set
 RWS-Post-⇒ : (P Q : RWS-Post Wr St A) → Set
 RWS-Post-⇒ P Q = ∀ r st outs → P r st outs → Q r st outs
 
+RWS-Post-⇒-trans : {P Q R : RWS-Post Wr St A}
+                 → RWS-Post-⇒ P Q → RWS-Post-⇒ Q R → RWS-Post-⇒ P R
+RWS-Post-⇒-trans p⇒q q⇒r r st outs p = q⇒r _ _ _ (p⇒q _ _ _ p)
+
 -- RWS-weakestPre computes a predicate transformer: it maps a RWS
 -- computation `m` and desired postcondition `Post` to the weakest precondition
 -- needed to prove `P` holds after running `m`.

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -300,7 +300,26 @@ module LibraBFT.Prelude where
     using (_∪?_)
     public
 
-  -- Evidence that a function is not injective
+  -- Injectivity for a function of two potentially different types (A and B) via functions to a
+  -- common type (C).
+
+  Injective' : ∀ {b c d e}{B : Set b}{C : Set c}{D : Set d} → (hB : B → D) → (hC : C → D) → (_≈_ : B → C → Set e) → Set _
+  Injective' {C = C} hB hC _≈_ = ∀ {b c} → hB b ≡ hC c → b ≈ c
+
+  Injective  : ∀ {c d e}{C : Set c}{D : Set d} → (h : C → D) → (_≈_ : Rel C e) → Set _
+  Injective h _≈_ = Injective' h h _≈_
+
+  Injective-≡ : ∀ {c d}{C : Set c}{D : Set d} → (h : C → D) → Set _
+  Injective-≡ h = Injective h _≡_
+
+  Injective-int : ∀{a b c d e}{A : Set a}{B : Set b}{C : Set c}{D : Set d}
+                → (_≈_ : A → B → Set e)
+                → (h  : C → D)
+                → (f₁ : A → C)
+                → (f₂ : B → C)
+                → Set (a ℓ⊔ b ℓ⊔ d ℓ⊔ e)
+  Injective-int _≈_ h f₁ f₂ = ∀ {a₁} {b₁} → h (f₁ a₁) ≡ h (f₂ b₁) → a₁ ≈ b₁
+
   NonInjective : ∀{a b c}{A : Set a}{B : Set b}
                → (_≈_ : Rel A c)
                → (A → B) → Set (a ℓ⊔ b ℓ⊔ c)

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -331,10 +331,10 @@ module LibraBFT.Prelude where
   NonInjective-≡ = NonInjective _≡_
 
   NonInjective-≡-preds : ∀{a b}{A : Set a}{B : Set b}{ℓ₁ ℓ₂ : Level}
-                      → (P1 : A → Set ℓ₁)
-                      → (P2 : A → Set ℓ₂)
+                      → (A → Set ℓ₁)
+                      → (A → Set ℓ₂)
                       → (A → B) → Set (a ℓ⊔ b ℓ⊔ ℓ₁ ℓ⊔ ℓ₂)
-  NonInjective-≡-preds Pred1 Pred2 f = Σ (NonInjective _≡_ f) λ { ((a₀ , a₁) , a₀≢a₁ , fa₀≡fa₁) → Pred1 a₀ × Pred2 a₁ }
+  NonInjective-≡-preds Pred1 Pred2 f = Σ (NonInjective _≡_ f) λ { ((a₀ , a₁) , _ , _) → Pred1 a₀ × Pred2 a₁ }
 
   NonInjective-≡-pred : ∀{a b}{A : Set a}{B : Set b}{ℓ : Level}
                       → (P : A → Set ℓ)

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -330,6 +330,17 @@ module LibraBFT.Prelude where
                  → (A → B) → Set (a ℓ⊔ b)
   NonInjective-≡ = NonInjective _≡_
 
+  NonInjective-≡-preds : ∀{a b}{A : Set a}{B : Set b}{ℓ₁ ℓ₂ : Level}
+                      → (P1 : A → Set ℓ₁)
+                      → (P2 : A → Set ℓ₂)
+                      → (A → B) → Set (a ℓ⊔ b ℓ⊔ ℓ₁ ℓ⊔ ℓ₂)
+  NonInjective-≡-preds Pred1 Pred2 f = Σ (NonInjective _≡_ f) λ { ((a₀ , a₁) , a₀≢a₁ , fa₀≡fa₁) → Pred1 a₀ × Pred2 a₁ }
+
+  NonInjective-≡-pred : ∀{a b}{A : Set a}{B : Set b}{ℓ : Level}
+                      → (P : A → Set ℓ)
+                      → (A → B) → Set (a ℓ⊔ b ℓ⊔ ℓ)
+  NonInjective-≡-pred Pred = NonInjective-≡-preds Pred Pred
+
   NonInjective-∘ : ∀{a b c}{A : Set a}{B : Set b}{C : Set c}
                  → {f : A → B}(g : B → C)
                  → NonInjective-≡  f

--- a/Optics/Functorial.agda
+++ b/Optics/Functorial.agda
@@ -72,10 +72,21 @@ module Optics.Functorial where
   _∙_ : ∀{S A B} → Lens S A → Lens A B → Lens S B
   (lens p) ∙ (lens q) = lens (λ F rf x x₁ → p F rf (q F rf x) x₁)
 
-  -- Relation between the same field of two states
+  -- Relation between the same field of two states This most general form allows us to specify a
+  -- Lens S A, a function A → B, and a relation between two B's, and holds iff the relation holds
+  -- between the values yielded by applying the Lens to two S's and then applying the function to
+  -- the results; more specific variants are provided below
+  _[_]L_f=_at_ : ∀ {ℓ} {S A B : Set} → S → (B → B → Set ℓ) → S → (A → B) → Lens S A → Set ℓ
+  s₁ [ _~_ ]L s₂ f= f at l = f (s₁ ^∙ l) ~ f (s₂ ^∙ l)
+
   _[_]L_at_ : ∀ {ℓ} {S A} → S → (A → A → Set ℓ) → S → Lens S A → Set ℓ
-  s₁ [ _~_ ]L s₂ at l = (s₁ ^∙ l) ~ (s₂ ^∙ l)
+  s₁ [ _~_ ]L s₂ at l = _[_]L_f=_at_ s₁ _~_ s₂ id l
+
+  infix 4 _≡L_f=_at_
+  _≡L_f=_at_ : ∀ {S A B : Set} → (s₁ s₂ : S) → (A → B) → Lens S A → Set
+  s₁ ≡L s₂ f= f at l = _[_]L_f=_at_ s₁ _≡_ s₂ f l
 
   infix 4 _≡L_at_
   _≡L_at_ : ∀ {S A} → (s₁ s₂ : S) → Lens S A → Set
-  _≡L_at_ = _[ _≡_ ]L_at_
+  s₁ ≡L s₂ at l = _[_]L_f=_at_ s₁ _≡_ s₂ id l
+

--- a/docs/PeerHandlerContracts.org
+++ b/docs/PeerHandlerContracts.org
@@ -473,12 +473,17 @@ abstract
     general) behaves in Agda.
 
     At the time of writing, there is no set discipline for when to use
-    =abstract= blocks. Conceivably, they could be used for *every* function,
-    since this would greatly improve the readability of the proof state for any
+    =abstract= blocks. Arguably, they should be used for *every* nontrivial function,
+    for several reasons.  First, it significantly improves the readability of the proof state for any
     peer handler contract proof. This is especially true in the instances where
     =with= or =rewrite= are used, which irrevocably normalize the proof state in
     an attempt to abstract over the given expression in both the goal type and
-    the type of (non-parameter) variables in context.
+    the type of (non-parameter) variables in context.  Second, it enforces
+    abstraction boundaries between functions, ensuring that changing the
+    implementation of a function doesn't change the shape of proofs of
+    functions that call it.  The overhead of this is that we must state and prove
+    explicit contracts for each function, but it is worth it for the sake of
+    sustainability.  For an example, see ~executeBlockESpec~ in 
 
 
 * Peer handler code


### PR DESCRIPTION
This pull request makes the `Abstract` properties hold unless they can provide a specific example of noninjectivity of abstract `Block`s that are "in the system".  This removes the possibility for the proofs to cheat by simply creating a pair of different `Block`s with the same `bId`, which is trivial without the requirement to show that those `Block`s are considered to be "in the system" by whomever is instantiating the `Abstract` properties.

This is pushed all the way through for our main correctness property `CommitsDoNotConflict`, and only partially for the extended properties that lack `RecordChain`s in which all `Record`s are known to be `InSys`.  This is because we cannot prove that the injectivity failures are `InSys` unless and until we model someone attempting to convince someone of an alternative history, thus actually exploting the injectivity failure.

This pull request strengthens the obligation required for the `PreferredRoundRule`, because if it wants to "bail out" by claiming there was an injectivity failure, it too must prove that it is with `Record`s that are `InSys`.  We've started towards that in another branch on the implementation side (this branch builds on that one, see #158), but we have not connected all the dots yet, so the gap is patched over using `obm-dangerous-magic'` for now.

This now also includes changes from #158; see the description there.