### PR TITLE
prove EitherD/Either versions of init equivalent; init contract

### DIFF
--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -16,7 +16,7 @@ import      LibraBFT.Impl.Consensus.ConsensusTypes.Vote       as Vote
 import      LibraBFT.Impl.Consensus.ConsensusTypes.VoteData   as VoteData
 import      LibraBFT.Impl.Consensus.ConsensusTypes.Properties.VoteData as VoteDataProps
 open import LibraBFT.Impl.Consensus.SafetyRules.SafetyRules
-open import LibraBFT.Impl.Handle
+import      LibraBFT.Impl.Handle                              as Handle
 open import LibraBFT.Impl.Properties.Util
 open import LibraBFT.Impl.OBM.Crypto                          as Crypto
 open import LibraBFT.Impl.OBM.Logging.Logging
@@ -30,8 +30,8 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
 
-open        ParamsWithInitAndHandlers InitAndHandlers
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers PeerCanSignForPK PeerCanSignForPK-stable
+open        ParamsWithInitAndHandlers Handle.fakeInitAndHandlers
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms Handle.fakeInitAndHandlers PeerCanSignForPK PeerCanSignForPK-stable
 open Invariants
 open RoundManagerTransProps
 

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -72,7 +72,7 @@ postulate -- TODO-1: initPE, initBS, initRS
 initRM : RoundManager
 initRM = RoundManager∙new
            ObmNeedFetch∙new
-           (EpochState∙new 1 (initVV genesisInfo))
+           (EpochState∙new 1 (initVV fakeGenesisInfo))
            initBS initRS initPE initPG initSR false
 
 -- Eventually, the initialization should establish properties we care about.
@@ -106,7 +106,7 @@ peerStep nid msg st = runHandler st (handle nid msg 0)
 
 InitAndHandlers : SystemInitAndHandlers ℓ-RoundManager ConcSysParms
 InitAndHandlers = mkSysInitAndHandlers
-                    genesisInfo
+                    fakeGenesisInfo
                     initRM
                     initWrapper
                     peerStep

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -63,7 +63,7 @@ initSR =
 initPG : ProposalGenerator
 initPG = ProposalGenerator∙new 0
 
-postulate -- TODO-1: initPE, initBS, initRS
+postulate -- TODO-1: initPE, initBS
   initPE : ProposerElection
   initBS : BlockStore
   initRS : RoundState

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -80,17 +80,17 @@ fakeInitRM = RoundManager∙new
 -- That means we cannot prove the base case for various properties,
 -- e.g., in Impl.Properties.VotesOnce
 -- TODO: create real RoundManager using LibraBFT.Impl.IO.OBM.Start
-initialRoundManagerAndMessages
+fakeInitialRoundManagerAndMessages
   : (a : Author) → GenesisInfo
   → RoundManager × List NetworkMsg
-initialRoundManagerAndMessages a _ = fakeInitRM , []
+fakeInitialRoundManagerAndMessages a _ = fakeInitRM , []
 
 -- TODO-2: These "wrappers" can probably be shared with FakeImpl, and therefore more of this could
 -- be factored into LibraBFT.ImplShared.Interface.* (maybe Output, in which case maybe that should
 -- be renamed?)
 
-initWrapper : NodeId → GenesisInfo → RoundManager × List (LYT.Action NetworkMsg)
-initWrapper nid g = ×-map₂ (List-map LYT.send) (initialRoundManagerAndMessages nid g)
+fakeInitWrapper : NodeId → GenesisInfo → RoundManager × List (LYT.Action NetworkMsg)
+fakeInitWrapper nid g = ×-map₂ (List-map LYT.send) (fakeInitialRoundManagerAndMessages nid g)
 
 -- Here we invoke the handler that models the real implementation handler.
 runHandler : RoundManager → LBFT Unit → RoundManager × List (LYT.Action NetworkMsg)
@@ -108,7 +108,7 @@ fakeInitAndHandlers : SystemInitAndHandlers ℓ-RoundManager ConcSysParms
 fakeInitAndHandlers = mkSysInitAndHandlers
                     fakeGenesisInfo
                     fakeInitRM
-                    initWrapper
+                    fakeInitWrapper
                     peerStep
 
 ------------------------------------------------------------------------------

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -51,29 +51,29 @@ postulate -- TODO-1: reasonable assumption that some RoundManager exists, though
   fakeRM : RoundManager
 
 postulate -- TODO-2: define GenesisInfo to match implementation and write these functions
-  initVV  : GenesisInfo → ValidatorVerifier
+  fakeInitVV  : GenesisInfo → ValidatorVerifier
 
-initSR : SafetyRules
-initSR =
+fakeInitSR : SafetyRules
+fakeInitSR =
   let sr = fakeRM ^∙ lSafetyRules
       sr = sr & srPersistentStorage ∙ pssSafetyData ∙ sdLastVotedRound ∙~ 0
       sr = sr & srPersistentStorage ∙ pssSafetyData ∙ sdEpoch          ∙~ 1
       sr = sr & srPersistentStorage ∙ pssSafetyData ∙ sdLastVote       ∙~ nothing
   in sr
 
-initPG : ProposalGenerator
-initPG = ProposalGenerator∙new 0
+fakeInitPG : ProposalGenerator
+fakeInitPG = ProposalGenerator∙new 0
 
 postulate -- TODO-1: initPE, initBS, initRS
-  initPE : ProposerElection
-  initBS : BlockStore
-  initRS : RoundState
+  fakeInitPE : ProposerElection
+  fakeInitBS : BlockStore
+  fakeInitRS : RoundState
 
-initRM : RoundManager
-initRM = RoundManager∙new
+fakeInitRM : RoundManager
+fakeInitRM = RoundManager∙new
            ObmNeedFetch∙new
-           (EpochState∙new 1 (initVV fakeGenesisInfo))
-           initBS initRS initPE initPG initSR false
+           (EpochState∙new 1 (fakeInitVV fakeGenesisInfo))
+           fakeInitBS fakeInitRS fakeInitPE fakeInitPG fakeInitSR false
 
 -- Eventually, the initialization should establish properties we care about.
 -- For now we just initialise to fakeRM.
@@ -83,7 +83,7 @@ initRM = RoundManager∙new
 initialRoundManagerAndMessages
   : (a : Author) → GenesisInfo
   → RoundManager × List NetworkMsg
