### PR TITLE
Make `Abstract` module provide evidence of specific injectivity failure

### DIFF
--- a/LibraBFT/Abstract/RecordChain/Assumptions.agda
+++ b/LibraBFT/Abstract/RecordChain/Assumptions.agda
@@ -112,4 +112,4 @@ module LibraBFT.Abstract.RecordChain.Assumptions
      → (rc' : RecordChain (Q q'))
      → (v' : α ∈QC q')
      → abs-vRound (∈QC-Vote q v) < abs-vRound (∈QC-Vote q' v')
-     → NonInjective-≡ bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
+     → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -55,7 +55,7 @@ module LibraBFT.Abstract.RecordChain.Properties
            → (p₀ : B b₀ ← Q q₀)
            → (p₁ : B b₁ ← Q q₁)
            → getRound b₀ ≡ getRound b₁
-           → NonInjective-≡ bId ⊎ b₀ ≡ b₁
+           → b₀ ≢ b₁ × bId b₀ ≡ bId b₁ ⊎ b₀ ≡ b₁
    lemmaS2 {b₀} {b₁} {q₀} {q₁} ex₀ ex₁ (B←Q refl h₀) (B←Q refl h₁) refl
      with b₀ ≟Block b₁
    ...| yes done = inj₂ done
@@ -75,7 +75,7 @@ module LibraBFT.Abstract.RecordChain.Properties
          v₁∈q₁ = ∈QC-Vote-correct q₁ a∈q₁
          ppp   = trans h₀ (trans (vote≡⇒QPrevId≡ {q₀} {q₁} v₀∈q₀ v₁∈q₁ (votes-only-once a honest ex₀ ex₁ a∈q₀ a∈q₁ v₀≡v₁))
                                  (sym h₁))
-     in inj₁ ((b₀ , b₁) , (imp , ppp))
+     in inj₁ (imp , ppp)
 
    ----------------
    -- Lemma S3
