### PR TITLE
Make `Impl` properties identify specific hash collisions

### DIFF
--- a/LibraBFT/Abstract/RecordChain/Assumptions.agda
+++ b/LibraBFT/Abstract/RecordChain/Assumptions.agda
@@ -112,4 +112,4 @@ module LibraBFT.Abstract.RecordChain.Assumptions
      → (rc' : RecordChain (Q q'))
      → (v' : α ∈QC q')
      → abs-vRound (∈QC-Vote q v) < abs-vRound (∈QC-Vote q' v')
-     → NonInjective-≡ bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
+     → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -55,7 +55,7 @@ module LibraBFT.Abstract.RecordChain.Properties
            → (p₀ : B b₀ ← Q q₀)
            → (p₁ : B b₁ ← Q q₁)
            → getRound b₀ ≡ getRound b₁
-           → NonInjective-≡ bId ⊎ b₀ ≡ b₁
+           → b₀ ≢ b₁ × bId b₀ ≡ bId b₁ ⊎ b₀ ≡ b₁
    lemmaS2 {b₀} {b₁} {q₀} {q₁} ex₀ ex₁ (B←Q refl h₀) (B←Q refl h₁) refl
      with b₀ ≟Block b₁
    ...| yes done = inj₂ done
@@ -75,7 +75,7 @@ module LibraBFT.Abstract.RecordChain.Properties
          v₁∈q₁ = ∈QC-Vote-correct q₁ a∈q₁
          ppp   = trans h₀ (trans (vote≡⇒QPrevId≡ {q₀} {q₁} v₀∈q₀ v₁∈q₁ (votes-only-once a honest ex₀ ex₁ a∈q₀ a∈q₁ v₀≡v₁))
                                  (sym h₁))
-     in inj₁ ((b₀ , b₁) , (imp , ppp))
+     in inj₁ (imp , ppp)
 
    ----------------
    -- Lemma S3