-initialRoundManagerAndMessages a _ = initRM , []
+initialRoundManagerAndMessages a _ = fakeInitRM , []
 
 -- TODO-2: These "wrappers" can probably be shared with FakeImpl, and therefore more of this could
 -- be factored into LibraBFT.ImplShared.Interface.* (maybe Output, in which case maybe that should
@@ -104,10 +104,10 @@ runHandler st handler = ×-map₂ (outputsToActions {st}) (proj₂ (LBFT-run han
 peerStep : NodeId → NetworkMsg → RoundManager → RoundManager × List (LYT.Action NetworkMsg)
 peerStep nid msg st = runHandler st (handle nid msg 0)
 
-InitAndHandlers : SystemInitAndHandlers ℓ-RoundManager ConcSysParms
-InitAndHandlers = mkSysInitAndHandlers
+fakeInitAndHandlers : SystemInitAndHandlers ℓ-RoundManager ConcSysParms
+fakeInitAndHandlers = mkSysInitAndHandlers
                     fakeGenesisInfo
-                    initRM
+                    fakeInitRM
                     initWrapper
                     peerStep
 

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -132,24 +132,20 @@ initEMWithOutput = do
       me                          = 0
   fromEither $ Init.initialize me nfLiwsVssVvPe now ObmNeedFetch∙new pg
 
-initEMWithOutput≡ : ∀ {x} → EitherD-run initEMWithOutput ≡ Right x → initEMWithOutput' ≡ Right x
-initEMWithOutput≡ {x} iewo
+initEMWithOutput≡ : ∀ {x} → EitherD-run initEMWithOutput ≡ x → initEMWithOutput' ≡ x
+initEMWithOutput≡ iewo
   with GenKeyFile.create 1 (0 ∷ 1 ∷ 2 ∷ 3 ∷ [])
+... | Left err rewrite iewo = refl
 ... | Right (nf , _ , vss , vv , pe , liws)
   with Init.initialize 0 (nf , liws , vss , vv , pe) now ObmNeedFetch∙new pg
-... | Right y rewrite iewo = cong Right refl
+... | Left err rewrite iewo = refl
+... | Right y  rewrite iewo = refl
 
-------------------------------------------------------------------------------
--- TODO : ASK CHRIS : regarding EitherD-run
-
-zzz : EitherD ErrLog ℕ
-zzz = do
-  r ← RightD 0
-  RightD r
-
-zzz' : Either ErrLog ℕ
-zzz' = Right 0
-
-zzz≡zzz' : zzz ≡ RightD 0 → zzz' ≡ Right 0
-zzz≡zzz' ()
-
+initEMWithOutput≡' : ∀ {x} → initEMWithOutput' ≡ x → EitherD-run initEMWithOutput ≡ x
+initEMWithOutput≡' iewo
+  with GenKeyFile.create 1 (0 ∷ 1 ∷ 2 ∷ 3 ∷ [])
+... | Left err rewrite iewo = refl
+... | Right (nf , _ , vss , vv , pe , liws)
+  with Init.initialize 0 (nf , liws , vss , vv , pe) now ObmNeedFetch∙new pg
+... | Left err rewrite iewo = refl
+... | Right y rewrite iewo = refl

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -78,16 +78,23 @@ postulate
   now           : Instant
   pg            : ProposalGenerator
 
-initEMWithOutput : Either ErrLog (EpochManager × List Output)
-initEMWithOutput = do
+initEMWithOutput' : Either ErrLog (EpochManager × List Output)
+initEMWithOutput' = do
   (nf , _ , vss , vv , pe , liws) ← GenKeyFile.create 1 (0 ∷ 1 ∷ 2 ∷ 3 ∷ [])
   let nfLiwsVssVvPe               = (nf , liws , vss , vv , pe)
       me                          = 0
   Init.initialize me nfLiwsVssVvPe now ObmNeedFetch∙new pg
 
+initEMWithOutput : EitherD ErrLog (EpochManager × List Output)
+initEMWithOutput = do
+  (nf , _ , vss , vv , pe , liws) ← fromEither $ GenKeyFile.create 1 (0 ∷ 1 ∷ 2 ∷ 3 ∷ [])
+  let nfLiwsVssVvPe               = (nf , liws , vss , vv , pe)
+      me                          = 0
+  fromEither $ Init.initialize me nfLiwsVssVvPe now ObmNeedFetch∙new pg
+
 initRMWithOutput : Either ErrLog (RoundManager × List Output)
 initRMWithOutput = do
-  (em , out) ← initEMWithOutput
+  (em , out) ← toEither initEMWithOutput
   rm         ← em ^∙ emObmRoundManager
   pure (rm , out)
 

--- a/LibraBFT/Impl/Handle.agda
+++ b/LibraBFT/Impl/Handle.agda
@@ -63,7 +63,7 @@ initSR =
 initPG : ProposalGenerator
 initPG = ProposalGenerator∙new 0
 
-postulate -- TODO-1: initPE, initBS
+postulate -- TODO-1: initPE, initBS, initRS
   initPE : ProposerElection
   initBS : BlockStore
   initRS : RoundState

--- a/LibraBFT/Impl/Handle/InitProperties.agda
+++ b/LibraBFT/Impl/Handle/InitProperties.agda
@@ -1,0 +1,118 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2021, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import LibraBFT.ImplShared.Base.Types
+
+open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
+open import LibraBFT.Base.ByteString
+open import LibraBFT.Base.Encode
+open import LibraBFT.Base.KVMap                         as Map
+open import LibraBFT.Base.PKCS
+open import LibraBFT.Concrete.System
+open import LibraBFT.Concrete.System.Parameters
+open import LibraBFT.Hash
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochDep
+open import LibraBFT.ImplShared.Interface.Output
+open import LibraBFT.ImplShared.Util.Crypto
+open import LibraBFT.ImplShared.Util.Util
+open import LibraBFT.Impl.IO.OBM.InputOutputHandlers
+open import LibraBFT.Impl.IO.OBM.Properties.InputOutputHandlers
+open import LibraBFT.Impl.Properties.Util
+open import LibraBFT.Lemmas
+open import LibraBFT.Prelude
+open import Optics.All
+
+open import LibraBFT.Impl.Consensus.EpochManagerTypes
+open import LibraBFT.Impl.Handle
+import      LibraBFT.Impl.IO.OBM.GenKeyFile             as GenKeyFile
+import      LibraBFT.Impl.OBM.Init                      as Init
+
+module LibraBFT.Impl.Handle.InitProperties where
+
+yyy : ∀ {x} → initEMWithOutput ≡ RightD x → initEMWithOutput' ≡ Right x
+yyy iewo
+  with GenKeyFile.create 1 (0 ∷ 1 ∷ 2 ∷ 3 ∷ [])
+... | Right (nf , _ , vss , vv , pe , liws)
+  with Init.initialize 0 (nf , liws , vss , vv , pe) now ObmNeedFetch∙new pg
+... | Right _
+  with iewo
+... | ()
+
+yyy' : ∀ {x} → initEMWithOutput ≡ RightD x → initEMWithOutput' ≡ Right x
+yyy' iewo
+  with iewo
+... | ()
+
+module initEMWithOutputSpec where
+
+  record ContractOk (em : EpochManager) (lo : List Output) : Set where
+    constructor mkContractOk
+    field
+      a  : em ^∙ emAuthor ≡ 0
+      c  : em ^∙ emConfig ≡
+                          ConsensusConfig∙new (em ^∙ emAuthor) (em ^∙ emAuthor)
+                           (SafetyRulesConfig∙new SRSLocal
+                            (em ^∙ emConfig ∙ ccSafetyRules ∙ srcExportConsensusKey)
+                            (Waypoint∙new (Version∙new (em ^∙ emAuthor) (em ^∙ emAuthor))
+                             (em ^∙ emConfig ∙ ccSafetyRules ∙ srcObmGenesisWaypoint ∙ wValue)))
+                           (em ^∙ emConfig ∙ ccSafetyRules ∙ srcExportConsensusKey)
+      sc : em ^∙ emStateComputer ≡
+                StateComputer∙new (Version∙new (em ^∙ emAuthor) (em ^∙ emAuthor))
+      s  : em ^∙ emStorage ≡
+                          MockStorage∙new
+                            (mkMockSharedStorage (em ^∙ emStorage ∙ msSharedStorage ∙ mssBlock)
+                             (em ^∙ emStorage ∙ msSharedStorage ∙ mssQc)
+                             (em ^∙ emStorage ∙ msSharedStorage ∙ mssLis)
+                             (em ^∙ emStorage ∙ msSharedStorage ∙ mssLastVote)
+                             (em ^∙ emStorage ∙ msSharedStorage ∙ mssHighestTimeoutCertificate)
+                             (ValidatorSet∙new ConsensusScheme∙new
+                              (em ^∙ emStorage ∙ msSharedStorage ∙ mssValidatorSet ∙ vsPayload)))
+                            (LedgerInfo∙new
+                             (BlockInfo∙new (em ^∙ emAuthor) (em ^∙ emAuthor)
+                              (em ^∙ emConfig ∙ ccSafetyRules ∙ srcObmGenesisWaypoint ∙ wValue)
+                              (em ^∙ emConfig ∙ ccSafetyRules ∙ srcObmGenesisWaypoint ∙ wValue)
+                              (Version∙new (em ^∙ emAuthor) (em ^∙ emAuthor))
+                              (em ^∙ emStorage ∙ msStorageLedger ∙ liCommitInfo ∙ biNextEpochState))
+                             (em ^∙ emConfig ∙ ccSafetyRules ∙ srcObmGenesisWaypoint ∙ wValue))
+                            (DiemDB∙new
+                             (mkLedgerStore
+                              (em ^∙ emStorage ∙ msObmDiemDB ∙ ddbLedgerStore ∙ lsObmVersionToEpoch)
+                              (em ^∙ emStorage ∙ msObmDiemDB ∙ ddbLedgerStore ∙ lsObmEpochToLIWS)
+                              (em ^∙ emStorage ∙ msObmDiemDB ∙ ddbLedgerStore ∙ lsLatestLedgerInfo)))
+      sr : em ^∙ emSafetyRulesManager ≡ mkSafetyRulesManager
+                                         ((em ^∙ emSafetyRulesManager)
+                                         SafetyRulesManager.srmInternalSafetyRules)
+      p  : em ^∙ emProcessor ≡
+        just
+         (RoundProcessorNormal
+          (RoundManager∙new
+           ObmNeedFetch∙new
+            (EpochState∙new (em ^∙ emAuthor)
+                            (mkValidatorVerifier Map.empty 0 0))
+            (BlockStore∙new (mkBlockTree {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!})
+                            (StateComputer∙new {!!})
+                            (MockStorage∙new {!!} {!!} {!!}))
+            (mkRoundState (mkExponentialTimeInterval 0 0.0 0)
+                          0 0 0 (mkPendingVotes Map.empty nothing Map.empty) nothing)
+            (ProposerElection∙new {!!})
+            (ProposalGenerator∙new {!!})
+            (mkSafetyRules {!!} {!!} {!!} {!!})
+            false))
+
+  Contract : Either ErrLog (EpochManager × List Output) → Set
+  Contract (Left _) = ⊤
+  Contract (Right (em , lo)) = ContractOk em lo
+
+--  open initEMWithOutputSpec
+
+  -- module _ (bt“ : BlockTree) (b : ExecutedBlock) (con : ContractOk bt“ b) where
+  -- postulate
+  --   contract' : EitherD-weakestPre (step₀ block bt) Contract
+
+  -- contract : Contract (initEMWithOutput.E block bt)
+  -- contract = EitherD-contract (step₀ block bt) Contract contract'
+

--- a/LibraBFT/Impl/Handle/InitProperties.agda
+++ b/LibraBFT/Impl/Handle/InitProperties.agda
@@ -6,102 +6,27 @@
 
 open import LibraBFT.ImplShared.Base.Types
 
-open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
-open import LibraBFT.Base.ByteString
-open import LibraBFT.Base.Encode
-open import LibraBFT.Base.KVMap                         as Map
-open import LibraBFT.Base.PKCS
-open import LibraBFT.Concrete.System
-open import LibraBFT.Concrete.System.Parameters
-open import LibraBFT.Hash
-open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.ImplShared.Consensus.Types.EpochDep
-open import LibraBFT.ImplShared.Interface.Output
-open import LibraBFT.ImplShared.Util.Crypto
-open import LibraBFT.ImplShared.Util.Util
-open import LibraBFT.Impl.IO.OBM.InputOutputHandlers
-open import LibraBFT.Impl.IO.OBM.Properties.InputOutputHandlers
-open import LibraBFT.Impl.Properties.Util
-open import LibraBFT.Lemmas
-open import LibraBFT.Prelude
-open import Optics.All
-
 open import LibraBFT.Impl.Consensus.EpochManagerTypes
 open import LibraBFT.Impl.Handle
 import      LibraBFT.Impl.IO.OBM.GenKeyFile             as GenKeyFile
 import      LibraBFT.Impl.OBM.Init                      as Init
+open import LibraBFT.ImplShared.Consensus.Types
+open import LibraBFT.ImplShared.Consensus.Types.EpochDep
+open import LibraBFT.ImplShared.Interface.Output
+open import LibraBFT.Impl.Properties.Util
+open import LibraBFT.Prelude
+open import Optics.All
 
 module LibraBFT.Impl.Handle.InitProperties where
 
-yyy : ∀ {x} → initEMWithOutput ≡ RightD x → initEMWithOutput' ≡ Right x
-yyy iewo
-  with GenKeyFile.create 1 (0 ∷ 1 ∷ 2 ∷ 3 ∷ [])
-... | Right (nf , _ , vss , vv , pe , liws)
-  with Init.initialize 0 (nf , liws , vss , vv , pe) now ObmNeedFetch∙new pg
-... | Right _
-  with iewo
-... | ()
-
-yyy' : ∀ {x} → initEMWithOutput ≡ RightD x → initEMWithOutput' ≡ Right x
-yyy' iewo
-  with iewo
-... | ()
 
 module initEMWithOutputSpec where
 
   record ContractOk (em : EpochManager) (lo : List Output) : Set where
     constructor mkContractOk
     field
-      a  : em ^∙ emAuthor ≡ 0
-      c  : em ^∙ emConfig ≡
-                          ConsensusConfig∙new (em ^∙ emAuthor) (em ^∙ emAuthor)
-                           (SafetyRulesConfig∙new SRSLocal
-                            (em ^∙ emConfig ∙ ccSafetyRules ∙ srcExportConsensusKey)
-                            (Waypoint∙new (Version∙new (em ^∙ emAuthor) (em ^∙ emAuthor))
-                             (em ^∙ emConfig ∙ ccSafetyRules ∙ srcObmGenesisWaypoint ∙ wValue)))
-                           (em ^∙ emConfig ∙ ccSafetyRules ∙ srcExportConsensusKey)
-      sc : em ^∙ emStateComputer ≡
-                StateComputer∙new (Version∙new (em ^∙ emAuthor) (em ^∙ emAuthor))
-      s  : em ^∙ emStorage ≡
-                          MockStorage∙new
-                            (mkMockSharedStorage (em ^∙ emStorage ∙ msSharedStorage ∙ mssBlock)
-                             (em ^∙ emStorage ∙ msSharedStorage ∙ mssQc)
-                             (em ^∙ emStorage ∙ msSharedStorage ∙ mssLis)
-                             (em ^∙ emStorage ∙ msSharedStorage ∙ mssLastVote)
-                             (em ^∙ emStorage ∙ msSharedStorage ∙ mssHighestTimeoutCertificate)
-                             (ValidatorSet∙new ConsensusScheme∙new
-                              (em ^∙ emStorage ∙ msSharedStorage ∙ mssValidatorSet ∙ vsPayload)))
-                            (LedgerInfo∙new
-                             (BlockInfo∙new (em ^∙ emAuthor) (em ^∙ emAuthor)
-                              (em ^∙ emConfig ∙ ccSafetyRules ∙ srcObmGenesisWaypoint ∙ wValue)
-                              (em ^∙ emConfig ∙ ccSafetyRules ∙ srcObmGenesisWaypoint ∙ wValue)
-                              (Version∙new (em ^∙ emAuthor) (em ^∙ emAuthor))
-                              (em ^∙ emStorage ∙ msStorageLedger ∙ liCommitInfo ∙ biNextEpochState))
-                             (em ^∙ emConfig ∙ ccSafetyRules ∙ srcObmGenesisWaypoint ∙ wValue))
-                            (DiemDB∙new
-                             (mkLedgerStore
-                              (em ^∙ emStorage ∙ msObmDiemDB ∙ ddbLedgerStore ∙ lsObmVersionToEpoch)
-                              (em ^∙ emStorage ∙ msObmDiemDB ∙ ddbLedgerStore ∙ lsObmEpochToLIWS)
-                              (em ^∙ emStorage ∙ msObmDiemDB ∙ ddbLedgerStore ∙ lsLatestLedgerInfo)))
-      sr : em ^∙ emSafetyRulesManager ≡ mkSafetyRulesManager
-                                         ((em ^∙ emSafetyRulesManager)
-                                         SafetyRulesManager.srmInternalSafetyRules)
-      p  : em ^∙ emProcessor ≡
-        just
-         (RoundProcessorNormal
-          (RoundManager∙new
-           ObmNeedFetch∙new
-            (EpochState∙new (em ^∙ emAuthor)
-                            (mkValidatorVerifier Map.empty 0 0))
-            (BlockStore∙new (mkBlockTree {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!} {!!})
-                            (StateComputer∙new {!!})
-                            (MockStorage∙new {!!} {!!} {!!}))
-            (mkRoundState (mkExponentialTimeInterval 0 0.0 0)
-                          0 0 0 (mkPendingVotes Map.empty nothing Map.empty) nothing)
-            (ProposerElection∙new {!!})
-            (ProposalGenerator∙new {!!})
-            (mkSafetyRules {!!} {!!} {!!} {!!})
-            false))
+       rmInv : Σ RoundManager λ rm → Invariants.RoundManagerInv rm
+                                   × em ^∙ emProcessor ≡ just (RoundProcessorNormal rm)
 
   Contract : Either ErrLog (EpochManager × List Output) → Set
   Contract (Left _) = ⊤

--- a/LibraBFT/Impl/Handle/InitProperties.agda
+++ b/LibraBFT/Impl/Handle/InitProperties.agda
@@ -4,16 +4,10 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.ImplShared.Base.Types
-
 open import LibraBFT.Impl.Consensus.EpochManagerTypes
-open import LibraBFT.Impl.Handle
-import      LibraBFT.Impl.IO.OBM.GenKeyFile             as GenKeyFile
-import      LibraBFT.Impl.OBM.Init                      as Init
 open import LibraBFT.ImplShared.Consensus.Types
-open import LibraBFT.ImplShared.Consensus.Types.EpochDep
 open import LibraBFT.ImplShared.Interface.Output
-open import LibraBFT.Impl.Properties.Util
+import      LibraBFT.Impl.Properties.Util             as Util
 open import LibraBFT.Prelude
 open import Optics.All
 
@@ -25,11 +19,12 @@ module initEMWithOutputSpec where
   record ContractOk (em : EpochManager) (lo : List Output) : Set where
     constructor mkContractOk
     field
-       rmInv : Σ RoundManager λ rm → Invariants.RoundManagerInv rm
-                                   × em ^∙ emProcessor ≡ just (RoundProcessorNormal rm)
+       rmInv : Σ RoundManager
+                 λ rm → em ^∙ emProcessor ≡ just (RoundProcessorNormal rm)
+                      × Util.Invariants.RoundManagerInv rm
 
   Contract : Either ErrLog (EpochManager × List Output) → Set
-  Contract (Left _) = ⊤
+  Contract (Left _)          = ⊤
   Contract (Right (em , lo)) = ContractOk em lo
 
 --  open initEMWithOutputSpec

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -29,11 +29,11 @@ open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
 open import Optics.All
 
-open import LibraBFT.Impl.Handle
-open        ParamsWithInitAndHandlers InitAndHandlers
+import      LibraBFT.Impl.Handle as Handle
+open        ParamsWithInitAndHandlers Handle.fakeInitAndHandlers
 open        PeerCanSignForPK
 open        EpochConfig
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers PeerCanSignForPK PeerCanSignForPK-stable
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms Handle.fakeInitAndHandlers PeerCanSignForPK PeerCanSignForPK-stable
 
 open Invariants
 open RoundManagerTransProps
@@ -43,11 +43,11 @@ open RoundManagerTransProps
 module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
-  initRM-correct  : ValidatorVerifier-correct (initRM  ^∙ rmValidatorVerifer)
-  initRM-btInv    : BlockTreeInv (rm→BlockTree-EC initRM)
-  initRM-qcs      : QCProps.SigsForVotes∈Rm-SentB4 [] initRM
+  initRM-correct  : ValidatorVerifier-correct (Handle.fakeInitRM  ^∙ rmValidatorVerifer)
+  initRM-btInv    : BlockTreeInv (rm→BlockTree-EC Handle.fakeInitRM)
+  initRM-qcs      : QCProps.SigsForVotes∈Rm-SentB4 [] Handle.fakeInitRM
 
-initRMSatisfiesInv : RoundManagerInv initRM
+initRMSatisfiesInv : RoundManagerInv Handle.fakeInitRM
 initRMSatisfiesInv =
   mkRoundManagerInv initRM-correct refl initRM-btInv
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
@@ -66,7 +66,7 @@ invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer step@(step-ho
   = invariantsCorrect pid pre' preach
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-init ini))))
    | yes refl