@@ -85,7 +85,7 @@ module LibraBFT.Abstract.RecordChain.Properties
            → (rc' : RecordChain (Q q')) → InSys (Q q')  -- Immediately before a (Q q), we have the certified block (B b), which is the 'B' in S3
            → (c3 : 𝕂-chain Contig 3 rc)                 -- This is B₀ ← C₀ ← B₁ ← C₁ ← B₂ ← C₂ in S3
            → round r₂ < getRound q'
-           → NonInjective-≡ bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
+           → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
    lemmaS3 {r₂} {q'} ex₀ (step rc' b←q') ex₁ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ _ b₂←q₂ c2) hyp
      with bft-property (qVotes-C1 q₂) (qVotes-C1 q')
    ...| (a , (a∈q₂mem , a∈q'mem , honest))
@@ -161,47 +161,49 @@ module LibraBFT.Abstract.RecordChain.Properties
        {rc : RecordChain r} → All-InSys rc
      → (q' : QC) → InSys (Q q')
      → {b' : Block}
-     → (rc' : RecordChain (B b')) → (ext : (B b') ← (Q q'))
+     → (rc' : RecordChain (B b')) → All-InSys rc' → (ext : (B b') ← (Q q'))
      → (c  : 𝕂-chain Contig k rc)
      → (ix : Fin k)
      → getRound (kchainBlock ix c) ≡ getRound b'
-     → NonInjective-≡ bId ⊎ (kchainBlock ix c ≡ b')
-   propS4-base-lemma-2 {rc = rc} prev∈sys q' q'∈sys rc' ext (s-chain r←b prf b←q c) zero hyp
-     = lemmaS2 (All-InSys⇒last-InSys prev∈sys) q'∈sys b←q ext hyp
-   propS4-base-lemma-2 prev∈sys q' q'∈sys rc' ext (s-chain r←b prf b←q c) (suc ix)
-     = propS4-base-lemma-2 (All-InSys-unstep (All-InSys-unstep prev∈sys)) q' q'∈sys rc' ext c ix
+     → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (kchainBlock ix c ≡ b')
+   propS4-base-lemma-2 {rc = rc} prev∈sys q' q'∈sys {b'} rc' rc'All∈sys ext (s-chain {b = b} r←b prf b←q c) zero hyp
+      with lemmaS2 (All-InSys⇒last-InSys prev∈sys) q'∈sys b←q ext hyp
+   ... | Left  (b≢b' , bIds≡) = inj₁ (((b , b') , b≢b' , bIds≡) , All-InSys-unstep prev∈sys here , rc'All∈sys here)
+   ... | Right y = Right y
+   propS4-base-lemma-2 prev∈sys q' q'∈sys rc' rc'All∈sys ext (s-chain r←b prf b←q c) (suc ix)
+     = propS4-base-lemma-2 (All-InSys-unstep (All-InSys-unstep prev∈sys)) q' q'∈sys rc' rc'All∈sys ext c ix
 
    propS4-base : ∀{q q'}
                → {rc : RecordChain (Q q)}   → All-InSys rc
-               → (rc' : RecordChain (Q q')) → InSys (Q q')
+               → (rc' : RecordChain (Q q')) → All-InSys rc'
                → (c3 : 𝕂-chain Contig 3 rc) -- This is B₀ ← C₀ ← B₁ ← C₁ ← B₂ ← C₂ in S4
                → getRound (c3 b⟦ suc (suc zero) ⟧) ≤ getRound q'
                → getRound q' ≤ getRound (c3 b⟦ zero ⟧)
-               → NonInjective-≡ bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
-   propS4-base {q' = q'} prev∈sys (step {B b} rc'@(step rc'' q←b) b←q@(B←Q refl _)) q'∈sys c3 hyp0 hyp1
+               → NonInjective-≡-pred (InSys ∘ B) bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
+   propS4-base {q' = q'} prev∈sys rc0@(step {B b} rc'@(step rc'' q←b) b←q@(B←Q refl _)) rc'All∈sys c3 hyp0 hyp1
      with propS4-base-lemma-1 c3 (getRound b) hyp0 hyp1
    ...| here r
-     with propS4-base-lemma-2 prev∈sys q' q'∈sys rc' b←q c3 zero (sym r)
+     with propS4-base-lemma-2 prev∈sys q' (All-InSys⇒last-InSys rc'All∈sys) rc' (All-InSys-unstep rc'All∈sys) b←q c3 zero (sym r)
    ...| inj₁ hb = inj₁ hb
    ...| inj₂ res
      with 𝕂-chain-∈RC c3 zero (suc (suc zero)) z≤n res rc'
-   ...| inj₁ hb   = inj₁ hb
+   ...| inj₁ (hb , (p1 , p2))  = inj₁ (hb , (prev∈sys p1 , rc'All∈sys (there b←q p2)))
    ...| inj₂ res' = inj₂ (there b←q res')
-   propS4-base {q} {q'} prev∈sys (step rc' (B←Q refl x₀)) q'∈sys c3 hyp0 hyp1
+   propS4-base {q} {q'} prev∈sys rc0@(step rc' b←q@(B←Q refl x₀)) rc'All∈sys c3 hyp0 hyp1
       | there (here r)
-     with propS4-base-lemma-2 prev∈sys q' q'∈sys rc' (B←Q refl x₀) c3 (suc zero) (sym r)
+     with propS4-base-lemma-2 prev∈sys q' (All-InSys⇒last-InSys rc'All∈sys) rc' (All-InSys-unstep rc'All∈sys) (B←Q refl x₀) c3 (suc zero) (sym r)
    ...| inj₁ hb = inj₁ hb
    ...| inj₂ res
      with 𝕂-chain-∈RC c3 (suc zero) (suc (suc zero)) (s≤s z≤n) res rc'
-   ...| inj₁ hb   = inj₁ hb
+   ...| inj₁ (hb , (p1 , p2))  = inj₁ (hb , ((prev∈sys p1) , (rc'All∈sys (there b←q p2))))
    ...| inj₂ res' = inj₂ (there (B←Q refl x₀) res')
-   propS4-base {q' = q'} prev∈sys (step rc' (B←Q refl x₀)) q'∈sys c3 hyp0 hyp1
+   propS4-base {q' = q'} prev∈sys rc0@(step rc' (B←Q refl x₀)) rc'All∈sys c3 hyp0 hyp1
       | there (there (here r))
-     with propS4-base-lemma-2 prev∈sys q' q'∈sys rc' (B←Q refl x₀) c3 (suc (suc zero)) (sym r)
+     with propS4-base-lemma-2 prev∈sys q' (All-InSys⇒last-InSys rc'All∈sys) rc' (All-InSys-unstep rc'All∈sys) (B←Q refl x₀) c3 (suc (suc zero)) (sym r)
    ...| inj₁ hb = inj₁ hb
    ...| inj₂ res
      with 𝕂-chain-∈RC c3 (suc (suc zero)) (suc (suc zero)) (s≤s (s≤s z≤n)) res rc'
-   ...| inj₁ hb   = inj₁ hb
+   ...| inj₁ (hb , (p1 , p2))  = inj₁ (hb , (prev∈sys p1 , rc'All∈sys (there (B←Q refl x₀) p2)))
    ...| inj₂ res' = inj₂ (there (B←Q refl x₀) res')
 
    propS4 : ∀{q q'}
@@ -212,10 +214,10 @@ module LibraBFT.Abstract.RecordChain.Properties
           -- In the paper, the proposition states that B₀ ←⋆ B, yet, B is the block preceding
           -- C, which in our case is 'prevBlock rc''. Hence, to say that B₀ ←⋆ B is
           -- to say that B₀ is a block in the RecordChain that goes all the way to C.
-          → NonInjective-≡ bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
+          → NonInjective-≡-pred (InSys ∘ B) bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
    propS4 {q' = q'} {rc} prev∈sys (step rc' b←q') prev∈sys' c3 hyp
      with getRound q' ≤?ℕ getRound (c3 b⟦ zero ⟧)
-   ...| yes rq≤rb₂ = propS4-base {q' = q'} prev∈sys (step rc' b←q') (All-InSys⇒last-InSys prev∈sys') c3 hyp rq≤rb₂
+   ...| yes rq≤rb₂ = propS4-base {q' = q'} prev∈sys (step rc' b←q') prev∈sys' c3 hyp rq≤rb₂
    propS4 {q' = q'} prev∈sys (step rc' b←q') all∈sys c3 hyp
       | no  rb₂<rq
      with lemmaS3 (All-InSys⇒last-InSys prev∈sys) (step rc' b←q')
@@ -242,7 +244,7 @@ module LibraBFT.Abstract.RecordChain.Properties
          → {b b' : Block}
          → CommitRule rc  b
          → CommitRule rc' b'
-         → NonInjective-≡ bId ⊎ ((B b) ∈RC rc' ⊎ (B b') ∈RC rc) -- Not conflicting means one extends the other.
+         → NonInjective-≡-pred (InSys ∘ B) bId ⊎ ((B b) ∈RC rc' ⊎ (B b') ∈RC rc) -- Not conflicting means one extends the other.
    thmS5 {rc = rc} prev∈sys {rc'} prev∈sys' (commit-rule c3 refl) (commit-rule c3' refl)
      with <-cmp (getRound (c3 b⟦ suc (suc zero) ⟧)) (getRound (c3' b⟦ suc (suc zero) ⟧))
    ...| tri≈ _ r≡r' _ = inj₁ <⊎$> (propS4 prev∈sys  rc' prev∈sys' c3  (≤-trans (≡⇒≤ r≡r')      (kchain-round-≤-lemma' c3' (suc (suc zero)))))

--- a/LibraBFT/Abstract/Records/Extends.agda
+++ b/LibraBFT/Abstract/Records/Extends.agda
@@ -47,9 +47,9 @@ module LibraBFT.Abstract.Records.Extends
 
   -- Equivalent records extend equivalent records (modulo injectivity
   -- failure of bId).
-  ←-≈Rec : ∀{r₀ r₁ s₀ s₁} → s₀ ← r₀ → s₁ ← r₁
+  ←-≈Rec : ∀{r₀ r₁ s₀ s₁} → (ext₀ : s₀ ← r₀) → (ext₁ : s₁ ← r₁)
            → r₀ ≈Rec r₁
-           → NonInjective-≡ bId ⊎ (s₀ ≈Rec s₁)
+           → NonInjective-≡-preds ((s₀ ≡_) ∘ B) ((s₁ ≡_) ∘ B) bId ⊎ (s₀ ≈Rec s₁)
   ←-≈Rec (I←B x x₁) (I←B x₂ x₃) hyp = inj₂ eq-I
   ←-≈Rec (I←B x x₁) (Q←B x₂ x₃) (eq-B refl)
     = ⊥-elim (maybe-⊥ (sym x₃) x₁)
@@ -61,7 +61,7 @@ module LibraBFT.Abstract.Records.Extends
                        -- in eq-Q
   ←-≈Rec (B←Q {b₀} x refl) (B←Q {b₁} w refl) (eq-Q refl)
     with b₀ ≟Block b₁
-  ...| no  hb  = inj₁ ((b₀ , b₁) , (λ x → hb x) , refl)
+  ...| no  hb  = inj₁ (((b₀ , b₁) , (λ x → hb x) , refl) , refl , refl)
   ...| yes prf = inj₂ (eq-B prf)
 
   ←-irrelevant : Irrelevant _←_

--- a/LibraBFT/Abstract/System.agda
+++ b/LibraBFT/Abstract/System.agda
@@ -47,6 +47,12 @@ module LibraBFT.Abstract.System
     All-InSys-step hyp ext r here = r
     All-InSys-step hyp ext r (there .ext r∈rc) = hyp r∈rc
 
+
+  -- We say an InSys predicate has NoCollisions if there are no two different Blocks that satisfy
+  -- InSys and have different ids.
+  NoCollisions : ∀{ℓ} → (Record → Set ℓ) → Set ℓ
+  NoCollisions ∈sys = ∀ {b₀ b₁} → ∈sys (B b₀) → ∈sys (B b₁) → bId b₀ ≡ bId b₁ → b₀ ≡ b₁
+
   -- We say an InSys predicate is /Complete/ when we can construct a record chain
   -- from any vote by an honest participant. This essentially says that whenever
   -- an honest participant casts a vote, they have checked that the voted-for

--- a/LibraBFT/Concrete/Obligations/PreferredRound.agda
+++ b/LibraBFT/Concrete/Obligations/PreferredRound.agda
@@ -193,10 +193,10 @@ module LibraBFT.Concrete.Obligations.PreferredRound
            cand hyp
   ...| va'Par , res
     with vdParent-prevRound-lemma rc' va' va'Par
-  ...| inj₁ hb    = inj₁ hb
+  ...| inj₁ hb    = inj₁ (hb , obm-dangerous-magic' "TODO-3: connect to InSys")
   ...| inj₂ final
     with make-cand-3-chain-lemma c3 va
-  ...| inj₁ hb = inj₁ hb
+  ...| inj₁ hb = inj₁ (hb , obm-dangerous-magic' "TODO-3: connect to InSys")
   ...| inj₂ xx = inj₂ (subst₂ _≤_
           (cong bRound (trans (cong (kchainBlock (suc zero) ∘ is-2chain) (sym R)) xx))
           final

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -31,19 +31,24 @@ module LibraBFT.Concrete.Properties
          (impl-correct : ImplObligations iiah 𝓔)
          where
 
-    open WithEC
-    open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
-    open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
-    import      LibraBFT.Concrete.Obligations.VotesOnce          𝓔 (ConcreteVoteEvidence 𝓔) as VO-obl
-    import      LibraBFT.Concrete.Obligations.PreferredRound     𝓔 (ConcreteVoteEvidence 𝓔) as PR-obl
-    open import LibraBFT.Concrete.Properties.VotesOnce                                       as VO
-    open import LibraBFT.Concrete.Properties.PreferredRound                                  as PR
-    open import LibraBFT.ImplShared.Util.HashCollisions iiah
+  open WithEC
+  open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
+  open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
+  import      LibraBFT.Concrete.Obligations.VotesOnce          𝓔 (ConcreteVoteEvidence 𝓔) as VO-obl
+  import      LibraBFT.Concrete.Obligations.PreferredRound     𝓔 (ConcreteVoteEvidence 𝓔) as PR-obl
+  open import LibraBFT.Concrete.Properties.VotesOnce                                       as VO
+  open import LibraBFT.Concrete.Properties.PreferredRound                                  as PR
+  open import LibraBFT.ImplShared.Util.HashCollisions iiah
 
-    open        ImplObligations impl-correct
-    open        PerState st
-    open        PerReachableState r
-    open        PerEpoch 𝓔
+  open        ImplObligations impl-correct
+  open        PerState st
+  open        PerReachableState r
+  open        PerEpoch 𝓔
+  open        IntermediateSystemState intSystemState
+
+  -- This module parameter asserts that there are no hash collisions between Blocks *in the system*,
+  -- allowing us to eliminate that case when the abstract properties claim it is the case.
+  module _ (no-collisions-InSys : NoCollisions InSys) where
 
     --------------------------------------------------------------------------------------------
     -- * A /ValidSysState/ is one in which both peer obligations are obeyed by honest peers * --
@@ -61,10 +66,8 @@ module LibraBFT.Concrete.Properties
       ; vss-preferred-round = PR.Proof.prr iiah 𝓔 sps-cor bsvr v≢0 ∈BI? iro pr₁ pr₂ st r
       }
 
-    open IntermediateSystemState intSystemState
-
     open All-InSys-props InSys
-    open WithAssumptions InSys
+    open WithAssumptions InSys no-collisions-InSys
 
     -- We can now invoke the various abstract correctness properties.  Note that the arguments are
     -- expressed in Abstract terms (RecordChain, CommitRule).  Proving the corresponding properties
@@ -79,37 +82,25 @@ module LibraBFT.Concrete.Properties
        → {b b' : Abs.Block}
        → CommitRule rc  b
        → CommitRule rc' b'
-       → NonInjective-≡ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
-    ConcCommitsDoNotConflict = CommitsDoNotConflict
-           (VO-obl.proof intSystemState (vss-votes-once validState))
-           (PR-obl.proof intSystemState (vss-preferred-round validState))
+       → (Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc
+    ConcCommitsDoNotConflict =
+      CommitsDoNotConflict
+        (VO-obl.proof intSystemState (vss-votes-once validState))
+        (PR-obl.proof intSystemState (vss-preferred-round validState))
 
     module _ (∈QC⇒AllSent : Complete InSys) where
 
-      ConcCommitsDoNotConflict' :
-        ∀{q q'}{rc  : RecordChain (Abs.Q q)}{rc' : RecordChain (Abs.Q q')}{b b' : Abs.Block}
-        → InSys (Abs.Q q) → InSys (Abs.Q q')
-        → CommitRule rc  b
-        → CommitRule rc' b'
-        → NonInjective-≡ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
-      ConcCommitsDoNotConflict' = CommitsDoNotConflict'
-           (VO-obl.proof intSystemState (vss-votes-once validState))
-           (PR-obl.proof intSystemState (vss-preferred-round validState))
-           ∈QC⇒AllSent
-
-      ConcCommitsDoNotConflict''
+      ConcCommitsDoNotConflict'
         : ∀{o o' q q'}
-        → {rcf  : RecordChainFrom o  (Abs.Q q)}
-        → {rcf' : RecordChainFrom o' (Abs.Q q')}
+        → {rcf  : RecordChainFrom o  (Abs.Q q)}  → All-InSys rcf
+        → {rcf' : RecordChainFrom o' (Abs.Q q')} → All-InSys rcf'
         → {b b' : Abs.Block}
-        → InSys (Abs.Q q)
-        → InSys (Abs.Q q')
         → CommitRuleFrom rcf  b
         → CommitRuleFrom rcf' b'
-        → NonInjective-≡ Abs.bId ⊎ Σ (RecordChain (Abs.Q q')) ((Abs.B b)  ∈RC_)
-                                 ⊎ Σ (RecordChain (Abs.Q q))  ((Abs.B b') ∈RC_)
-      ConcCommitsDoNotConflict'' = CommitsDoNotConflict''
-           (VO-obl.proof intSystemState (vss-votes-once validState))
-           (PR-obl.proof intSystemState (vss-preferred-round validState))
-           ∈QC⇒AllSent
-
+        →   Σ (RecordChain (Abs.Q q')) ((Abs.B b)  ∈RC_)
+          ⊎ Σ (RecordChain (Abs.Q q))  ((Abs.B b') ∈RC_)
+      ConcCommitsDoNotConflict' =
+        CommitsDoNotConflict'
+          (VO-obl.proof intSystemState (vss-votes-once validState))
+          (PR-obl.proof intSystemState (vss-preferred-round validState))
+          ∈QC⇒AllSent

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -315,6 +315,17 @@ module LibraBFT.Prelude where
                  → (A → B) → Set (a ℓ⊔ b)
   NonInjective-≡ = NonInjective _≡_
 
+  NonInjective-≡-preds : ∀{a b}{A : Set a}{B : Set b}{ℓ₁ ℓ₂ : Level}
+                      → (A → Set ℓ₁)
+                      → (A → Set ℓ₂)
+                      → (A → B) → Set (a ℓ⊔ b ℓ⊔ ℓ₁ ℓ⊔ ℓ₂)
+  NonInjective-≡-preds Pred1 Pred2 f = Σ (NonInjective _≡_ f) λ { ((a₀ , a₁) , _ , _) → Pred1 a₀ × Pred2 a₁ }
+
+  NonInjective-≡-pred : ∀{a b}{A : Set a}{B : Set b}{ℓ : Level}
+                      → (P : A → Set ℓ)
+                      → (A → B) → Set (a ℓ⊔ b ℓ⊔ ℓ)
+  NonInjective-≡-pred Pred = NonInjective-≡-preds Pred Pred
+
   NonInjective-∘ : ∀{a b c}{A : Set a}{B : Set b}{C : Set c}
                  → {f : A → B}(g : B → C)
                  → NonInjective-≡  f


### PR DESCRIPTION
This pull request makes the `Abstract` properties hold unless they can provide a specific example of noninjectivity of abstract `Block`s that are "in the system", according to a predicate provided as a module parameter.  This removes the possibility for the proofs to cheat by simply creating a pair of different `Block`s with the same `bId`, which is trivial without the requirement to show that those `Block`s are considered to be "in the system" by whomever is instantiating the `Abstract` properties.  The top-level `Abstract` modules now take a module parameter that asserts that there are no injectivity failures among `Record`s that are "in the system", which allows us to eliminate the possibility of such an injectivity failure., yielding the desired correctness properties.  We have yet to push this up to the implementation we are modelling, so this gap is "papered over" for now using `obm-damgerous-magic`.