@@ -85,7 +85,7 @@ module LibraBFT.Abstract.RecordChain.Properties
            → (rc' : RecordChain (Q q')) → InSys (Q q')  -- Immediately before a (Q q), we have the certified block (B b), which is the 'B' in S3
            → (c3 : 𝕂-chain Contig 3 rc)                 -- This is B₀ ← C₀ ← B₁ ← C₁ ← B₂ ← C₂ in S3
            → round r₂ < getRound q'
-           → NonInjective-≡ bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
+           → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
    lemmaS3 {r₂} {q'} ex₀ (step rc' b←q') ex₁ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ _ b₂←q₂ c2) hyp
      with bft-property (qVotes-C1 q₂) (qVotes-C1 q')
    ...| (a , (a∈q₂mem , a∈q'mem , honest))
@@ -161,47 +161,49 @@ module LibraBFT.Abstract.RecordChain.Properties
        {rc : RecordChain r} → All-InSys rc
      → (q' : QC) → InSys (Q q')
      → {b' : Block}
-     → (rc' : RecordChain (B b')) → (ext : (B b') ← (Q q'))
+     → (rc' : RecordChain (B b')) → All-InSys rc' → (ext : (B b') ← (Q q'))
      → (c  : 𝕂-chain Contig k rc)
      → (ix : Fin k)
      → getRound (kchainBlock ix c) ≡ getRound b'
-     → NonInjective-≡ bId ⊎ (kchainBlock ix c ≡ b')
-   propS4-base-lemma-2 {rc = rc} prev∈sys q' q'∈sys rc' ext (s-chain r←b prf b←q c) zero hyp
-     = lemmaS2 (All-InSys⇒last-InSys prev∈sys) q'∈sys b←q ext hyp
-   propS4-base-lemma-2 prev∈sys q' q'∈sys rc' ext (s-chain r←b prf b←q c) (suc ix)
-     = propS4-base-lemma-2 (All-InSys-unstep (All-InSys-unstep prev∈sys)) q' q'∈sys rc' ext c ix
+     → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (kchainBlock ix c ≡ b')
+   propS4-base-lemma-2 {rc = rc} prev∈sys q' q'∈sys {b'} rc' rc'All∈sys ext (s-chain {b = b} r←b prf b←q c) zero hyp
+      with lemmaS2 (All-InSys⇒last-InSys prev∈sys) q'∈sys b←q ext hyp
+   ... | Left  (b≢b' , bIds≡) = inj₁ (((b , b') , b≢b' , bIds≡) , All-InSys-unstep prev∈sys here , rc'All∈sys here)
+   ... | Right y = Right y
+   propS4-base-lemma-2 prev∈sys q' q'∈sys rc' rc'All∈sys ext (s-chain r←b prf b←q c) (suc ix)
+     = propS4-base-lemma-2 (All-InSys-unstep (All-InSys-unstep prev∈sys)) q' q'∈sys rc' rc'All∈sys ext c ix
 
    propS4-base : ∀{q q'}
                → {rc : RecordChain (Q q)}   → All-InSys rc
-               → (rc' : RecordChain (Q q')) → InSys (Q q')
+               → (rc' : RecordChain (Q q')) → All-InSys rc'
                → (c3 : 𝕂-chain Contig 3 rc) -- This is B₀ ← C₀ ← B₁ ← C₁ ← B₂ ← C₂ in S4
                → getRound (c3 b⟦ suc (suc zero) ⟧) ≤ getRound q'
                → getRound q' ≤ getRound (c3 b⟦ zero ⟧)
-               → NonInjective-≡ bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
-   propS4-base {q' = q'} prev∈sys (step {B b} rc'@(step rc'' q←b) b←q@(B←Q refl _)) q'∈sys c3 hyp0 hyp1
+               → NonInjective-≡-pred (InSys ∘ B) bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
+   propS4-base {q' = q'} prev∈sys rc0@(step {B b} rc'@(step rc'' q←b) b←q@(B←Q refl _)) rc'All∈sys c3 hyp0 hyp1
      with propS4-base-lemma-1 c3 (getRound b) hyp0 hyp1
    ...| here r
-     with propS4-base-lemma-2 prev∈sys q' q'∈sys rc' b←q c3 zero (sym r)
+     with propS4-base-lemma-2 prev∈sys q' (All-InSys⇒last-InSys rc'All∈sys) rc' (All-InSys-unstep rc'All∈sys) b←q c3 zero (sym r)
    ...| inj₁ hb = inj₁ hb
    ...| inj₂ res
      with 𝕂-chain-∈RC c3 zero (suc (suc zero)) z≤n res rc'
-   ...| inj₁ hb   = inj₁ hb
+   ...| inj₁ (hb , (p1 , p2))  = inj₁ (hb , (prev∈sys p1 , rc'All∈sys (there b←q p2)))
    ...| inj₂ res' = inj₂ (there b←q res')
-   propS4-base {q} {q'} prev∈sys (step rc' (B←Q refl x₀)) q'∈sys c3 hyp0 hyp1
+   propS4-base {q} {q'} prev∈sys rc0@(step rc' b←q@(B←Q refl x₀)) rc'All∈sys c3 hyp0 hyp1
       | there (here r)
-     with propS4-base-lemma-2 prev∈sys q' q'∈sys rc' (B←Q refl x₀) c3 (suc zero) (sym r)
+     with propS4-base-lemma-2 prev∈sys q' (All-InSys⇒last-InSys rc'All∈sys) rc' (All-InSys-unstep rc'All∈sys) (B←Q refl x₀) c3 (suc zero) (sym r)
    ...| inj₁ hb = inj₁ hb
    ...| inj₂ res
      with 𝕂-chain-∈RC c3 (suc zero) (suc (suc zero)) (s≤s z≤n) res rc'
-   ...| inj₁ hb   = inj₁ hb
+   ...| inj₁ (hb , (p1 , p2))  = inj₁ (hb , ((prev∈sys p1) , (rc'All∈sys (there b←q p2))))
    ...| inj₂ res' = inj₂ (there (B←Q refl x₀) res')
-   propS4-base {q' = q'} prev∈sys (step rc' (B←Q refl x₀)) q'∈sys c3 hyp0 hyp1
+   propS4-base {q' = q'} prev∈sys rc0@(step rc' (B←Q refl x₀)) rc'All∈sys c3 hyp0 hyp1
       | there (there (here r))
-     with propS4-base-lemma-2 prev∈sys q' q'∈sys rc' (B←Q refl x₀) c3 (suc (suc zero)) (sym r)
+     with propS4-base-lemma-2 prev∈sys q' (All-InSys⇒last-InSys rc'All∈sys) rc' (All-InSys-unstep rc'All∈sys) (B←Q refl x₀) c3 (suc (suc zero)) (sym r)
    ...| inj₁ hb = inj₁ hb
    ...| inj₂ res
      with 𝕂-chain-∈RC c3 (suc (suc zero)) (suc (suc zero)) (s≤s (s≤s z≤n)) res rc'
-   ...| inj₁ hb   = inj₁ hb
+   ...| inj₁ (hb , (p1 , p2))  = inj₁ (hb , (prev∈sys p1 , rc'All∈sys (there (B←Q refl x₀) p2)))
    ...| inj₂ res' = inj₂ (there (B←Q refl x₀) res')
 
    propS4 : ∀{q q'}
@@ -212,10 +214,10 @@ module LibraBFT.Abstract.RecordChain.Properties
           -- In the paper, the proposition states that B₀ ←⋆ B, yet, B is the block preceding
           -- C, which in our case is 'prevBlock rc''. Hence, to say that B₀ ←⋆ B is
           -- to say that B₀ is a block in the RecordChain that goes all the way to C.
-          → NonInjective-≡ bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
+          → NonInjective-≡-pred (InSys ∘ B) bId ⊎ B (c3 b⟦ suc (suc zero) ⟧) ∈RC rc'
    propS4 {q' = q'} {rc} prev∈sys (step rc' b←q') prev∈sys' c3 hyp
      with getRound q' ≤?ℕ getRound (c3 b⟦ zero ⟧)
-   ...| yes rq≤rb₂ = propS4-base {q' = q'} prev∈sys (step rc' b←q') (All-InSys⇒last-InSys prev∈sys') c3 hyp rq≤rb₂
+   ...| yes rq≤rb₂ = propS4-base {q' = q'} prev∈sys (step rc' b←q') prev∈sys' c3 hyp rq≤rb₂
    propS4 {q' = q'} prev∈sys (step rc' b←q') all∈sys c3 hyp
       | no  rb₂<rq
      with lemmaS3 (All-InSys⇒last-InSys prev∈sys) (step rc' b←q')
@@ -242,7 +244,7 @@ module LibraBFT.Abstract.RecordChain.Properties
          → {b b' : Block}
          → CommitRule rc  b
          → CommitRule rc' b'
-         → NonInjective-≡ bId ⊎ ((B b) ∈RC rc' ⊎ (B b') ∈RC rc) -- Not conflicting means one extends the other.
+         → NonInjective-≡-pred (InSys ∘ B) bId ⊎ ((B b) ∈RC rc' ⊎ (B b') ∈RC rc) -- Not conflicting means one extends the other.
    thmS5 {rc = rc} prev∈sys {rc'} prev∈sys' (commit-rule c3 refl) (commit-rule c3' refl)
      with <-cmp (getRound (c3 b⟦ suc (suc zero) ⟧)) (getRound (c3' b⟦ suc (suc zero) ⟧))
    ...| tri≈ _ r≡r' _ = inj₁ <⊎$> (propS4 prev∈sys  rc' prev∈sys' c3  (≤-trans (≡⇒≤ r≡r')      (kchain-round-≤-lemma' c3' (suc (suc zero)))))

--- a/LibraBFT/Abstract/Records/Extends.agda
+++ b/LibraBFT/Abstract/Records/Extends.agda
@@ -47,9 +47,9 @@ module LibraBFT.Abstract.Records.Extends
 
   -- Equivalent records extend equivalent records (modulo injectivity
   -- failure of bId).
-  ←-≈Rec : ∀{r₀ r₁ s₀ s₁} → s₀ ← r₀ → s₁ ← r₁
+  ←-≈Rec : ∀{r₀ r₁ s₀ s₁} → (ext₀ : s₀ ← r₀) → (ext₁ : s₁ ← r₁)
            → r₀ ≈Rec r₁
-           → NonInjective-≡ bId ⊎ (s₀ ≈Rec s₁)
+           → NonInjective-≡-preds ((s₀ ≡_) ∘ B) ((s₁ ≡_) ∘ B) bId ⊎ (s₀ ≈Rec s₁)
   ←-≈Rec (I←B x x₁) (I←B x₂ x₃) hyp = inj₂ eq-I
   ←-≈Rec (I←B x x₁) (Q←B x₂ x₃) (eq-B refl)
     = ⊥-elim (maybe-⊥ (sym x₃) x₁)
@@ -61,7 +61,7 @@ module LibraBFT.Abstract.Records.Extends
                        -- in eq-Q
   ←-≈Rec (B←Q {b₀} x refl) (B←Q {b₁} w refl) (eq-Q refl)
     with b₀ ≟Block b₁
-  ...| no  hb  = inj₁ ((b₀ , b₁) , (λ x → hb x) , refl)
+  ...| no  hb  = inj₁ (((b₀ , b₁) , (λ x → hb x) , refl) , refl , refl)
   ...| yes prf = inj₂ (eq-B prf)
 
   ←-irrelevant : Irrelevant _←_

--- a/LibraBFT/Abstract/System.agda
+++ b/LibraBFT/Abstract/System.agda
@@ -47,6 +47,12 @@ module LibraBFT.Abstract.System
     All-InSys-step hyp ext r here = r
     All-InSys-step hyp ext r (there .ext r∈rc) = hyp r∈rc
 
+
+  -- We say an InSys predicate has NoCollisions if there are no two different Blocks that satisfy
+  -- InSys and have different ids.
+  NoCollisions : ∀{ℓ} → (Record → Set ℓ) → Set ℓ
+  NoCollisions ∈sys = ∀ {b₀ b₁} → ∈sys (B b₀) → ∈sys (B b₁) → bId b₀ ≡ bId b₁ → b₀ ≡ b₁
+
   -- We say an InSys predicate is /Complete/ when we can construct a record chain
   -- from any vote by an honest participant. This essentially says that whenever
   -- an honest participant casts a vote, they have checked that the voted-for

--- a/LibraBFT/Base/KVMap.agda
+++ b/LibraBFT/Base/KVMap.agda
@@ -98,6 +98,11 @@ module LibraBFT.Base.KVMap  where
                   → (prf : lookup k kvm ≡ nothing)
                   → lookup k (kvm-insert k v kvm prf) ≡ just v
 
+   -- Haskell's insert updates the value even if the key is already in the map
+   lookup-correct-haskell
+                  : {kvm : KVMap Key Val}
+                  → lookup k (kvm-insert-Haskell k v kvm) ≡ just v
+
    lookup-correct-update
                   : {kvm : KVMap Key Val}
                   → (prf : lookup k kvm ≢ nothing)

--- a/LibraBFT/Concrete/Obligations/PreferredRound.agda
+++ b/LibraBFT/Concrete/Obligations/PreferredRound.agda
@@ -193,10 +193,10 @@ module LibraBFT.Concrete.Obligations.PreferredRound
            cand hyp
   ...| va'Par , res
     with vdParent-prevRound-lemma rc' va' va'Par
-  ...| inj₁ hb    = inj₁ hb
+  ...| inj₁ hb    = inj₁ (hb , obm-dangerous-magic' "TODO-3: connect to InSys")
   ...| inj₂ final
     with make-cand-3-chain-lemma c3 va
-  ...| inj₁ hb = inj₁ hb
+  ...| inj₁ hb = inj₁ (hb , obm-dangerous-magic' "TODO-3: connect to InSys")
   ...| inj₂ xx = inj₂ (subst₂ _≤_
           (cong bRound (trans (cong (kchainBlock (suc zero) ∘ is-2chain) (sym R)) xx))
           final

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -31,19 +31,24 @@ module LibraBFT.Concrete.Properties
          (impl-correct : ImplObligations iiah 𝓔)
          where
 
-    open WithEC
-    open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
-    open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
-    import      LibraBFT.Concrete.Obligations.VotesOnce          𝓔 (ConcreteVoteEvidence 𝓔) as VO-obl
-    import      LibraBFT.Concrete.Obligations.PreferredRound     𝓔 (ConcreteVoteEvidence 𝓔) as PR-obl
-    open import LibraBFT.Concrete.Properties.VotesOnce                                       as VO
-    open import LibraBFT.Concrete.Properties.PreferredRound                                  as PR
-    open import LibraBFT.ImplShared.Util.HashCollisions iiah
+  open WithEC
+  open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs
+  open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
+  import      LibraBFT.Concrete.Obligations.VotesOnce          𝓔 (ConcreteVoteEvidence 𝓔) as VO-obl
+  import      LibraBFT.Concrete.Obligations.PreferredRound     𝓔 (ConcreteVoteEvidence 𝓔) as PR-obl
+  open import LibraBFT.Concrete.Properties.VotesOnce                                       as VO
+  open import LibraBFT.Concrete.Properties.PreferredRound                                  as PR
+  open import LibraBFT.ImplShared.Util.HashCollisions iiah
 
-    open        ImplObligations impl-correct
-    open        PerState st
-    open        PerReachableState r
-    open        PerEpoch 𝓔
+  open        ImplObligations impl-correct
+  open        PerState st
+  open        PerReachableState r
+  open        PerEpoch 𝓔
+  open        IntermediateSystemState intSystemState
+
+  -- This module parameter asserts that there are no hash collisions between Blocks *in the system*,
+  -- allowing us to eliminate that case when the abstract properties claim it is the case.
+  module _ (no-collisions-InSys : NoCollisions InSys) where
 
     --------------------------------------------------------------------------------------------
     -- * A /ValidSysState/ is one in which both peer obligations are obeyed by honest peers * --
@@ -61,10 +66,8 @@ module LibraBFT.Concrete.Properties
       ; vss-preferred-round = PR.Proof.prr iiah 𝓔 sps-cor bsvr v≢0 ∈BI? iro pr₁ pr₂ st r
       }
 
-    open IntermediateSystemState intSystemState
-
     open All-InSys-props InSys
-    open WithAssumptions InSys
+    open WithAssumptions InSys no-collisions-InSys
 
     -- We can now invoke the various abstract correctness properties.  Note that the arguments are
     -- expressed in Abstract terms (RecordChain, CommitRule).  Proving the corresponding properties
@@ -79,37 +82,25 @@ module LibraBFT.Concrete.Properties
        → {b b' : Abs.Block}
        → CommitRule rc  b
        → CommitRule rc' b'
-       → NonInjective-≡ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
-    ConcCommitsDoNotConflict = CommitsDoNotConflict
-           (VO-obl.proof intSystemState (vss-votes-once validState))
-           (PR-obl.proof intSystemState (vss-preferred-round validState))
+       → (Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc
+    ConcCommitsDoNotConflict =
+      CommitsDoNotConflict
+        (VO-obl.proof intSystemState (vss-votes-once validState))
+        (PR-obl.proof intSystemState (vss-preferred-round validState))
 
     module _ (∈QC⇒AllSent : Complete InSys) where
 
-      ConcCommitsDoNotConflict' :
-        ∀{q q'}{rc  : RecordChain (Abs.Q q)}{rc' : RecordChain (Abs.Q q')}{b b' : Abs.Block}
-        → InSys (Abs.Q q) → InSys (Abs.Q q')
-        → CommitRule rc  b
-        → CommitRule rc' b'
-        → NonInjective-≡ Abs.bId ⊎ ((Abs.B b) ∈RC rc' ⊎ (Abs.B b') ∈RC rc)
-      ConcCommitsDoNotConflict' = CommitsDoNotConflict'
-           (VO-obl.proof intSystemState (vss-votes-once validState))
-           (PR-obl.proof intSystemState (vss-preferred-round validState))
-           ∈QC⇒AllSent
-
-      ConcCommitsDoNotConflict''
+      ConcCommitsDoNotConflict'
         : ∀{o o' q q'}
-        → {rcf  : RecordChainFrom o  (Abs.Q q)}
-        → {rcf' : RecordChainFrom o' (Abs.Q q')}
+        → {rcf  : RecordChainFrom o  (Abs.Q q)}  → All-InSys rcf
+        → {rcf' : RecordChainFrom o' (Abs.Q q')} → All-InSys rcf'
         → {b b' : Abs.Block}
-        → InSys (Abs.Q q)
-        → InSys (Abs.Q q')
         → CommitRuleFrom rcf  b
         → CommitRuleFrom rcf' b'
-        → NonInjective-≡ Abs.bId ⊎ Σ (RecordChain (Abs.Q q')) ((Abs.B b)  ∈RC_)
-                                 ⊎ Σ (RecordChain (Abs.Q q))  ((Abs.B b') ∈RC_)
-      ConcCommitsDoNotConflict'' = CommitsDoNotConflict''
-           (VO-obl.proof intSystemState (vss-votes-once validState))
-           (PR-obl.proof intSystemState (vss-preferred-round validState))
-           ∈QC⇒AllSent
-
+        →   Σ (RecordChain (Abs.Q q')) ((Abs.B b)  ∈RC_)
+          ⊎ Σ (RecordChain (Abs.Q q))  ((Abs.B b') ∈RC_)
+      ConcCommitsDoNotConflict' =
+        CommitsDoNotConflict'
+          (VO-obl.proof intSystemState (vss-votes-once validState))
+          (PR-obl.proof intSystemState (vss-preferred-round validState))
+          ∈QC⇒AllSent

--- a/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -91,8 +91,8 @@ module insertBlockE (block : ExecutedBlock)(bt : BlockTree) where
         nothing → LeftD fakeErr
         (just parentBlock) → (do
           parentBlock' ← addChild parentBlock blockId
-          let bt' = bt & btIdToBlock ∙~ Map.insert (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
-          pure (  (bt' & btIdToBlock ∙~ Map.insert blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
+          let bt' = bt & btIdToBlock ∙~ Map.kvm-insert-Haskell (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
+          pure (  (bt' & btIdToBlock ∙~ Map.kvm-insert-Haskell blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
                , block))
 
   E : VariantFor Either

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -31,18 +31,6 @@ open QCProps
 
 module LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockStore where
 
-module getBlockSpec (hv : HashValue) (bs : BlockStore) where
-
-  Ok : Set
-  Ok = ∃[ eb ] (getBlock hv bs ≡ just eb)
-
-  postulate -- TODO-2: Refine contract
-            -- This contract is only a sketch, and will need to be modified when
-            -- hash collisions are are modeled.
-    correctBlockData
-      : ∀ bd → hashBD bd ≡ hv → (isOk : Ok) → let (eb , _) = isOk in
-          eb ^∙ ebBlock ≈Block record (eb ^∙ ebBlock) { _bId = hv ;  _bBlockData = bd }
-
 module executeBlockESpec (bs : BlockStore) (block : Block) where
 
   Ok : Set
@@ -51,32 +39,30 @@ module executeBlockESpec (bs : BlockStore) (block : Block) where
   record ContractOk (eb : ExecutedBlock) : Set where
     constructor mkContractOk
     field
-      ebBlock≈ : eb ^∙ ebBlock ≈Block block
+      ebBlock≡ : block ≡ eb ^∙ ebBlock
 
-  postulate -- TODO: Refine `ContractOk` and prove
+  postulate -- TODO: prove
     contract : (isOk : Ok) → ContractOk (proj₁ isOk)
 
-module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
+module executeAndInsertBlockESpec (bs0 : BlockStore) (vblock : ValidBlock) where
+  block   = vbBlock vblock
+  block-c = vbValid vblock
   open executeAndInsertBlockE bs0 block
 
   open import LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockTree
+
+  blockId = block ^∙ bId
 
   ------   These are used only outside this module.  
   Ok : Set
   Ok = ∃₂ λ bs' eb → executeAndInsertBlockE bs0 block ≡ Right (bs' , eb)
 
-  private
-    Ok' : BlockStore → ExecutedBlock → Either ErrLog (BlockStore × ExecutedBlock) → Set
-    Ok' bs' eb m = m ≡ Right (bs' , eb)
-
-  Err : Set
-  Err = ∃[ e ] (executeAndInsertBlockE bs0 block ≡ Left e)
-  ------
+  open Reqs block (bs0 ^∙ bsInner)
 
   record ContractOk (bs' : BlockStore) (eb : ExecutedBlock) : Set where
     constructor mkContractOk
     field
-      ebBlock≈ : hashBD (block ^∙ bBlockData) ≡ block ^∙ bId → eb ^∙ ebBlock ≈Block block
+      ebBlock≈ : NoHC1 → eb ^∙ ebBlock ≈Block block
       bsInv    : ∀ {eci}
                  → Preserves BlockStoreInv (bs0 , eci) (bs' , eci)
       -- executeAndInsertBlockE does not modify BlockTree fields other than btIDToBlock
@@ -86,45 +72,68 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
   Contract (Left x) = ⊤
   Contract (Right (bs' , eb)) = ContractOk bs' eb
 
+  -- TUTORIAL: This proof has some additional commentary helping to understand the structure of the
+  -- proof, and showing an example of how using abstract variants of functions makes proofs more
+  -- resilient to change, as explained in
+  -- https://github.com/oracle/bft-consensus-agda/blob/main/docs/PeerHandlerContracts.org
   contract' : EitherD-weakestPre step₀ Contract
+  -- step₀ is a maybeSD in context of EitherD.  Therefore, via MonadMaybeD and EitherD-MonadMaybeD,
+  -- this translates to EitherD-maybe.  We first deal with the easy case, applying the NoHC1
+  -- function provided to ebBlock≈ to evidence eb≡ that eb is in btIdToBlock.
   proj₂ contract' eb eb≡ =
-    mkContractOk ebBlock≈ id refl
-    where
-    ebBlock≈ : hashBD (block ^∙ bBlockData) ≡ block ^∙ bId → eb ^∙ ebBlock ≈Block block
-    ebBlock≈ bid≡ =
-      getBlockSpec.correctBlockData
-        (block ^∙ bId) bs0 (block ^∙ bBlockData) (bid≡) (eb , eb≡)
-
-    qcPres : ∀ qc → PreservesL (qc ∈RoundManager_) rmBlockStore bs0 bs0
-    qcPres qc rm = id
-
+    mkContractOk (λ nohc → nohc eb≡ block-c) id refl
   proj₁ contract' getBlock≡nothing = contract₁
     where
+    -- step₁ is again a maybeSD; if bs0 ^∙ bsRoot ≡ nothing, the Contract is trivial
     contract₁ : EitherD-weakestPre step₁ Contract
     proj₁ contract₁ _ = tt
+    -- otherwise, bs0 ^∙ bsRoot ≡ just bsr, and we have an ifD; in the true branch, step₁ returns a
+    -- Left, so again it is trivial
     proj₁ (proj₂ contract₁ bsr bsr≡) _ = tt
+    -- in the else branch, we call step₂ bsr
     proj₂ (proj₂ contract₁ bsr bsr≡) btr<br = contract₂
       where
-      contract₃ : ∀ eb → ExecutedBlock∙new block stateComputeResult ≡ eb
+      contract₃ : ∀ eb → block ≡ (eb ^∙ ebBlock)
                   → EitherD-weakestPre (step₃ eb) Contract
 
-      -- TODO-2: The structure of this proof changes, and therefore it breaks, when we fully implement
-      -- executeBlockE.  This suggests that we should be using the contract for
-      -- executeBlockE, not depending on looking into its implementation here
-      contract₂ : EitherD-weakestPre (step₂ bsr) Contract
-      proj₂ contract₂ eb eb≡ ._ refl =
-        contract₃ eb (inj₂-injective eb≡)
-      proj₁ contract₂ (ErrCBlockNotFound _) executeBlockE≡Left = tt
-      proj₁ contract₂ (ErrVerify _) executeBlockE≡Left = tt
-      -- > eitherSD (pathFromRoot parentBlockId bs0) LeftD λ blocksToReexecute →
-      proj₁ (proj₁ contract₂ (ErrECCBlockNotFound parentBlockId) executeBlockE≡Left) _ _ = tt
-      -- > case⊎D (forM) blocksToReexecute (executeBlockE bs0 ∘ (_^∙ ebBlock)) of λ where
-      proj₁ (proj₂ (proj₁ contract₂ (ErrECCBlockNotFound parentBlockId) executeBlockE≡Left) blocksToReexecute btr≡) _ _ = tt
-      proj₂ (proj₂ (proj₁ contract₂ (ErrECCBlockNotFound parentBlockId) executeBlockE≡Left) blocksToReexecute btr≡) _ _ eb eb≡ =
-        contract₃ eb (sym eb≡)
+      module EB = executeBlockESpec bs0 block
+      open EB.ContractOk
 
-      contract₃ eb eb≡ bs1 bs1≡ = contract₄
+      contract₂ : EitherD-weakestPre (step₂ bsr) Contract
+      proj₂ contract₂ eb eb≡ ._             executeBlockE≡Right@refl = let con = (EB.contract (eb , eb≡))
+                                                                       in contract₃ eb
+                                                                                    (EB.ContractOk.ebBlock≡ con)
+
+      proj₁ contract₂ (ErrCBlockNotFound _) executeBlockE≡Left = tt
+      proj₁ contract₂ (ErrVerify _)         executeBlockE≡Left = tt
+      proj₁ contract₂ (ErrInfo _)           executeBlockE≡Left = tt
+      -- if executeBlockE returns Left (ErrECCBlockNotFound parentBlockId), then we have two casesdue to
+      -- eitherSD (pathFromRoot parentBlockId bs0) LeftD λ blocksToReexecute →
+      -- in the first case, we have a Left, so it's easy
+      proj₁        (proj₁ contract₂ (ErrECCBlockNotFound parentBlockId) executeBlockE≡Left) _ _ = tt
+      -- in the second case, we have
+      -- case⊎D (forM) blocksToReexecute (executeBlockE bs0 ∘ (_^∙ ebBlock)) of λ where
+      -- and therefore two more cases; if the case⊎D returns Left, it's easy again
+      proj₁ (proj₂ (proj₁ contract₂ (ErrECCBlockNotFound parentBlockId) executeBlockE≡Left) blocksToReexecute btr≡) _ _ = tt
+      -- if the case⊎D returns a Right, we call executeBlockE₀ (the EitherD variant).  We use executeBlockE≡ to handle case
+      -- analysis on the result of calling the abstract executeBlockE variant, ensuring we must use the contract for
+      -- executeBlockE because the proof cannot "look into" the implementation of executeBlockE, which makes the proof
+      -- more resilient in case of changes in its implementation.
+      -- TODO-2: clean this up by writing a general version of the contract for executeBlockE
+      proj₂ (proj₂ (proj₁ contract₂ (ErrECCBlockNotFound parentBlockId) executeBlockE≡Left) blocksToReexecute btr≡) _ _
+        with  executeBlockE bs0  block | inspect
+             (executeBlockE bs0) block
+      ... | Left  x | [ R ] rewrite executeBlockE≡ R = tt
+      ... | Right y | [ R ] rewrite executeBlockE≡ R =
+        λ where c refl ._ refl →
+                  let con = EB.contract (c , R) in
+                  contract₃ c
+                            (ebBlock≡ con)
+                            _ refl
+
+      contract₃ eb refl _ _ = contract₄
         where
+
         contract₄ : EitherD-weakestPre (step₄ eb) Contract
         contract₄
            with insertBlockESpec.contract eb (bs0 ^∙ bsInner)
@@ -132,27 +141,9 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
            with BlockTree.insertBlockE.E eb (bs0 ^∙ bsInner)
         ...| Left _ = tt
         ...| Right (bt' , eb') =
-           λ where ._ refl → mkContractOk (const ebBlock≈) btP bss≡x
+           λ where ._ refl → mkContractOk IBE.blocks≈ btP bss≡x
            where
            module IBE = insertBlockESpec.ContractOk con
-
-           eb≈ : block ≡ eb ^∙ ebBlock
-           eb≈ = cong (_^∙ ebBlock) eb≡
-
-           ebBlock≈ : eb' ^∙ ebBlock ≈Block block
-           ebBlock≈ = sym≈Block $ begin
-             block
-               ≡⟨ eb≈ ⟩
-             (eb  ^∙ ebBlock)
-               ≡⟨ cong (λ b → eb ^∙ ebBlock & bSignature ∙~ (b ^∙ bSignature)) (sym eb≈) ⟩
-             (eb  ^∙ ebBlock & bSignature ∙~ (block ^∙ bSignature))
-               ≡⟨ sym≈Block IBE.block≈ ⟩
-             (eb' ^∙ ebBlock & bSignature ∙~ (block ^∙ bSignature))
-               ∎
-             where open ≡-Reasoning
-
-           bts≡x : _
-           bts≡x = IBE.bt≡x
 
            open BlockStoreInv
 
@@ -160,27 +151,28 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (block : Block) where
            btP (mkBlockStoreInv bti) = mkBlockStoreInv (IBE.btiPres bti)
 
            bss≡x : bs0 ≡ (bs0 & bsInner ∙~ bt' & bsInner ∙ btIdToBlock ∙~ (bs0 ^∙ (bsInner ∙ btIdToBlock)))
-           bss≡x rewrite sym bts≡x = refl
+           bss≡x rewrite sym IBE.bt≡x = refl
 
   contract : Contract (executeAndInsertBlockE bs0 block)
   contract = EitherD-contract (executeAndInsertBlockE.step₀ bs0 block) Contract contract'
 
-module executeAndInsertBlockMSpec (b : Block) where
+module executeAndInsertBlockMSpec (vb : ValidBlock) where
+  b = vbBlock vb
+
   -- NOTE: This function returns any errors, rather than producing them as output.
   module _ (pre : RoundManager) where
-
-    bs = pre ^∙ rmBlockStore
+    bs = pre ^∙ lBlockStore
 
     contract
       : ∀ Post
         → (∀ e → {- At the moment we do not need to know why it failed -} Post (Left e) pre [])
-        → ((isOk : executeAndInsertBlockESpec.Ok bs b) → let (bs' , eb , _) = isOk in
-             executeAndInsertBlockESpec.ContractOk bs b bs' eb
+        → ((isOk : executeAndInsertBlockESpec.Ok bs vb) → let (bs' , eb , _) = isOk in
+             executeAndInsertBlockESpec.ContractOk bs vb bs' eb
            → Post (Right eb) (pre & rmBlockStore ∙~ bs') [])
         → LBFT-weakestPre (executeAndInsertBlockM b) Post pre
     proj₁ (contract Post pfBail pfOk ._ refl) e ≡left = pfBail e
     proj₂ (contract Post pfBail pfOk ._ refl) (bs' , eb) ≡right ._ refl unit refl
-       with executeAndInsertBlockESpec.contract bs b
+       with executeAndInsertBlockESpec.contract bs vb
     ...| con rewrite ≡right = pfOk (bs' , eb , refl) con
 
 module insertSingleQuorumCertMSpec

--- a/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
+++ b/LibraBFT/Impl/Consensus/BlockStorage/Properties/SyncManager.agda
@@ -123,6 +123,7 @@ module addCertsMSpec
       field
         -- General invariants / properties
         rmInv         : Preserves RoundManagerInv pre post
+        dnmBtIdToBlk  : post ≡L pre at (lBlockTree ∙ btIdToBlock)
         noEpochChange : NoEpochChange pre post
         noVoteOuts    : OutputProps.NoVotes outs
         -- Voting

--- a/LibraBFT/Impl/Consensus/Network/Properties.agda
+++ b/LibraBFT/Impl/Consensus/Network/Properties.agda
@@ -10,10 +10,13 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.NetworkMsg
 open import LibraBFT.ImplShared.Util.Util
 open import LibraBFT.Impl.Consensus.Network
+open import LibraBFT.Impl.Properties.Util
 open import LibraBFT.Prelude
 open import Optics.All
 
 module LibraBFT.Impl.Consensus.Network.Properties where
+
+open Invariants
 
 module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : ValidatorVerifier) where
   postulate -- TODO-2: Refine contract
@@ -23,5 +26,5 @@ module processProposalSpec (proposal : ProposalMsg) (myEpoch : Epoch) (vv : Vali
       : case (processProposal proposal myEpoch vv) of λ where
           (Left _) → Unit
           (Right _) → proposal ^∙ pmProposal ∙ bEpoch ≡ myEpoch
-                      × hashBD (proposal ^∙ pmProposal ∙ bBlockData) ≡ proposal ^∙ pmProposal ∙ bId
+                      × BlockId-correct (proposal ^∙ pmProposal)
 

--- a/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -40,7 +40,8 @@ open RoundManagerTransProps
 
 module LibraBFT.Impl.Consensus.RoundManager.Properties where
 
-module executeAndVoteMSpec (b : Block) where
+module executeAndVoteMSpec (vb : ValidBlock) where
+  b = vbBlock vb
 
   open executeAndVoteM b
   open SafetyRulesProps
@@ -57,6 +58,7 @@ module executeAndVoteMSpec (b : Block) where
   module _ (pre : RoundManager) where
 
     open QCProps
+    open Invariants.Reqs b (pre ^∙ lBlockTree)
 
     record Contract (r : Either ErrLog Vote) (post : RoundManager) (outs : List Output) : Set where
       constructor mkContract
@@ -67,15 +69,14 @@ module executeAndVoteMSpec (b : Block) where
         noMsgOuts     : OutputProps.NoMsgs outs
         -- Voting
         lvr≡?             : Bool
-        voteResultCorrect : hashBD (b ^∙ bBlockData) ≡ b ^∙ bId
-                            → VoteResultCorrect pre post lvr≡? r
+        voteResultCorrect : NoHC1 → VoteResultCorrect pre post lvr≡? r
         -- QCs
         qcPost : ∈Post⇒∈PreOr isbQc pre post
 
     contract' :
       LBFT-weakestPre (executeAndVoteM b) Contract pre
     contract' =
-      executeAndInsertBlockMSpec.contract b pre Post₀
+      executeAndInsertBlockMSpec.contract vb pre Post₀
         (λ where e ._ refl → contractBail [] refl)
         contract₁
       where
@@ -96,8 +97,8 @@ module executeAndVoteMSpec (b : Block) where
         qcPost : ∈Post⇒∈PreOr isbQc pre pre
         qcPost qc = Left
 
-      module EAIBM = executeAndInsertBlockMSpec b
-      module EAIBE = executeAndInsertBlockESpec (EAIBM.bs pre) b
+      module EAIBM = executeAndInsertBlockMSpec vb
+      module EAIBE = executeAndInsertBlockESpec (EAIBM.bs pre) vb
       module _ (isOk : EAIBE.Ok) (con : EAIBE.ContractOk (proj₁ isOk) (proj₁ (proj₂ isOk))) where
 
         module EAIBECon = EAIBE.ContractOk con
@@ -109,14 +110,14 @@ module executeAndVoteMSpec (b : Block) where
 
         -- State invariants
         module _  where
-          btP : Preserves BlockTreeInv (rm→BlockTree-EC pre) (rm→BlockTree-EC pre₁)
-          btP bti = BSInv⇒BTInv-pres EAIBECon.bsInv bti
+          bsP : Preserves BlockStoreInv (rm→BlockStore-EC pre) (rm→BlockStore-EC pre₁)
+          bsP bsi = EAIBECon.bsInv bsi
 
           srP : Preserves SafetyRulesInv (pre ^∙ lSafetyRules) (pre₁ ^∙ lSafetyRules)
           srP = mkPreservesSafetyRulesInv id
 
         invP₁ : Preserves RoundManagerInv pre pre₁
-        invP₁ = mkPreservesRoundManagerInv id id btP srP
+        invP₁ = mkPreservesRoundManagerInv id id bsP srP
 
         qcPost-BT : _
         qcPost-BT = ∈Post⇒∈PreOrBT-QCs≡ isbQc
@@ -169,6 +170,11 @@ module executeAndVoteMSpec (b : Block) where
                 qcPost₂
             contract₂⇒-help (Right vote) vrc ._ refl = contract₃
               where
+
+              open RoundManagerInv
+              open BlockStoreInv
+              open BlockTreeInv
+
               contract₃ : RWS-weakestPre (step₃ vote) (RWS-Post++ Contract CASVouts) unit pre₃
               contract₃ =
                 PersistentLivenessStorageProps.saveVoteMSpec.contract vote
@@ -178,12 +184,13 @@ module executeAndVoteMSpec (b : Block) where
                 Post₃ : LBFT-Post (Either ErrLog Unit)
                 Post₃ = RWS-weakestPre-ebindPost unit (const $ ok vote) (RWS-Post++ Contract CASVouts)
 
-                vgc₃ : hashBD (b ^∙ bBlockData) ≡ b ^∙ bId
-                       → Voting.VoteGeneratedCorrect pre pre₃ vote b {- proposedBlock -}
-                vgc₃ bid≡ =
+                vgc₃ : NoHC1 → Voting.VoteGeneratedCorrect pre pre₃ vote b {- proposedBlock -}
+                vgc₃ nohc =
                   Voting.glue-VoteNotGenerated-VoteGeneratedCorrect
                     (mkVoteNotGenerated refl refl)
-                    (Voting.substVoteGeneratedCorrect proposedBlock b (EAIBECon.ebBlock≈ bid≡) vrc)
+                    (Voting.substVoteGeneratedCorrect proposedBlock b
+                      (EAIBECon.ebBlock≈ nohc)
+                      vrc)
 
                 noMsgOutsBail₃ : ∀ outs → NoMsgs outs → NoMsgs (CASVouts ++ outs)
                 noMsgOutsBail₃ outs noMsgs = ++-NoMsgs CASVouts outs CASVCon.noMsgOuts noMsgs
@@ -194,7 +201,7 @@ module executeAndVoteMSpec (b : Block) where
                 contractBail₃ : ∀ outs → NoMsgs outs → NoErrors outs → Post₃ (Left fakeErr) pre₃ outs
                 contractBail₃ outs noMsgOuts noErrOuts =
                   mkContract invP₂ CASVCon.noEpochChange (noMsgOutsBail₃ outs noMsgOuts)
-                    CASVCon.lvr≡? (Right ∘ Voting.mkVoteGeneratedUnsavedCorrect vote ∘ vgc₃)
+                    CASVCon.lvr≡? ((Right ∘ Voting.mkVoteGeneratedUnsavedCorrect vote) ∘ vgc₃)
                     qcPost₂
 
                 contractOk₃ : ∀ outs → NoMsgs outs → NoErrors outs → Post₃ (Right unit) pre₃ outs
@@ -206,18 +213,21 @@ module executeAndVoteMSpec (b : Block) where
 
     contract
       : ∀ Post
-        → (∀ r st outs → Contract r st outs → Post r st outs)
+        → RWS-Post-⇒ Contract Post
         → LBFT-weakestPre (executeAndVoteM b) Post pre
     contract Post pf =
       RWS-⇒ Contract Post pf (executeAndVoteM b) unit pre contract'
 
-module processProposalMSpec (proposal : Block) where
+module processProposalMSpec (vproposal : ValidBlock) where
+  proposal = vbBlock vproposal
 
   open import LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockStore
   open import LibraBFT.Impl.Consensus.Liveness.Properties.ProposerElection
   open        LibraBFT.Impl.Consensus.RoundManager.processProposalM proposal
 
   module _ (pre : RoundManager) where
+
+    open Invariants.Reqs (vbBlock vproposal) (pre ^∙ lBlockTree)
 
     record Contract (u : Unit) (post : RoundManager) (outs : List Output) : Set where
       constructor mkContract
@@ -227,8 +237,7 @@ module processProposalMSpec (proposal : Block) where
         noEpochChange : NoEpochChange pre post
         noProposals   : OutputProps.NoProposals outs
         -- Voting
-        voteAttemptCorrect : hashBD (proposal ^∙ bBlockData) ≡ proposal ^∙ bId
-                             → Voting.VoteAttemptCorrect pre post outs proposal
+        voteAttemptCorrect : NoHC1 → Voting.VoteAttemptCorrect pre post outs proposal
         -- QCs
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
         qcPost    : QCProps.∈Post⇒∈PreOr (_≡ proposal ^∙ bQuorumCert) pre post
@@ -253,13 +262,13 @@ module processProposalMSpec (proposal : Block) where
       contractBail : ∀ {outs} → OutputProps.NoMsgs outs → Contract unit pre outs
       contractBail{outs} nmo =
         mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
-          noProposals (const vac) outQcs qcPost
+          noProposals vac outQcs qcPost
         where
           noProposals : NoProposals outs
           noProposals = OutputProps.NoMsgs⇒NoProposals outs nmo
 
-          vac : Voting.VoteAttemptCorrect pre pre outs proposal
-          vac = Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs nmo)
+          vac : NoHC1 → Voting.VoteAttemptCorrect pre pre outs proposal
+          vac _ = Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs nmo)
 
           outQcs : QCProps.OutputQc∈RoundManager outs pre
           outQcs = QCProps.NoMsgs⇒OutputQc∈RoundManager outs pre nmo
@@ -269,10 +278,10 @@ module processProposalMSpec (proposal : Block) where
 
       contract-step₂ : RWS-weakestPre (executeAndVoteM proposal >>= step₂) Contract unit pre
       contract-step₂ =
-        executeAndVoteMSpec.contract proposal pre
+        executeAndVoteMSpec.contract vproposal pre
           (RWS-weakestPre-bindPost unit step₂ Contract) pf-step₂
         where
-        module EAV = executeAndVoteMSpec proposal
+        module EAV = executeAndVoteMSpec vproposal
 
         pf-step₂ : RWS-Post-⇒ (EAV.Contract pre) (RWS-weakestPre-bindPost unit step₂ Contract)
         pf-step₂ r st outs con = pf r EAVSpec.voteResultCorrect
@@ -280,8 +289,7 @@ module processProposalMSpec (proposal : Block) where
           module EAVSpec = executeAndVoteMSpec.Contract con
           rmInv₂ = transPreservesRoundManagerInv reflPreservesRoundManagerInv EAVSpec.rmInv
 
-          pf : (r : Either ErrLog Vote) (vrc : hashBD (proposal ^∙ bBlockData) ≡ proposal ^∙ bId
-                                               → EAV.VoteResultCorrect pre st EAVSpec.lvr≡? r)
+          pf : (r : Either ErrLog Vote) (vrc : NoHC1 → EAV.VoteResultCorrect pre st EAVSpec.lvr≡? r)
                → RWS-weakestPre-bindPost unit step₂ Contract r st outs
           pf (Left _) vrc ._ refl =
             mkContract rmInv₂ EAVSpec.noEpochChange
@@ -295,11 +303,11 @@ module processProposalMSpec (proposal : Block) where
             noProposals : NoProposals (outs ++ LogErr _ ∷ [])
             noProposals = NoMsgs⇒NoProposals (outs ++ LogErr _ ∷ []) noMsgs
 
-            vac : hashBD (proposal ^∙ bBlockData) ≡ proposal ^∙ bId → Voting.VoteAttemptCorrect pre st (outs ++ LogErr _ ∷ []) proposal
-            vac bid≡ =
+            vac : NoHC1 → Voting.VoteAttemptCorrect pre st (outs ++ LogErr _ ∷ []) proposal
+            vac nohc =
               inj₁ (EAVSpec.lvr≡?
                    , Voting.mkVoteUnsentCorrect
-                       (NoMsgs⇒NoVotes (outs ++ LogErr _ ∷ []) noMsgs) (vrc bid≡))
+                       (NoMsgs⇒NoVotes (outs ++ LogErr _ ∷ []) noMsgs) (vrc nohc))
 
             qcOuts : QCProps.OutputQc∈RoundManager (outs ++ LogErr _ ∷ []) st
             qcOuts = QCProps.NoMsgs⇒OutputQc∈RoundManager (outs ++ LogErr _ ∷ []) st noMsgs
@@ -328,13 +336,12 @@ module processProposalMSpec (proposal : Block) where
                 where
                 vm = VoteMsg∙new vote si
 
-                vac : hashBD (proposal ^∙ bBlockData) ≡ proposal ^∙ bId
-                      → Voting.VoteAttemptCorrect pre stUpdateRS (outs ++ SendVote vm _ ∷ []) proposal
-                vac bid≡ =
+                vac : NoHC1 → Voting.VoteAttemptCorrect pre stUpdateRS (outs ++ SendVote vm _ ∷ []) proposal
+                vac nohc =
                   inj₂ (Voting.mkVoteSentCorrect vm recipient
                          (OutputProps.++-NoVotes-OneVote outs _ (OutputProps.NoMsgs⇒NoVotes outs EAVSpec.noMsgOuts) refl)
                          (Voting.glue-VoteGeneratedCorrect-VoteNotGenerated{s₂ = st}
-                           (vrc bid≡) (mkVoteNotGenerated refl refl)))
+                           (vrc nohc) (mkVoteNotGenerated refl refl)))
 
                 outQcs : QCProps.OutputQc∈RoundManager (outs ++ SendVote vm _ ∷ []) stUpdateRS
                 outQcs =
@@ -387,7 +394,7 @@ module processProposalMSpec (proposal : Block) where
 
                   rmInv₃ : Preserves RoundManagerInv pre stUpdateRS
                   rmInv₃ = transPreservesRoundManagerInv rmInv₂
-                           (mkPreservesRoundManagerInv id id (BSInv⇒BTInv-pres bsP) srP)
+                           (mkPreservesRoundManagerInv id id bsP srP)
 
     contract : ∀ Post → RWS-Post-⇒ Contract Post → LBFT-weakestPre (processProposalM proposal) Post pre
     contract Post pf = LBFT-⇒ Contract Post pf (processProposalM proposal) pre contract'
@@ -406,6 +413,7 @@ module syncUpMSpec
       field
         -- General invariants / properties
         rmInv         : Preserves RoundManagerInv pre post
+        dnmBtIdToBlk  : post ≡L pre at (lBlockTree ∙ btIdToBlock)
         noEpochChange : NoEpochChange pre post
         noVoteOuts    : OutputProps.NoVotes outs
         -- Voting
@@ -424,7 +432,7 @@ module syncUpMSpec
 
       contract₁ : RWS-weakestPre-bindPost unit step₁ Contract (BlockStoreProps.syncInfoMSpec.syncInfo pre) pre []
       proj₂ (contract₁ localSyncInfo lsi≡) hnc≡false =
-        mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre}) refl
+        mkContract reflPreservesRoundManagerInv refl (reflNoEpochChange{pre}) refl
           (reflVoteNotGenerated{pre})
           [] qcPost
         where
@@ -447,7 +455,7 @@ module syncUpMSpec
            where module VSpec = verifyMSpec.Contract con
         contract₃ (Left x) st outs con ._ refl
            | refl
-           = mkContract VSpec.rmInv (reflNoEpochChange{st})
+           = mkContract VSpec.rmInv (cong (_^∙ lBlockTree ∙ btIdToBlock) VSpec.noStateChange) (reflNoEpochChange{st})
                (++-NoVotes outs [] (NoMsgs⇒NoVotes outs VSpec.noMsgOuts) refl)
                (reflVoteNotGenerated{st})
                noOutQcs qcPost
@@ -473,7 +481,7 @@ module syncUpMSpec
 
            contract₄ : RWS-Post-⇒ (addCertsMSpec.Contract syncInfo retriever st₃) Post₃
            contract₄ (Left  _) st₄ outs₄ con₄ ._ refl =
-             mkContract AC.rmInv AC.noEpochChange noVotes₄ AC.noVote noOutQcs AC.qcPost
+             mkContract AC.rmInv AC.dnmBtIdToBlk AC.noEpochChange noVotes₄ AC.noVote noOutQcs AC.qcPost
              where
              module AC    = addCertsMSpec.Contract con₄
              module VSpec = verifyMSpec.Contract con₃
@@ -516,6 +524,7 @@ module ensureRoundAndSyncUpMSpec
       field
         -- General invariants / properties
         rmInv         : Preserves RoundManagerInv pre post
+        dnmBtIdToBlk  : post ≡L pre at (lBlockTree ∙ btIdToBlock)
         noEpochChange : NoEpochChange pre post
         noVoteOuts    : OutputProps.NoVotes outs
         -- Voting
@@ -527,7 +536,7 @@ module ensureRoundAndSyncUpMSpec
     contract'
       : LBFT-weakestPre (ensureRoundAndSyncUpM now messageRound syncInfo author helpRemote) Contract pre
     proj₁ (contract' ._ refl) _         =
-      mkContract id refl refl vng outqcs qcPost
+      mkContract id refl refl refl vng outqcs qcPost
       where
         vng : VoteNotGenerated pre pre true
         vng = mkVoteNotGenerated refl refl
@@ -547,7 +556,7 @@ module ensureRoundAndSyncUpMSpec
 
         contract-step₁' : _
         contract-step₁' (Left  _   ) st outs con =
-          mkContract SU.rmInv SU.noEpochChange SU.noVoteOuts SU.noVote SU.noOutQcs SU.qcPost
+          mkContract SU.rmInv SU.dnmBtIdToBlk SU.noEpochChange SU.noVoteOuts SU.noVote SU.noOutQcs SU.qcPost
           where
           module SU = syncUpMSpec.Contract con
         contract-step₁' (Right unit) st outs con = contract-step₂
@@ -563,10 +572,10 @@ module ensureRoundAndSyncUpMSpec
 
           contract-step₂ : Post (Right unit) st outs
           proj₁ (contract-step₂ ._ refl ._ refl) _ =
-            mkContract SU.rmInv SU.noEpochChange noVoteOuts' SU.noVote
+            mkContract SU.rmInv SU.dnmBtIdToBlk SU.noEpochChange noVoteOuts' SU.noVote
               noOutQcs SU.qcPost
           proj₂ (contract-step₂ ._ refl ._ refl) _ =
-            mkContract SU.rmInv SU.noEpochChange noVoteOuts' SU.noVote
+            mkContract SU.rmInv SU.dnmBtIdToBlk SU.noEpochChange noVoteOuts' SU.noVote
               noOutQcs SU.qcPost
 
     contract : ∀ Post → RWS-Post-⇒ Contract Post → LBFT-weakestPre (ensureRoundAndSyncUpM now messageRound syncInfo author helpRemote) Post pre
@@ -574,13 +583,14 @@ module ensureRoundAndSyncUpMSpec
       LBFT-⇒ Contract Post pf (ensureRoundAndSyncUpM now messageRound syncInfo author helpRemote) pre contract'
 
 module processProposalMsgMSpec
-  (now : Instant) (pm : ProposalMsg) where
+  (now : Instant) (pm : ProposalMsg) (vproposal : BlockId-correct (pm ^∙ pmProposal)) where
 
   proposal = pm ^∙ pmProposal
-
   open processProposalMsgM now pm
 
   module _ (pre : RoundManager) where
+
+    open Invariants.Reqs proposal (pre ^∙ lBlockTree)
 
     record Contract (_ : Unit) (post : RoundManager) (outs : List Output) : Set where
       constructor mkContract
@@ -589,8 +599,7 @@ module processProposalMsgMSpec
         rmInv         : Preserves RoundManagerInv pre post
         noEpochChange : NoEpochChange pre post
         -- Voting
-        voteAttemptCorrect : hashBD (proposal ^∙ bBlockData) ≡ proposal ^∙ bId
-                             → Voting.VoteAttemptCorrect pre post outs proposal
+        voteAttemptCorrect : NoHC1 → Voting.VoteAttemptCorrect pre post outs proposal
         -- QCs
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
         qcPost    : QCProps.∈Post⇒∈PreOr (_QC∈NM (P pm)) pre post
@@ -600,10 +609,10 @@ module processProposalMsgMSpec
       where
       contractBail : ∀ outs → OutputProps.NoMsgs outs → Contract unit pre outs
       contractBail outs nmo =
-        mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre}) (const vac) outqcs qcPost
+        mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre}) vac outqcs qcPost
         where
-        vac : Voting.VoteAttemptCorrect pre pre outs proposal
-        vac = Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs nmo)
+        vac : NoHC1 → Voting.VoteAttemptCorrect pre pre outs proposal
+        vac _ = Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs nmo)
 
         outqcs : QCProps.OutputQc∈RoundManager outs pre
         outqcs = QCProps.NoMsgs⇒OutputQc∈RoundManager outs pre nmo
@@ -615,25 +624,27 @@ module processProposalMsgMSpec
       proj₁ contract ≡nothing = contractBail _ refl
       proj₂ contract = contract-step₁
         where
+        -- These arguments come from the second proof obligation of RWS-weakestPre for RWS-maybe
         module _ (pAuthor : Author) (pAuthor≡ : pm ^∙ pmProposer ≡ just pAuthor) where
           pf-step₂ : RWS-Post-⇒ _ (RWS-weakestPre-bindPost unit step₂ Contract)
 
           contract-step₁ : LBFT-weakestPre (step₁ pAuthor) Contract pre
           contract-step₁ =
             ensureRoundAndSyncUpMSpec.contract now (pm ^∙ pmProposal ∙ bRound) (pm ^∙ pmSyncInfo) pAuthor true pre
-              (RWS-weakestPre-bindPost unit step₂ Contract) pf-step₂
+            (RWS-weakestPre-bindPost unit step₂ Contract)
+            pf-step₂
 
           pf-step₂ r st outs con = pf-step₂' r
             where
             module ERASU = ensureRoundAndSyncUpMSpec.Contract con
             contractBailAfterSync : ∀ outs' → OutputProps.NoMsgs outs' → RWS-Post++ Contract outs unit st outs'
             contractBailAfterSync outs' noMsgs' =
-              mkContract ERASU.rmInv ERASU.noEpochChange (const vac) outqcs qcPost
+              mkContract ERASU.rmInv ERASU.noEpochChange vac outqcs qcPost
               where
-              vac : Voting.VoteAttemptCorrect pre st (outs ++ outs') proposal
-              vac = Left (true , (Voting.mkVoteUnsentCorrect
-                                   (OutputProps.++-NoVotes outs _ ERASU.noVoteOuts (OutputProps.NoMsgs⇒NoVotes outs' noMsgs'))
-                                   (Left ERASU.noVote)))
+              vac : NoHC1 → Voting.VoteAttemptCorrect pre st (outs ++ outs') proposal
+              vac _ = Left (true , (Voting.mkVoteUnsentCorrect
+                                     (OutputProps.++-NoVotes outs _ ERASU.noVoteOuts (OutputProps.NoMsgs⇒NoVotes outs' noMsgs'))
+                                     (Left ERASU.noVote)))
 
               outqcs : QCProps.OutputQc∈RoundManager (outs ++ outs') st
               outqcs =
@@ -653,9 +664,15 @@ module processProposalMsgMSpec
             pf-step₂' (Right false) ._ refl ._ refl =
               contractBailAfterSync _ refl
             pf-step₂' (Right true) ._ refl =
-              processProposalMSpec.contract (pm ^∙ pmProposal) st (RWS-Post++ Contract outs) pf-step₃
+              processProposalMSpec.contract (proposal , vproposal)
+                                            st
+                                            (RWS-Post++ Contract outs)
+                                            pf-step₃
               where
-              pf-step₃ : RWS-Post-⇒ _ (RWS-Post++ Contract outs)
+
+              pf-step₃ : RWS-Post-⇒
+                           (processProposalMSpec.Contract (proposal , vproposal) _)
+                           (RWS-Post++ Contract outs)
               pf-step₃ unit st' outs' con =
                 mkContract
                   (transPreservesRoundManagerInv ERASU.rmInv (PP.rmInv con))
@@ -663,11 +680,10 @@ module processProposalMsgMSpec
                   vac outqcs qcPost
                 where
                 module PP = processProposalMSpec.Contract
-                vac : hashBD (proposal ^∙ bBlockData) ≡ proposal ^∙ bId
-                      → Voting.VoteAttemptCorrect pre st' (outs ++ outs') proposal
-                vac bid≡ =
+                vac : NoHC1 → Voting.VoteAttemptCorrect pre st' (outs ++ outs') proposal
+                vac nohc rewrite sym ERASU.dnmBtIdToBlk =
                   Voting.glue-VoteNotGenerated-VoteAttemptCorrect{outs₁ = outs}
-                    ERASU.noVote ERASU.noVoteOuts (PP.voteAttemptCorrect con bid≡)
+                    ERASU.noVote ERASU.noVoteOuts (PP.voteAttemptCorrect con nohc)
 
                 outqcs : QCProps.OutputQc∈RoundManager (outs ++ outs') st'
                 outqcs =

--- a/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
+++ b/LibraBFT/Impl/Consensus/SafetyRules/Properties/SafetyRules.agda
@@ -282,8 +282,8 @@ module constructAndSignVoteMSpec where
 
         -- State invariants
         module _ where
-          btip₁ : Preserves BlockTreeInv (rm→BlockTree-EC pre) (rm→BlockTree-EC preUpdatedSD)
-          btip₁ = id
+          bsip₁ : Preserves BlockStoreInv (rm→BlockStore-EC pre) (rm→BlockStore-EC preUpdatedSD)
+          bsip₁ = id
 
           emP : Preserves EpochsMatch pre preUpdatedSD
           emP eq = trans eq (Requirements.es≡₁ reqs)
@@ -313,7 +313,7 @@ module constructAndSignVoteMSpec where
               ≤-trans round≤ (≤-trans (≡⇒≤ (Requirements.lvr≡ reqs)) (<⇒≤ r>lvr))
 
           invP₁ : Preserves RoundManagerInv pre preUpdatedSD
-          invP₁ = mkPreservesRoundManagerInv id emP btip₁ srP
+          invP₁ = mkPreservesRoundManagerInv id emP bsip₁ srP
 
         -- Some lemmas
         module _ where
@@ -366,15 +366,15 @@ module constructAndSignVoteMSpec where
 
             -- State invariants
             module _ where
-              btiP₂ : Preserves BlockTreeInv (rm→BlockTree-EC pre) (rm→BlockTree-EC preUpdatedSD₂)
-              btiP₂ = id
+              bsiP₂ : Preserves BlockStoreInv (rm→BlockStore-EC pre) (rm→BlockStore-EC preUpdatedSD₂)
+              bsiP₂ = id
 
               srP₂ : Preserves SafetyRulesInv (pre ^∙ lSafetyRules) (preUpdatedSD₂ ^∙ lSafetyRules)
               srP₂ = mkPreservesSafetyRulesInv
                        (const $ mkSafetyDataInv (Requirements.es≡₂ reqs) (≡⇒≤ (cong (_^∙ bRound) pb≡vpb)))
 
               invP₂ : Preserves RoundManagerInv pre preUpdatedSD₂
-              invP₂ = mkPreservesRoundManagerInv id emP btiP₂ srP₂
+              invP₂ = mkPreservesRoundManagerInv id emP bsiP₂ srP₂
 
     contract
       : ∀ pre Post

--- a/LibraBFT/Impl/Handle/Properties.agda
+++ b/LibraBFT/Impl/Handle/Properties.agda
@@ -44,12 +44,12 @@ module LibraBFT.Impl.Handle.Properties where
 
 postulate -- TODO-2: prove (waiting on: `initRM`)
   initRM-correct  : ValidatorVerifier-correct (Handle.fakeInitRM  ^∙ rmValidatorVerifer)
-  initRM-btInv    : BlockTreeInv (rm→BlockTree-EC Handle.fakeInitRM)
+  initRM-bsInv    : BlockStoreInv (rm→BlockStore-EC Handle.fakeInitRM)
   initRM-qcs      : QCProps.SigsForVotes∈Rm-SentB4 [] Handle.fakeInitRM
 
 initRMSatisfiesInv : RoundManagerInv Handle.fakeInitRM
 initRMSatisfiesInv =
-  mkRoundManagerInv initRM-correct refl initRM-btInv
+  mkRoundManagerInv initRM-correct refl initRM-bsInv
     (mkSafetyRulesInv (mkSafetyDataInv refl z≤n))
 
 invariantsCorrect -- TODO-1: Decide whether this and direct corollaries should live in an `Properties.Invariants` module

--- a/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
+++ b/LibraBFT/Impl/IO/OBM/Properties/InputOutputHandlers.agda
@@ -44,14 +44,18 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
 
   module _ (pool : SentMessages) (pre : RoundManager) where
 
+    open Invariants.Reqs (pm ^∙ pmProposal) (pre ^∙ lBlockTree)
+
     record Contract (_ : Unit) (post : RoundManager) (outs : List Output) : Set where
       constructor mkContract
       field
         -- General properties / invariants
         rmInv              : Preserves RoundManagerInv pre post
+        invalidProposal    : ¬ (BlockId-correct (pm ^∙ pmProposal)) → pre ≡ post × OutputProps.NoVotes outs
         noEpochChange      : NoEpochChange pre post
         -- Voting
-        voteAttemptCorrect : Voting.VoteAttemptCorrectWithEpochReq pre post outs (pm ^∙ pmProposal)
+        voteAttemptCorrect : BlockId-correct (pm ^∙ pmProposal)
+                           → NoHC1 → Voting.VoteAttemptCorrectWithEpochReq pre post outs (pm ^∙ pmProposal)
         -- QCs
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs post
         qcPost    : QCProps.∈Post⇒∈PreOr (_QC∈NM (P pm)) pre post
@@ -68,12 +72,12 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
 
       contractBail : ∀ outs → OutputProps.NoMsgs outs → Contract unit pre outs
       contractBail outs noMsgs =
-        mkContract reflPreservesRoundManagerInv (reflNoEpochChange{pre})
+        mkContract reflPreservesRoundManagerInv (const $ refl , OutputProps.NoMsgs⇒NoVotes outs noMsgs) (reflNoEpochChange{pre})
           vac outQcs∈RM qcPost
         where
-        vac : Voting.VoteAttemptCorrectWithEpochReq pre pre outs (pm ^∙ pmProposal)
-        vac = Voting.mkVoteAttemptCorrectWithEpochReq
-                (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs noMsgs)) tt
+        vac : BlockId-correct (pm ^∙ pmProposal) → NoHC1 → Voting.VoteAttemptCorrectWithEpochReq pre pre outs (pm ^∙ pmProposal)
+        vac _ _ = Voting.mkVoteAttemptCorrectWithEpochReq
+                    (Voting.voteAttemptBailed outs (OutputProps.NoMsgs⇒NoVotes outs noMsgs)) tt
 
         outQcs∈RM : QCProps.OutputQc∈RoundManager outs pre
         outQcs∈RM = QCProps.NoMsgs⇒OutputQc∈RoundManager outs pre noMsgs
@@ -87,30 +91,32 @@ module handleProposalSpec (now : Instant) (pm : ProposalMsg) where
       proj₁ (contract-step₁ (myEpoch@._ , vv@._) refl) (inj₂ i) pp≡Left =
         contractBail _ refl
       proj₂ (contract-step₁ (myEpoch@._ , vv@._) refl) unit pp≡Right =
-        processProposalMsgMSpec.contract now pm pre Contract pf
+        processProposalMsgMSpec.contract now pm proposalId≡ pre Contract pf
         where
-        module PPM = processProposalMsgMSpec now pm
 
         sdEpoch≡ : pre ^∙ pssSafetyData-rm ∙ sdEpoch ≡ pm ^∙ pmProposal ∙ bEpoch
         sdEpoch≡
           with processProposalSpec.contract pm myEpoch vv
         ...| con rewrite pp≡Right = sym (proj₁ con)
 
-        proposalId≡ : hashBD (pm ^∙ pmProposal ∙ bBlockData) ≡ pm ^∙ pmProposal ∙ bId
+        proposalId≡ : BlockId-correct (pm ^∙ pmProposal)
         proposalId≡
            with processProposalSpec.contract pm myEpoch vv
         ...| con rewrite pp≡Right = proj₂ con
 
+        module PPM = processProposalMsgMSpec now pm proposalId≡
+
         pf : RWS-Post-⇒ (PPM.Contract pre) Contract
         pf unit st outs con =
-          mkContract PPMSpec.rmInv PPMSpec.noEpochChange
+          mkContract PPMSpec.rmInv (λ x → ⊥-elim (x proposalId≡)) PPMSpec.noEpochChange
             vac PPMSpec.outQcs∈RM PPMSpec.qcPost
           where
           module PPMSpec = processProposalMsgMSpec.Contract con
 
-          vac : Voting.VoteAttemptCorrectWithEpochReq pre st outs (pm ^∙ pmProposal)
-          vac = Voting.mkVoteAttemptCorrectWithEpochReq (PPMSpec.voteAttemptCorrect proposalId≡)
-                  (Voting.voteAttemptEpochReq! (PPMSpec.voteAttemptCorrect proposalId≡) sdEpoch≡)
+          vac : BlockId-correct (pm ^∙ pmProposal) → NoHC1
+              → Voting.VoteAttemptCorrectWithEpochReq pre st outs (pm ^∙ pmProposal)
+          vac _ nohc = Voting.mkVoteAttemptCorrectWithEpochReq (PPMSpec.voteAttemptCorrect nohc)
+                         (Voting.voteAttemptEpochReq! (PPMSpec.voteAttemptCorrect nohc) sdEpoch≡)
 
     contract! : LBFT-Post-True Contract (handleProposal now pm) pre
     contract! = LBFT-contract (handleProposal now pm) Contract pre contract

--- a/LibraBFT/Impl/Properties/VotesOnce.agda
+++ b/LibraBFT/Impl/Properties/VotesOnce.agda
@@ -57,9 +57,22 @@ newVote⇒lv≡{pre}{pid}{s'}{v = v}{m}{pk} preach sps@(step-msg{sndr , nm} m∈
    with cong _vSignature v≈rbld
 ...| refl = ⊥-elim ∘′ ¬msb4 $ qcVoteSigsSentB4-handle pid preach sps m∈acts qc∈m sig vs∈qc v≈rbld ¬bootstrap
 
-newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vote∈vm m∈outs sig hpk ¬bootstrap ¬msb4
+newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vote∈vm m∈acts sig hpk ¬bootstrap ¬msb4
   with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid)
-...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , voteUnsent)) sdEpoch≡?) _ _ =
+...| handleProposalSpec.mkContract _ invalidProposal _ vac _ _
+   -- TODO-2: DRY fail.  This pattern arises several times in this file, where we need to know that
+   -- the proposal being processed is valid, and to use handleProposalSpec to derive a contradiction
+   -- if is not.  Some are identical, some are not.
+   with BlockId-correct? (pm ^∙ pmProposal)
+...| no  ¬validProposal = ⊥-elim (sendVote∉actions {outs = handleOuts} {st = handlePre}
+                                    (sym (proj₂ $ invalidProposal ¬validProposal)) m∈acts)
+  where
+  handlePre  = peerStates pre pid
+  handleOuts = LBFT-outs (handle pid (P pm) 0) (peerStates pre pid)
+
+...| yes refl
+   with vac refl (nohc preach m∈pool pid ini (invariantsCorrect pid pre preach) refl refl)
+...| Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , voteUnsent)) sdEpoch≡? =
   ⊥-elim (¬voteUnsent voteUnsent)
   where
   handleOuts = LBFT-outs (handle pid (P pm) 0) (peerStates pre pid)
@@ -67,8 +80,8 @@ newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vot
   ¬voteUnsent : ¬ Voting.VoteUnsentCorrect (peerStates pre pid) _ _ _ _
   ¬voteUnsent (Voting.mkVoteUnsentCorrect noVoteMsgOuts _) =
     sendVote∉actions{outs = handleOuts}{st = peerStates pre pid}
-      (sym noVoteMsgOuts) m∈outs
-...| handleProposalSpec.mkContract _ _ (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect (VoteMsg∙new v' _) rcvr voteMsgOuts vgCorrect)) sdEpoch≡?) _ _ =
+      (sym noVoteMsgOuts) m∈acts
+...| Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect (VoteMsg∙new v' _) rcvr voteMsgOuts vgCorrect)) sdEpoch≡? =
   sentVoteIsPostLV
   where
   handlePost = LBFT-post (handle pid (P pm) 0) (peerStates pre pid)
@@ -79,7 +92,7 @@ newVote⇒lv≡{pre}{pid}{v = v} preach (step-msg{sndr , P pm} m∈pool ini) vot
     with Voting.VoteGeneratedCorrect.state vgCorrect
   ...| RoundManagerTransProps.mkVoteGenerated lv≡v _
     rewrite sym lv≡v
-    = cong (just ∘ _^∙ vmVote) (sendVote∈actions{outs = handleOuts}{st = peerStates pre pid} (sym voteMsgOuts) m∈outs)
+    = cong (just ∘ _^∙ vmVote) (sendVote∈actions{outs = handleOuts}{st = peerStates pre pid} (sym voteMsgOuts) m∈acts)
 
 newVote⇒lv≡{pre}{pid}{s' = s'}{v = v} preach (step-msg{sndr , V vm} m∈pool ini) vote∈vm m∈outs sig hpk ¬bootstrap ¬msb4 =
   ⊥-elim (sendVote∉actions{outs = hvOut}{st = hvPre} (sym noVotes) m∈outs)
@@ -349,7 +362,10 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-ho
 
       analyzeVoteAttempt : just v ≡ peerStates pre pid ^∙ pssSafetyData-rm ∙ sdLastVote
       analyzeVoteAttempt
-         with voteAttemptCorrect
+         with BlockId-correct? (pm ^∙ pmProposal)
+      ...| no ¬validProposal rewrite sym (proj₁ (invalidProposal ¬validProposal)) = ≡pidLV
+      ...| yes refl
+         with voteAttemptCorrect refl (nohc rss m∈pool pid ini (invariantsCorrect pid pre rss) refl refl)
       ...| Voting.mkVoteAttemptCorrectWithEpochReq (Left (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?
          with nvg⊎vgusc
       ...| Left (mkVoteNotGenerated lv≡ lvr≤) = OldVote.≡pidLVPre₁ lv≡
@@ -358,7 +374,7 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-ho
       ...| Left (mkVoteOldGenerated lvr≡ lv≡) = OldVote.≡pidLVPre₁ lv≡
       ...| Right (mkVoteNewGenerated lvr< lvr≡) =
          ⊥-elim (<⇒≢ (NewVote.rv'<rv vote lv≡v lvr< lvr≡ sdEpoch≡? blockTriggered) (sym ≡round))
-      analyzeVoteAttempt | Voting.mkVoteAttemptCorrectWithEpochReq (Right (Voting.mkVoteSentCorrect vm pid voteMsgOuts vgCorrect)) sdEpoch≡?
+      analyzeVoteAttempt | yes refl | Voting.mkVoteAttemptCorrectWithEpochReq (Right (Voting.mkVoteSentCorrect vm pid voteMsgOuts vgCorrect)) sdEpoch≡?
          with vgCorrect
       ...| Voting.mkVoteGeneratedCorrect (mkVoteGenerated lv≡v voteSrc) blockTriggered
          with voteSrc
@@ -379,7 +395,7 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-ho
    = ⊥-elim ∘′ ¬msb4 $ qcVoteSigsSentB4-handle pid rss sps m'∈acts qc∈m' sig' vs∈qc v≈ ¬bootstrap
 ...| vote∈vm
    rewrite sym $ StepPeer-post-lemma{pre = pre} sp
-   = sameId m m'∈acts ≡pidLV
+   = sameId m m∈pool m'∈acts ≡pidLV
    where
 
    handlePre = peerStates pre pid
@@ -390,14 +406,20 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-ho
    handlePst : NetworkMsg → RoundManager
    handlePst m = LBFT-post (handle sndr m 0) handlePre
 
-   sameId : ∀ m → send (V (VoteMsg∙new v' _)) ∈ outputsToActions{State = handlePre} (handleOuts m) → just v ≡ handlePst m ^∙ pssSafetyData-rm ∙ sdLastVote → v ≡L v' at vProposedId
-   sameId (P pm) m'∈acts ≡pidLV = analyzeVoteAttempt
+   sameId : ∀ {sndr} m → (sndr , m) ∈ msgPool pre
+          → send (V (VoteMsg∙new v' _)) ∈ outputsToActions{State = handlePre} (handleOuts m)
+          → just v ≡ handlePst m ^∙ pssSafetyData-rm ∙ sdLastVote → v ≡L v' at vProposedId
+   sameId (P pm) m∈pool m'∈acts ≡pidLV = analyzeVoteAttempt
      where
      open handleProposalSpec.Contract (handleProposalSpec.contract! 0 pm (msgPool pre) handlePre)
 
      analyzeVoteAttempt : v ≡L v' at vProposedId
      analyzeVoteAttempt
-        with voteAttemptCorrect
+        with BlockId-correct? (pm ^∙ pmProposal)
+     ...| no ¬validProposal = ⊥-elim (sendVote∉actions {outs = handleOuts (P pm)} {st = handlePre}
+                                      (sym (proj₂ $ invalidProposal ¬validProposal)) m'∈acts)
+     ...| yes refl
+        with voteAttemptCorrect refl (nohc rss m∈pool pid ini (invariantsCorrect pid pre rss) refl refl)
      ...| Voting.mkVoteAttemptCorrectWithEpochReq (Left (_ , vuc)) sdEpoch≡? =
         ⊥-elim (sendVote∉actions {outs = handleOuts (P pm)} {st = handlePre} (sym $ Voting.VoteUnsentCorrect.noVoteMsgOuts vuc) m'∈acts)
      ...| Voting.mkVoteAttemptCorrectWithEpochReq (Right (Voting.mkVoteSentCorrect vm pid voteMsgOuts vgCorrect)) sdEpoch≡?
@@ -416,26 +438,33 @@ sameERasLV⇒sameId{pid}{pid'}{pk} (step-s rss (step-peer{pre = pre} sp@(step-ho
             ≡⟨ cong (just ∘ _^∙ vmVote) (sym $ sendVote∈actions{outs = handleOuts (P pm)}{st = handlePre} (sym voteMsgOuts) m'∈acts) ⟩
           just v' ∎
 
-
-   sameId (V vm) m'∈acts ≡pidLV =
+   sameId (V vm) _ m'∈acts ≡pidLV =
      ⊥-elim (sendVote∉actions {outs = hvOuts} {st = peerStates pre pid} (sym noVotes) m'∈acts)
      where
      hvOuts = LBFT-outs (handleVote 0 vm) (peerStates pre pid)
 
      open handleVoteSpec.Contract (handleVoteSpec.contract! 0 vm (msgPool pre) handlePre)
-   sameId (C x) ()
+   sameId (C x) _ ()
 
 votesOnce₁ : Common.IncreasingRoundObligation Handle.fakeInitAndHandlers 𝓔
 votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {m} {v'} {m'} hpk (vote∈qc {vs} {qc} vs∈qc v≈rbld qc∈m) m∈acts sig ¬bootstrap ¬msb pcspkv v'⊂m' m'∈pool sig' ¬bootstrap' eid≡
    with cong _vSignature v≈rbld
 ...| refl = ⊥-elim ∘′ ¬msb $ qcVoteSigsSentB4-handle pid preach sps m∈acts qc∈m sig vs∈qc v≈rbld ¬bootstrap
 
-votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈outs sig ¬bootstrap ¬msb pcspkv v'⊂m' m'∈pool sig' ¬bootstrap' eid≡
+votesOnce₁ {pid = pid} {pid'} {pk = pk} {pre = pre} preach sps@(step-msg {sndr , P pm} m∈pool ini) {v} {.(V (VoteMsg∙new v _))} {v'} {m'} hpk vote∈vm m∈acts sig ¬bootstrap ¬msb pcspkv v'⊂m' m'∈pool sig' ¬bootstrap' eid≡
   with handleProposalSpec.contract! 0 pm (msgPool pre) (peerStates pre pid)
-...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡?) _ _ =
-  ⊥-elim (sendVote∉actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym noVoteMsgOuts) m∈outs)
-...| handleProposalSpec.mkContract _ noEpochChange (Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?) _ _
-  with sendVote∈actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym voteMsgOuts) m∈outs
+...| handleProposalSpec.mkContract _ invProp noEpochChange vac _ _
+   with BlockId-correct? (pm ^∙ pmProposal)
+...| no ¬validProposal = ⊥-elim (sendVote∉actions {outs = hpOut} {st = hpPre} (sym (proj₂ $ invProp ¬validProposal)) m∈acts )
+   where
+   hpPre  = peerStates pre pid
+   hpOut  = LBFT-outs (handleProposal 0 pm) hpPre
+...| yes refl
+   with vac refl (nohc preach m∈pool pid ini (invariantsCorrect pid pre preach) refl refl)
+...| Voting.mkVoteAttemptCorrectWithEpochReq (inj₁ (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts nvg⊎vgusc)) sdEpoch≡? =
+     ⊥-elim (sendVote∉actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym noVoteMsgOuts) m∈acts)
+...| Voting.mkVoteAttemptCorrectWithEpochReq (inj₂ (Voting.mkVoteSentCorrect vm pid₁ voteMsgOuts vgCorrect)) sdEpoch≡?
+  with sendVote∈actions{outs = LBFT-outs (handleProposal 0 pm) (peerStates pre pid)}{st = peerStates pre pid} (sym voteMsgOuts) m∈acts
 ...| refl = ret
   where
   -- Some definitions
@@ -538,7 +567,10 @@ votesOnce₂{pid}{pk = pk}{pre} rss (step-msg{sndr , m“} m“∈pool ini){v}{v
 
   v≡v' : v ≡ v'
   v≡v'
-    with voteAttemptCorrect
+    with BlockId-correct? (pm ^∙ pmProposal)
+  ...| no ¬validProposal = ⊥-elim (sendVote∉actions {outs = hpOut} {st = hpPre} (sym (proj₂ $ invalidProposal ¬validProposal)) m∈acts)
+  ...| yes refl
+    with voteAttemptCorrect refl (nohc rss m“∈pool pid ini (invariantsCorrect pid pre rss) refl refl   )
   ...| Voting.mkVoteAttemptCorrectWithEpochReq (Left (_ , Voting.mkVoteUnsentCorrect noVoteMsgOuts _)) _ =
     ⊥-elim (sendVote∉actions{outs = hpOut}{st = hpPre} (sym noVoteMsgOuts) m∈acts)
   ...| Voting.mkVoteAttemptCorrectWithEpochReq (Right (Voting.mkVoteSentCorrect vm pid voteMsgOuts _)) _ = begin

--- a/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -653,9 +653,14 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   bPayload : Lens Block (Maybe TX)
   bPayload = bBlockData ∙ bdPayload
 
+  bdQcSigs : Lens Block (KVMap Author Signature)
+  bdQcSigs = bBlockData ∙ bdQuorumCert ∙ qcLedgerInfo ∙ liwsSignatures
+
+  -- Equivalence of Blocks modulo signatures (both on the Block and in the QuorumCert it contains)
   infix 4 _≈Block_
   _≈Block_ : (b₁ b₂ : Block) → Set
-  b₁ ≈Block b₂ = b₁ ≡ record b₂ { _bSignature = _bSignature b₁ }
+  b₁ ≈Block b₂ = b₁ ≡ (b₂ & bSignature ∙~ (b₁ ^∙ bSignature)
+                          & bdQcSigs   ∙~ (b₁ ^∙ bdQcSigs))
 
   sym≈Block : Symmetric _≈Block_
   sym≈Block refl = refl

--- a/LibraBFT/ImplShared/Util/Crypto.agda
+++ b/LibraBFT/ImplShared/Util/Crypto.agda
@@ -48,7 +48,8 @@ module LibraBFT.ImplShared.Util.Crypto where
   -- of serializable types), and then define hashBD using this and prove that it ensures hashBD-inj.
   -- Note also the TODO below related to HashTags.
 
-  record BlockDataInjectivityProps (bd1 bd2 : BlockData) : Set where
+  record _BlockDataInjectivityProps_ (bd1 bd2 : BlockData) : Set where
+    constructor mkBdInjProps
     field
       bdInjEpoch  : bd1 ≡L bd2 at bdEpoch
       bdInjRound  : bd1 ≡L bd2 at bdRound
@@ -59,11 +60,43 @@ module LibraBFT.ImplShared.Util.Crypto where
       bdInjBTProp : ∀ {tx}{auth} → bd1 ^∙ bdBlockType ≡ Proposal tx auth
                                  → bd1 ^∙ bdBlockType ≡ bd2 ^∙ bdBlockType
 
+  sameBlockData⇒≈ : ∀ {b1 b2}
+                    → b1 ^∙ bId ≡ b2 ^∙ bId
+                    → (b1 ^∙ bBlockData) BlockDataInjectivityProps (b2 ^∙ bBlockData)
+                    → b1 ≈Block b2
+  sameBlockData⇒≈ {b1} {b2} refl (mkBdInjProps refl refl refl refl nil gen prop)
+     with b1 ^∙ bBlockData ∙ bdBlockType
+  ...| NilBlock         rewrite nil  refl = refl
+  ...| Genesis          rewrite gen  refl = refl
+  ...| Proposal tx auth rewrite prop refl = refl
+
+
+  BSL : Set
+  BSL = List ByteString
+
+  _≟-BSL_ : ∀ (bsl1 bsl2 : List ByteString) → Dec (bsl1 ≡ bsl2)
+  _≟-BSL_ = List-≡-dec _≟ByteString_
+
+  hashBSL = sha256 ∘ bs-concat
+
   postulate
-    hashBD     : BlockData → HashValue
-    hashBD-inj : ∀ {bd1 bd2}
-               → hashBD bd1 ≡ hashBD bd2
-               → NonInjective-≡ sha256 ⊎ BlockDataInjectivityProps bd1 bd2
+    hashBSL-inj : Injective-≡ hashBSL
+
+  postulate
+    blockData-bsl     : BlockData → List ByteString
+
+  hashBD : BlockData → HashValue
+  hashBD = hashBSL ∘ blockData-bsl
+
+  Injective-BlockData : Set
+  Injective-BlockData = Injective-int _BlockDataInjectivityProps_ hashBSL blockData-bsl blockData-bsl
+
+  -- TODO-1: prove it using bs-concat-inj
+  postulate
+    hashBD-inj : Injective-BlockData
+
+  hashBlock : Block → HashValue
+  hashBlock = hashBD ∘ (_^∙ bBlockData)
 
   blockInfoBSList : BlockInfo → List ByteString
   blockInfoBSList (BlockInfo∙new epoch round id execStId ver mes) =

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -315,6 +315,17 @@ module LibraBFT.Prelude where
                  → (A → B) → Set (a ℓ⊔ b)
   NonInjective-≡ = NonInjective _≡_
 
+  NonInjective-≡-preds : ∀{a b}{A : Set a}{B : Set b}{ℓ₁ ℓ₂ : Level}
+                      → (A → Set ℓ₁)
+                      → (A → Set ℓ₂)
+                      → (A → B) → Set (a ℓ⊔ b ℓ⊔ ℓ₁ ℓ⊔ ℓ₂)
+  NonInjective-≡-preds Pred1 Pred2 f = Σ (NonInjective _≡_ f) λ { ((a₀ , a₁) , _ , _) → Pred1 a₀ × Pred2 a₁ }
+
+  NonInjective-≡-pred : ∀{a b}{A : Set a}{B : Set b}{ℓ : Level}
+                      → (P : A → Set ℓ)
+                      → (A → B) → Set (a ℓ⊔ b ℓ⊔ ℓ)
+  NonInjective-≡-pred Pred = NonInjective-≡-preds Pred Pred
+
   NonInjective-∘ : ∀{a b c}{A : Set a}{B : Set b}{C : Set c}
                  → {f : A → B}(g : B → C)
                  → NonInjective-≡  f

--- a/LibraBFT/Prelude.agda
+++ b/LibraBFT/Prelude.agda
@@ -304,7 +304,26 @@ module LibraBFT.Prelude where
     using (_∪?_)
     public
 
-  -- Evidence that a function is not injective
+  -- Injectivity for a function of two potentially different types (A and B) via functions to a
+  -- common type (C).
+
+  Injective' : ∀ {b c d e}{B : Set b}{C : Set c}{D : Set d} → (hB : B → D) → (hC : C → D) → (_≈_ : B → C → Set e) → Set _
+  Injective' {C = C} hB hC _≈_ = ∀ {b c} → hB b ≡ hC c → b ≈ c
+
+  Injective  : ∀ {c d e}{C : Set c}{D : Set d} → (h : C → D) → (_≈_ : Rel C e) → Set _
+  Injective h _≈_ = Injective' h h _≈_
+
+  Injective-≡ : ∀ {c d}{C : Set c}{D : Set d} → (h : C → D) → Set _
+  Injective-≡ h = Injective h _≡_
+
+  Injective-int : ∀{a b c d e}{A : Set a}{B : Set b}{C : Set c}{D : Set d}
+                → (_≈_ : A → B → Set e)
+                → (h  : C → D)
+                → (f₁ : A → C)
+                → (f₂ : B → C)
+                → Set (a ℓ⊔ b ℓ⊔ d ℓ⊔ e)
+  Injective-int _≈_ h f₁ f₂ = ∀ {a₁} {b₁} → h (f₁ a₁) ≡ h (f₂ b₁) → a₁ ≈ b₁
+
   NonInjective : ∀{a b c}{A : Set a}{B : Set b}
                → (_≈_ : Rel A c)
                → (A → B) → Set (a ℓ⊔ b ℓ⊔ c)

--- a/Optics/Functorial.agda
+++ b/Optics/Functorial.agda
@@ -72,10 +72,21 @@ module Optics.Functorial where
   _∙_ : ∀{S A B} → Lens S A → Lens A B → Lens S B
   (lens p) ∙ (lens q) = lens (λ F rf x x₁ → p F rf (q F rf x) x₁)
 
-  -- Relation between the same field of two states
+  -- Relation between the same field of two states This most general form allows us to specify a
+  -- Lens S A, a function A → B, and a relation between two B's, and holds iff the relation holds
+  -- between the values yielded by applying the Lens to two S's and then applying the function to
+  -- the results; more specific variants are provided below
+  _[_]L_f=_at_ : ∀ {ℓ} {S A B : Set} → S → (B → B → Set ℓ) → S → (A → B) → Lens S A → Set ℓ
+  s₁ [ _~_ ]L s₂ f= f at l = f (s₁ ^∙ l) ~ f (s₂ ^∙ l)
+
   _[_]L_at_ : ∀ {ℓ} {S A} → S → (A → A → Set ℓ) → S → Lens S A → Set ℓ
-  s₁ [ _~_ ]L s₂ at l = (s₁ ^∙ l) ~ (s₂ ^∙ l)
+  s₁ [ _~_ ]L s₂ at l = _[_]L_f=_at_ s₁ _~_ s₂ id l
+
+  infix 4 _≡L_f=_at_
+  _≡L_f=_at_ : ∀ {S A B : Set} → (s₁ s₂ : S) → (A → B) → Lens S A → Set
+  s₁ ≡L s₂ f= f at l = _[_]L_f=_at_ s₁ _≡_ s₂ f l
 
   infix 4 _≡L_at_
   _≡L_at_ : ∀ {S A} → (s₁ s₂ : S) → Lens S A → Set
-  _≡L_at_ = _[ _≡_ ]L_at_
+  s₁ ≡L s₂ at l = _[_]L_f=_at_ s₁ _≡_ s₂ id l
+

--- a/docs/PeerHandlerContracts.org
+++ b/docs/PeerHandlerContracts.org
@@ -479,12 +479,17 @@ abstract
     general) behaves in Agda.
 
     At the time of writing, there is no set discipline for when to use
-    =abstract= blocks. Conceivably, they could be used for *every* function,
-    since this would greatly improve the readability of the proof state for any
+    =abstract= blocks. Arguably, they should be used for *every* nontrivial function,
+    for several reasons.  First, it significantly improves the readability of the proof state for any
     peer handler contract proof. This is especially true in the instances where
     =with= or =rewrite= are used, which irrevocably normalize the proof state in
     an attempt to abstract over the given expression in both the goal type and
-    the type of (non-parameter) variables in context.
+    the type of (non-parameter) variables in context.  Second, it enforces
+    abstraction boundaries between functions, ensuring that changing the
+    implementation of a function doesn't change the shape of proofs of
+    functions that call it.  The overhead of this is that we must state and prove
+    explicit contracts for each function, but it is worth it for the sake of
+    sustainability.  For an example, see ~executeBlockESpec~ in 
 
 
 * Peer handler code


### PR DESCRIPTION
So far, our proofs depend on an assumption that hash collisions don't exist. But they do! We have required hash collisions to be put in context of a ReachableSystemState just to remind ourselves that we cannot assume lack of hash collisions "for free". But this did not mean much because nothing connected the specific hash collisions to that ReachableSystemState.

This PR makes the first steps towards doing so, dealing with one important class of potential hash collisions: those on BlockIds, requiring properties to depend only on the assumption that these hash collisions do not exist in the specific state for which a property is proved. This is achieved by defining a notion of a hash being in the state (e.g., a Proposal that has the same hash as a Block already stored in the BlockTree, but with different BlockData. See LibraBFT.ImplShared.Util.HashCollisions.HashCollisionFound.

This requires us to capture the fact that we validate new Proposals "off the wire" before handling them, and propagate this information "down the stack" in order to connect it with an assumption that a hash collision does not exist *in the ReachableSystemState in which the Proposal is handled. This validity of Proposals is propagated down via module parameters, and the lack of hash collisions is propagated through arguments to the specific contract properties that require them.

There is room for improvement streamlining this, especially in LibraBFT.Impl.Properties.VotesOnce. There are also still a number of uses of meta-sha256-cr, which does not tie the hash collision to the ReachableSystemState. Addressing these will likely require the addition of more kinds of specific hash collision. When we have eliminated all uses of meta-sha256-cr, and proved all properties, we will then know that we have a precise and narrow summary of the possible hash collisions, the absence of which our proofs require.