-  rewrite override-target-≡{a = pid}{b = initRM}{f = peerStates pre'}
+  rewrite override-target-≡{a = pid}{b = Handle.fakeInitRM}{f = peerStates pre'}
    |       sym $ ++-identityʳ (msgPool pre')
    = initRMSatisfiesInv
 invariantsCorrect pid pre@._ (step-s{pre = pre'} preach (step-peer (step-honest (step-msg{sndr , P pm} m∈pool ini))))
@@ -134,9 +134,9 @@ qcVoteSigsSentB4 pid st (step-s rss (step-peer{pid'}{pre = pre} (step-honest sps
    = ret
    where
    ret : QCProps.SigsForVotes∈Rm-SentB4 (msgPool st) (peerStates st pid)
-   ret rewrite override-target-≡{a = pid}{b = initRM}{f = peerStates pre}
+   ret rewrite override-target-≡{a = pid}{b = Handle.fakeInitRM}{f = peerStates pre}
        |       sym $ ++-identityʳ (msgPool pre)
-       = QCProps.++-SigsForVote∈Rm-SentB4{rm = initRM} (msgPool pre) initRM-qcs
+       = QCProps.++-SigsForVote∈Rm-SentB4{rm = Handle.fakeInitRM} (msgPool pre) initRM-qcs
 ...| step-msg{sndr , nm} m∈pool init
    rewrite override-target-≡{a = pid}{b = LBFT-post (handle pid nm 0) (peerStates pre pid)} {f = peerStates pre}
    = QCProps.++-SigsForVote∈Rm-SentB4 {rm = LBFT-post (handle pid nm 0) (peerStates pre pid)} _ (handlePreservesSigsB4 rss m∈pool)
@@ -153,7 +153,7 @@ qcVoteSigsSentB4-sps
     → MsgWithSig∈ pk sig (msgPool pre)
 qcVoteSigsSentB4-sps pid pre rss (step-init uni) qc∈s sig vs∈qcvs ≈v ¬gen
    rewrite sym $ ++-identityʳ (msgPool pre)
-   = QCProps.++-SigsForVote∈Rm-SentB4{rm = initRM} (msgPool pre) initRM-qcs qc∈s sig vs∈qcvs ≈v ¬gen
+   = QCProps.++-SigsForVote∈Rm-SentB4{rm = Handle.fakeInitRM} (msgPool pre) initRM-qcs qc∈s sig vs∈qcvs ≈v ¬gen
 qcVoteSigsSentB4-sps pid pre rss (step-msg{sndr , m} m∈pool ini) {qc}{v}{pk} qc∈s sig {vs} vs∈qcvs ≈v ¬gen
    with m
    -- TODO-2: refactor for DRY

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -149,7 +149,7 @@ qcVoteSigsSentB4-sps
     → WithVerSig pk v
     → ∀ {vs : Author × Signature} → let (pid , sig) = vs in
       vs ∈ qcVotes qc → rebuildVote qc vs ≈Vote v
-    → ¬ ∈GenInfo-impl genesisInfo sig
+    → ¬ ∈GenInfo-impl fakeGenesisInfo sig
     → MsgWithSig∈ pk sig (msgPool pre)
 qcVoteSigsSentB4-sps pid pre rss (step-init uni) qc∈s sig vs∈qcvs ≈v ¬gen
    rewrite sym $ ++-identityʳ (msgPool pre)
@@ -252,7 +252,7 @@ qcVoteSigsSentB4-handle
     → WithVerSig pk v
     → ∀ {vs : Author × Signature} → let (pid , sig) = vs in
       vs ∈ qcVotes qc → rebuildVote qc vs ≈Vote v
-    → ¬ ∈GenInfo-impl genesisInfo sig
+    → ¬ ∈GenInfo-impl fakeGenesisInfo sig
     → MsgWithSig∈ pk sig (msgPool pre)
 qcVoteSigsSentB4-handle pid {pre} {m} {s} {acts} preach sps@(step-init ini) ()
 qcVoteSigsSentB4-handle pid {pre} {m} {s} {acts} preach sps@(step-msg {_ , nm} m∈pool ini) m∈acts {qc} qc∈m sig vs∈qc v≈rbld ¬gen =

--- a/LibraBFT/Impl/IO/OBM/GenKeyFile.agda
+++ b/LibraBFT/Impl/IO/OBM/GenKeyFile.agda
@@ -33,17 +33,22 @@ mkValidatorSignersAndVerifierAndProposerElection
 NfLiwsVssVvPe =
   (U64 × LedgerInfoWithSignatures × List ValidatorSigner × ValidatorVerifier × ProposerElection)
 
-create
+create'
   : U64 → List EndpointAddress {-→ SystemDRG-}
   → Either ErrLog
     ( U64 × AddressToSkAndPkAssocList
     × List ValidatorSigner × ValidatorVerifier × ProposerElection × LedgerInfoWithSignatures )
-create numFailures addresses {-drg-} = do
+create' numFailures addresses {-drg-} = do
  authors       ← mkAuthors {-drg-} numFailures addresses
  (s , vv , pe) ← mkValidatorSignersAndVerifierAndProposerElection numFailures authors
  case Genesis.obmMkGenesisLedgerInfoWithSignatures s (ValidatorSet.obmFromVV vv) of λ where
        (Left err)   → Left err
        (Right liws) → pure (numFailures , authors , s , vv , pe , liws)
+
+abstract
+  create = create'
+  create≡ : create ≡ create'
+  create≡ = refl
 
 mkAuthors {-drg-} numFailures0 addresses0 = do
   addrs <- checkAddresses

--- a/LibraBFT/Impl/IO/OBM/GenKeyFile.agda
+++ b/LibraBFT/Impl/IO/OBM/GenKeyFile.agda
@@ -28,7 +28,6 @@ mkAuthors : {-Crypto.SystemDRG →-} U64 → List EndpointAddress
 mkValidatorSignersAndVerifierAndProposerElection
           : U64 → AddressToSkAndPkAssocList
           → Either ErrLog (List ValidatorSigner × ValidatorVerifier × ProposerElection)
-
 ------------------------------------------------------------------------------
 
 NfLiwsVssVvPe =
@@ -58,6 +57,7 @@ mkAuthors {-drg-} numFailures0 addresses0 = do
 postulate
   mkSK : NodeId → SK
   mkPK : NodeId → PK
+
 genKeys    zero   = []
 genKeys x@(suc n) = (mkSK x , mkPK x) ∷ genKeys n
 

--- a/LibraBFT/Impl/OBM/Init.agda
+++ b/LibraBFT/Impl/OBM/Init.agda
@@ -24,12 +24,17 @@ module LibraBFT.Impl.OBM.Init where
 ------------------------------------------------------------------------------
 -- Everything below is specific to Agda.
 
-initialize
+initialize'
   : AuthorName → GenKeyFile.NfLiwsVssVvPe → Instant → ObmNeedFetch → ProposalGenerator
   → Either ErrLog (EpochManager × List Output)
-initialize me nfLiwsVssVvPe now obmNeedFetch proposalGenerator = do
+initialize' me nfLiwsVssVvPe now obmNeedFetch proposalGenerator = do
   (nc , occp , liws , sk , pe) ← ConsensusProvider.obmInitialData me nfLiwsVssVvPe
   ConsensusProvider.startConsensus
     nc now occp liws sk
     obmNeedFetch proposalGenerator
     (StateComputer∙new BlockInfo.gENESIS_VERSION)
+
+abstract
+  initialize = initialize'
+  initialize≡ : initialize ≡ initialize'
+  initialize≡ = refl

--- a/LibraBFT/Impl/Properties/Common.agda
+++ b/LibraBFT/Impl/Properties/Common.agda
@@ -17,7 +17,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.Network            as Network
 open import LibraBFT.Impl.Consensus.Network.Properties as NetworkProps
 open import LibraBFT.Impl.Consensus.RoundManager
-open import LibraBFT.Impl.Handle
+import      LibraBFT.Impl.Handle                       as Handle
 open import LibraBFT.Impl.IO.OBM.InputOutputHandlers
 open import LibraBFT.Impl.IO.OBM.Properties.InputOutputHandlers
 open import LibraBFT.Impl.Handle.Properties
@@ -31,12 +31,12 @@ open RoundManagerTransProps
 
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
-open        ParamsWithInitAndHandlers InitAndHandlers
+open        ParamsWithInitAndHandlers Handle.fakeInitAndHandlers
 open        PeerCanSignForPK
 
-open import LibraBFT.ImplShared.Util.HashCollisions InitAndHandlers
+open import LibraBFT.ImplShared.Util.HashCollisions Handle.fakeInitAndHandlers
 
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms Handle.fakeInitAndHandlers
                                PeerCanSignForPK PeerCanSignForPK-stable
 
 -- This module contains definitions and lemmas used by proofs of the

--- a/LibraBFT/Impl/Properties/Common.agda
+++ b/LibraBFT/Impl/Properties/Common.agda
@@ -72,14 +72,14 @@ postulate -- TODO-1: Prove (waiting on: complete definition of `initRM`)
       → initialised st pid ≡ uninitd
       → qc QCProps.∈RoundManager (peerStates st pid)
       → vs ∈ qcVotes qc
-      → ∈GenInfo-impl genesisInfo (proj₂ vs)
+      → ∈GenInfo-impl fakeGenesisInfo (proj₂ vs)
 
 module ∈GenInfoProps where
   sameSig∉ : ∀ {pk} {v v' : Vote}
              → (sig : WithVerSig pk v) (sig' : WithVerSig pk v')
-             → ¬ ∈GenInfo-impl genesisInfo (ver-signature sig)
+             → ¬ ∈GenInfo-impl fakeGenesisInfo (ver-signature sig)
              → ver-signature sig' ≡ ver-signature sig
-             → ¬ ∈GenInfo-impl genesisInfo (ver-signature sig')
+             → ¬ ∈GenInfo-impl fakeGenesisInfo (ver-signature sig')
   sameSig∉ _ _ ¬gen ≡sig rewrite ≡sig = ¬gen
 
 -- Lemmas for `PeerCanSignForPK`
@@ -142,7 +142,7 @@ module ReachableSystemStateProps where
       → ReachableSystemState st
       → PeerCanSignForPK st v pid pk
       → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-      → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
+      → ¬ (∈GenInfo-impl fakeGenesisInfo (ver-signature sig))
       → MsgWithSig∈ pk (ver-signature sig) (msgPool st)
       → initialised st pid ≡ initd
   mws∈pool⇒initd{pk = pk}{v} (step-s{pre = pre} rss step@(step-peer sp@(step-cheat cmc))) pcsfpk hpk sig ¬gen mws∈pool =
@@ -185,7 +185,7 @@ module ReachableSystemStateProps where
       → (sps : StepPeerState pid (msgPool st) (initialised st) (peerStates st pid) (s' , outs))
       → PeerCanSignForPK st v pid pk
       → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-      → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
+      → ¬ (∈GenInfo-impl fakeGenesisInfo (ver-signature sig))
       → MsgWithSig∈ pk (ver-signature sig) (msgPool st)
       → s' ^∙ rmEpoch ≡ v ^∙ vEpoch
       → peerStates st pid ^∙ rmEpoch ≡ v ^∙ vEpoch

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -243,7 +243,7 @@ module QCProps where
     → WithVerSig pk v →
     ∀ {vs : Author × Signature} → let (pid , sig) = vs in
       vs ∈ qcVotes qc → rebuildVote qc vs ≈Vote v
-    → ¬(∈GenInfo-impl genesisInfo sig)
+    → ¬(∈GenInfo-impl fakeGenesisInfo sig)
     → MsgWithSig∈ pk sig pool
 
   SigsForVotes∈Rm-SentB4 : SentMessages → RoundManager → Set

--- a/LibraBFT/Impl/Properties/Util.agda
+++ b/LibraBFT/Impl/Properties/Util.agda
@@ -19,14 +19,14 @@ open import LibraBFT.ImplShared.Consensus.Types.EpochDep
 open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.ConsensusTypes.Block as Block
-open import LibraBFT.Impl.Handle
+import      LibraBFT.Impl.Handle as Handle
 open import LibraBFT.Lemmas
 open import LibraBFT.Prelude
 open import Optics.All
 
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
-open        ParamsWithInitAndHandlers InitAndHandlers
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers PeerCanSignForPK PeerCanSignForPK-stable
+open        ParamsWithInitAndHandlers Handle.fakeInitAndHandlers
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms Handle.fakeInitAndHandlers PeerCanSignForPK PeerCanSignForPK-stable
 
 module LibraBFT.Impl.Properties.Util where
 

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -50,7 +50,7 @@ newVote⇒lv≡
     → StepPeerState pid (msgPool pre) (initialised pre)
         (peerStates pre pid) (s' , acts)
     → v ⊂Msg m → send m ∈ acts → (sig : WithVerSig pk v)
-    → Meta-Honest-PK pk → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
+    → Meta-Honest-PK pk → ¬ (∈GenInfo-impl fakeGenesisInfo (ver-signature sig))
     → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
     → LastVoteIs s' v
 newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach sps@(step-msg{sndr , nm} m∈pool ini) (vote∈qc{vs}{qc} vs∈qc v≈rbld qc∈m) m∈acts sig hpk ¬gen ¬msb4
@@ -92,7 +92,7 @@ oldVoteRound≤lvr
   : ∀ {pid pk v}{pre : SystemState}
     → (r : ReachableSystemState pre)
     → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-    → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
+    → ¬ (∈GenInfo-impl fakeGenesisInfo (ver-signature sig))
     → MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
     → PeerCanSignForPK pre v pid pk
     → (peerStates pre pid) ^∙ rmEpoch ≡ (v ^∙ vEpoch)
@@ -176,11 +176,11 @@ sameERasLV⇒sameId-lem₁ :
   → (sp : StepPeer pre pid' s acts)
   → ∀ {v v'} → Meta-Honest-PK pk
   → PeerCanSignForPK (StepPeer-post sp) v pid pk
-  → (sig' : WithVerSig pk v') → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig'))
+  → (sig' : WithVerSig pk v') → ¬ (∈GenInfo-impl fakeGenesisInfo (ver-signature sig'))
   → (mws : MsgWithSig∈ pk (ver-signature sig') (msgPool pre))
   → v ≡L v' at vEpoch → v ≡L v' at vRound
   → Σ[ mws ∈ MsgWithSig∈ pk (ver-signature sig') (msgPool pre) ]
-      (¬ ∈GenInfo-impl genesisInfo (ver-signature ∘ msgSigned $ mws)
+      (¬ ∈GenInfo-impl fakeGenesisInfo (ver-signature ∘ msgSigned $ mws)
        × PeerCanSignForPK pre v pid pk
        × v  ≡L msgPart mws at vEpoch
        × v  ≡L msgPart mws at vRound
@@ -196,7 +196,7 @@ sameERasLV⇒sameId-lem₁{pid}{pid'}{pk}{pre = pre} rss sp {v}{v'} hpk pcsfpk s
   ≡voteData : msgPart mws ≡L v' at vVoteData
   ≡voteData = ⊎-elimˡ (PerReachableState.meta-sha256-cr rss) (sameSig⇒sameVoteData sig' (msgSigned mws) (sym ∘ msgSameSig $ mws))
 
-  ¬gen' : ¬ ∈GenInfo-impl genesisInfo (ver-signature ∘ msgSigned $ mws)
+  ¬gen' : ¬ ∈GenInfo-impl fakeGenesisInfo (ver-signature ∘ msgSigned $ mws)
   ¬gen' rewrite msgSameSig mws = ¬gen
 
   -- The peer can sign for `v` now, so it can sign for `v` in the preceeding
@@ -212,7 +212,7 @@ sameERasLV⇒sameId
     → just v ≡ peerStates st pid ^∙ pssSafetyData-rm ∙ sdLastVote
     → PeerCanSignForPK st v pid pk
     → v' ⊂Msg m' → (pid' , m') ∈ (msgPool st)
-    → (sig' : WithVerSig pk v') → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig'))
+    → (sig' : WithVerSig pk v') → ¬ (∈GenInfo-impl fakeGenesisInfo (ver-signature sig'))
     → v ≡L v' at vEpoch → v ≡L v' at vRound
     → v ≡L v' at vProposedId
 -- Cheat steps cannot be where an honestly signed message originated.

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -17,7 +17,7 @@ open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.Network            as Network
 open import LibraBFT.Impl.Consensus.Network.Properties as NetworkProps
 open import LibraBFT.Impl.Consensus.RoundManager
-open import LibraBFT.Impl.Handle
+import      LibraBFT.Impl.Handle                       as Handle
 open import LibraBFT.Impl.Handle.Properties
 open import LibraBFT.Impl.IO.OBM.InputOutputHandlers
 open import LibraBFT.Impl.IO.OBM.Properties.InputOutputHandlers
@@ -33,10 +33,10 @@ open RoundManagerTransProps
 
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 
-open        ParamsWithInitAndHandlers InitAndHandlers
-open import LibraBFT.ImplShared.Util.HashCollisions InitAndHandlers
+open        ParamsWithInitAndHandlers Handle.fakeInitAndHandlers
+open import LibraBFT.ImplShared.Util.HashCollisions Handle.fakeInitAndHandlers
 
-open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms InitAndHandlers
+open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms Handle.fakeInitAndHandlers
                                PeerCanSignForPK PeerCanSignForPK-stable
 open        Structural impl-sps-avp
 
@@ -425,7 +425,7 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-ho
      open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm (msgPool pre) handlePre)
    sameId (C x) ()
 
-votesOnce₁ : Common.IncreasingRoundObligation InitAndHandlers 𝓔
+votesOnce₁ : Common.IncreasingRoundObligation Handle.fakeInitAndHandlers 𝓔
 votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {m} {v'} {m'} hpk (vote∈qc {vs} {qc} vs∈qc v≈rbld qc∈m) m∈acts sig ¬gen ¬msb pcspkv v'⊂m' m'∈pool sig' ¬gen' eid≡
    with cong _vSignature v≈rbld
 ...| refl = ⊥-elim ∘′ ¬msb $ qcVoteSigsSentB4-handle pid preach sps m∈acts qc∈m sig vs∈qc v≈rbld ¬gen
@@ -499,7 +499,7 @@ votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr
     ...| nothing | _ = z≤n
     ...| just lv | round≤ = ≤-trans (≤-trans round≤ (<⇒≤ lvr<)) (≡⇒≤ (sym lvr≡))
 
-  ret : v' [ _<_ ]L v at vRound ⊎ Common.VoteForRound∈ InitAndHandlers 𝓔 pk (v ^∙ vRound) (v ^∙ vEpoch) (v ^∙ vProposedId) (msgPool pre)
+  ret : v' [ _<_ ]L v at vRound ⊎ Common.VoteForRound∈ Handle.fakeInitAndHandlers 𝓔 pk (v ^∙ vRound) (v ^∙ vEpoch) (v ^∙ vProposedId) (msgPool pre)
   ret
     with <-cmp (v' ^∙ vRound) (v ^∙ vRound)
   ...| tri< rv'<rv _ _ = Left rv'<rv
@@ -518,7 +518,7 @@ votesOnce₁{pid = pid}{pid'}{pk = pk}{pre = pre} preach sps@(step-msg{sndr , V 
   hvOut = LBFT-outs (handleVote 0 vm) hvPre
   open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm (msgPool pre) hvPre)
 
-votesOnce₂ : VO.ImplObligation₂ InitAndHandlers 𝓔
+votesOnce₂ : VO.ImplObligation₂ Handle.fakeInitAndHandlers 𝓔
 votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v' = v'} hpk v⊂m m∈acts sig ¬gen ¬msb4 pcsfpk v'⊂m' m'∈acts sig' ¬gen' ¬msb4' pcsfpk' ≡epoch ≡round
    with v⊂m
 ...| vote∈qc vs∈qc v≈rbld qc∈m rewrite cong _vSignature v≈rbld =

--- a/LibraBFT/ImplFake/Handle.agda
+++ b/LibraBFT/ImplFake/Handle.agda
@@ -68,7 +68,7 @@ module LibraBFT.ImplFake.Handle where
  initRM : RoundManager
  initRM = RoundManager∙new
             ObmNeedFetch∙new
-            (EpochState∙new 1 (initVV genesisInfo))
+            (EpochState∙new 1 (initVV fakeGenesisInfo))
             initBS initRS initPE initPG initSR false
 
  -- Eventually, the initialization should establish some properties we care about, but for now we
@@ -103,7 +103,7 @@ module LibraBFT.ImplFake.Handle where
 
  FakeInitAndHandlers : SystemInitAndHandlers ℓ-RoundManager ConcSysParms
  FakeInitAndHandlers = mkSysInitAndHandlers
-                         genesisInfo
+                         fakeGenesisInfo
                          initRM
                          initWrapper
                          peerStep

--- a/LibraBFT/ImplFake/Handle/Properties.agda
+++ b/LibraBFT/ImplFake/Handle/Properties.agda
@@ -107,7 +107,7 @@ module LibraBFT.ImplFake.Handle.Properties where
                  → initialised st pid ≡ initd
                  → qc ∈RoundManager (peerStates st pid)
                  → vs ∈ qcVotes qc
-                 → ¬ (∈GenInfo-impl genesisInfo (proj₂ vs))
+                 → ¬ (∈GenInfo-impl fakeGenesisInfo (proj₂ vs))
                  → MsgWithSig∈ pk (proj₂ vs) (msgPool st)
 
   -- We can prove this easily because we don't yet do epoch changes,
@@ -173,7 +173,7 @@ module LibraBFT.ImplFake.Handle.Properties where
   newVoteSameEpochGreaterRound : ∀ {pre : SystemState}{pid s' outs v m pk}
                                → ReachableSystemState pre
                                → StepPeerState pid (msgPool pre) (initialised pre) (peerStates pre pid) (s' , outs)
-                               → ¬ (∈GenInfo-impl genesisInfo (_vSignature v))
+                               → ¬ (∈GenInfo-impl fakeGenesisInfo (_vSignature v))
                                → Meta-Honest-PK pk
                                → v ⊂Msg m → send m ∈ outs → (sig : WithVerSig pk v)
                                → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
@@ -222,5 +222,5 @@ module LibraBFT.ImplFake.Handle.Properties where
                       -- For signed every vote v of every outputted message
                       → v ⊂Msg m → send m ∈ outs
                       → (wvs : WithVerSig pk v)
-                      → (¬ ∈GenInfo-impl genesisInfo (ver-signature wvs))
+                      → (¬ ∈GenInfo-impl fakeGenesisInfo (ver-signature wvs))
                       → v ^∙ vRound ≢ 0

--- a/LibraBFT/ImplFake/Properties.agda
+++ b/LibraBFT/ImplFake/Properties.agda
@@ -27,7 +27,7 @@ module LibraBFT.ImplFake.Properties (𝓔 : EpochConfig) where
                               ; gvc     = genVotesConsistent
                               ; gvr     = genVotesRound≡0
                               ; v≢0     = ¬genVotesRound≢0
-                              ; ∈GI?    = ∈GenInfo?-impl genesisInfo
+                              ; ∈GI?    = ∈GenInfo?-impl fakeGenesisInfo
                               ; iro     = Common.vo₁ 𝓔
                               ; vo₂     = VO.vo₂ 𝓔
                               ; pr₁     = PR.pr₁ 𝓔

--- a/LibraBFT/ImplFake/Properties/VotesOnceDirect.agda
+++ b/LibraBFT/ImplFake/Properties/VotesOnceDirect.agda
@@ -41,7 +41,7 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                        → StepPeerState pid (msgPool st) (initialised st)
                                        (peerStates st pid) (s' , outs)
                        → v ⊂Msg m → send m ∈ outs → (sig : WithVerSig pk v)
-                       → Meta-Honest-PK pk → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
+                       → Meta-Honest-PK pk → ¬ (∈GenInfo-impl fakeGenesisInfo (ver-signature sig))
                        → ¬ MsgWithSig∈ pk (ver-signature sig) (msgPool st)
                        → v ^∙ vEpoch ≡ s' ^∙ rmEpoch
                        → v ^∙ vRound ≡ s' ^∙ rmLastVotedRound
@@ -64,7 +64,7 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
   MsgWithSig⇒ValidSenderInitialised : ∀ {st v pk}
                                     → ReachableSystemState st
                                     → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-                                    → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
+                                    → ¬ (∈GenInfo-impl fakeGenesisInfo (ver-signature sig))
                                     → MsgWithSig∈ pk (ver-signature sig) (msgPool st)
                                     → ∃[ pid ] ( initialised st pid ≡ initd
                                                × PeerCanSignForPK st v pid pk )
@@ -123,7 +123,7 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                  → ReachableSystemState st
                  → PeerCanSignForPK st v pid pk
                  → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-                 → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
+                 → ¬ (∈GenInfo-impl fakeGenesisInfo (ver-signature sig))
                  → MsgWithSig∈ pk (ver-signature sig) (msgPool st)
                  → initialised st pid ≡ initd
   msg∈pool⇒initd {pid'} {st = st} step@(step-s r (step-peer {pid} (step-honest stPeer))) pcs pkH sig ¬gen msv
@@ -162,7 +162,7 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
                                        (peerStates st pid) (s' , outs))
                 → PeerCanSignForPK st v pid pk
                 → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-                → ¬ ∈GenInfo-impl genesisInfo (ver-signature sig)
+                → ¬ ∈GenInfo-impl fakeGenesisInfo (ver-signature sig)
                 → MsgWithSig∈ pk (ver-signature sig) (msgPool st)
                 → s' ^∙ rmEpoch ≡ (v ^∙ vEpoch)
                 → (peerStates st pid) ^∙ rmEpoch ≡ (v ^∙ vEpoch)
@@ -174,7 +174,7 @@ module LibraBFT.ImplFake.Properties.VotesOnceDirect (𝓔 : EpochConfig) where
   oldVoteRound≤lvr : ∀ {pid pk v}{pre : SystemState}
                    → (r : ReachableSystemState pre)
                    → Meta-Honest-PK pk → (sig : WithVerSig pk v)
-                   → ¬ (∈GenInfo-impl genesisInfo (ver-signature sig))
+                   → ¬ (∈GenInfo-impl fakeGenesisInfo (ver-signature sig))
                    → MsgWithSig∈ pk (ver-signature sig) (msgPool pre)
                    → PeerCanSignForPK pre v pid pk
                    → (peerStates pre pid) ^∙ rmEpoch ≡ (v ^∙ vEpoch)

--- a/LibraBFT/ImplShared/Consensus/Types.agda
+++ b/LibraBFT/ImplShared/Consensus/Types.agda
@@ -194,7 +194,7 @@ module LibraBFT.ImplShared.Consensus.Types where
   postulate -- valid assumption
     -- We postulate the existence of GenesisInfo known to all
     -- TODO: construct one or write a function that generates one from some parameters.
-    genesisInfo : GenesisInfo
+    fakeGenesisInfo : GenesisInfo
 
   data ∈GenInfo-impl (gi : GenesisInfo) : Signature → Set where
    inGenQC : ∀ {vs} → vs ∈ qcVotes (genQC gi) → ∈GenInfo-impl gi (proj₂ vs)
@@ -205,10 +205,11 @@ module LibraBFT.ImplShared.Consensus.Types where
   postulate -- TODO-1: prove after defining genInfo
     genVotesRound≡0     : ∀ {pk v}
                        → (wvs : WithVerSig pk v)
-                       → ∈GenInfo-impl genesisInfo (ver-signature wvs)
+                       → ∈GenInfo-impl fakeGenesisInfo (ver-signature wvs)
                        → v ^∙ vRound ≡ 0
     genVotesConsistent : (v1 v2 : Vote)
-                       → ∈GenInfo-impl genesisInfo (_vSignature v1) → ∈GenInfo-impl genesisInfo (_vSignature v2)
+                       → ∈GenInfo-impl fakeGenesisInfo (_vSignature v1)
+                       → ∈GenInfo-impl fakeGenesisInfo (_vSignature v2)
                      → v1 ^∙ vProposedId ≡ v2 ^∙ vProposedId
 
   -- To enable modeling of logging info that has not been added yet,

--- a/LibraBFT/ImplShared/Consensus/Types/EpochDep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochDep.agda
@@ -88,7 +88,7 @@ import LibraBFT.Abstract.BFT
                               -- for the *first* epoch (soon to be renamed to BootStrapInfo avoid
                               -- this confusion).  This is temporary until we do epoch change; then
                               -- it will need to be provided by the caller.
-      where genId           = GenesisInfo.genQC genesisInfo ^∙ (qcVoteData ∙ vdProposed ∙ biId)
+      where genId           = GenesisInfo.genQC fakeGenesisInfo ^∙ (qcVoteData ∙ vdProposed ∙ biId)
             authorsMap      = vv ^∙ vvAddressToValidatorInfo
             authors         = kvm-toList authorsMap
             authorsIDs≢     = kvm-keys-All≢ authorsMap


### PR DESCRIPTION
prefix a LOT of stuff with `fake` to make it easier to identify and remove later

Impl/Handle
- prove EitherD/Either versions of initEMWithOutput are equivalent
- fake renames
- reordered stuff in file

Impl/Handle/InitProperties
- new file
- initial shot at contract
