### PR TITLE
Extend evidence that injectivity failures are `InSys` across `Concrete` modules

### DIFF
--- a/LibraBFT/Abstract/RecordChain/Assumptions.agda
+++ b/LibraBFT/Abstract/RecordChain/Assumptions.agda
@@ -103,13 +103,16 @@ module LibraBFT.Abstract.RecordChain.Assumptions
    -- checks have been performed and we can infer this information solely
    -- by seeing α has knowledge of the 2-chain in Fig2 above.
    --
+
+   open All-InSys-props InSys
+
    PreferredRoundRule : Set ℓ
    PreferredRoundRule
      = ∀(α : Member) → Meta-Honest-Member α
-     → ∀{q q'}(q∈𝓢 : InSys (Q q))(q'∈𝓢 : InSys (Q q'))
-     → {rc : RecordChain (Q q)}{n : ℕ}(c3 : 𝕂-chain Contig (3 + n) rc)
+     → ∀{q q'}
+     → {rc : RecordChain (Q q)} → All-InSys rc → {n : ℕ}(c3 : 𝕂-chain Contig (3 + n) rc)
      → (v : α ∈QC q) -- α knows of the 2-chain because it voted on the tail of the 3-chain!
-     → (rc' : RecordChain (Q q'))
+     → {rc' : RecordChain (Q q')} → All-InSys rc'
      → (v' : α ∈QC q')
      → abs-vRound (∈QC-Vote q v) < abs-vRound (∈QC-Vote q' v')
      → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')

--- a/LibraBFT/Abstract/RecordChain/Properties.agda
+++ b/LibraBFT/Abstract/RecordChain/Properties.agda
@@ -81,12 +81,14 @@ module LibraBFT.Abstract.RecordChain.Properties
    -- Lemma S3
 
    lemmaS3 : ∀{r₂ q'}
-             {rc : RecordChain r₂}      → InSys r₂
-           → (rc' : RecordChain (Q q')) → InSys (Q q')  -- Immediately before a (Q q), we have the certified block (B b), which is the 'B' in S3
+             {rc : RecordChain r₂}      → All-InSys rc
+           → (rc' : RecordChain (Q q')) → All-InSys rc' -- Immediately before a (Q q), we have the certified block (B b), which is the 'B' in S3
            → (c3 : 𝕂-chain Contig 3 rc)                 -- This is B₀ ← C₀ ← B₁ ← C₁ ← B₂ ← C₂ in S3
            → round r₂ < getRound q'
            → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (getRound (kchainBlock (suc (suc zero)) c3) ≤ prevRound rc')
-   lemmaS3 {r₂} {q'} ex₀ (step rc' b←q') ex₁ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ _ b₂←q₂ c2) hyp
+   lemmaS3 {r₂} {q'} ais₀ (step rc' b←q') ais₁ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ _ b₂←q₂ c2) hyp
+     with All-InSys⇒last-InSys ais₀ | All-InSys⇒last-InSys ais₁
+   ...| ex₀ | ex₁
      with bft-property (qVotes-C1 q₂) (qVotes-C1 q')
    ...| (a , (a∈q₂mem , a∈q'mem , honest))
         with Any-sym (Any-map⁻ a∈q₂mem) | Any-sym (Any-map⁻ a∈q'mem)
@@ -102,7 +104,8 @@ module LibraBFT.Abstract.RecordChain.Properties
    ...| tri> _ _ va'<va₂
      with subst₂ _<_ a∈q'rnd≡ a∈q₂rnd≡   (≤-trans va'<va₂ (≤-reflexive (sym a∈q₂rnd≡)))
    ...| res = ⊥-elim (n≮n (getRound q') (≤-trans res (≤-unstep hyp)))
-   lemmaS3 {q' = q'} ex₀ (step rc' b←q') ex₁ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ P b₂←q₂ c2) hyp
+   lemmaS3 {q' = q'} ais₀ (step rc' b←q') ais₁ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ P b₂←q₂ c2) hyp
+      | ex₀ | ex₁
       | (a , (a∈q₂mem , a∈q'mem , honest))
       | a∈q₂ | a∈q'
       | a∈q'rnd≡ | a∈q₂rnd≡
@@ -112,15 +115,16 @@ module LibraBFT.Abstract.RecordChain.Properties
       in ⊥-elim (<⇒≢ hyp (vote≡⇒QRound≡ {q₂} {q'} v₂∈q₂ v'∈q'
                                         (votes-only-once a honest {q₂} {q'} ex₀ ex₁ a∈q₂ a∈q'
                                                          (trans a∈q₂rnd≡ v₂≡v'))))
-   lemmaS3 {r} {q'} ex₀ (step rc' b←q') ex₁  (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ P b₂←q₂ c2) hyp
+   lemmaS3 {r} {q'} ais₀ (step rc' b←q') ais₁ (s-chain {rc = rc} {b = b₂} {q₂} r←b₂ P b₂←q₂ c2) hyp
+      | ex₀ | ex₁
       | (a , (a∈q₂mem , a∈q'mem , honest))
       | a∈q₂ | a∈q'
       | a∈q'rnd≡ | a∈q₂rnd≡
       | tri< va₂<va' _ _
      with b←q'
    ...| B←Q rrr xxx
-      = preferred-round-rule a honest {q₂} {q'} ex₀ ex₁ (s-chain r←b₂ P b₂←q₂ c2) a∈q₂
-                    (step rc' (B←Q rrr xxx)) a∈q'
+      = preferred-round-rule a honest {q₂} {q'} ais₀ (s-chain r←b₂ P b₂←q₂ c2) a∈q₂
+                    {step rc' (B←Q rrr xxx)} ais₁ a∈q'
                           (≤-trans (≤-reflexive (cong suc a∈q₂rnd≡))
                                    va₂<va')
 
@@ -220,8 +224,8 @@ module LibraBFT.Abstract.RecordChain.Properties
    ...| yes rq≤rb₂ = propS4-base {q' = q'} prev∈sys (step rc' b←q') prev∈sys' c3 hyp rq≤rb₂
    propS4 {q' = q'} prev∈sys (step rc' b←q') all∈sys c3 hyp
       | no  rb₂<rq
-     with lemmaS3 (All-InSys⇒last-InSys prev∈sys) (step rc' b←q')
-                  (All-InSys⇒last-InSys all∈sys) c3
+     with lemmaS3 prev∈sys (step rc' b←q')
+                  all∈sys c3
                   (subst (_< getRound q') (kchainBlockRoundZero-lemma c3) (≰⇒> rb₂<rq))
    ...| inj₁ hb = inj₁ hb
    ...| inj₂ ls3

--- a/LibraBFT/Concrete/Obligations.agda
+++ b/LibraBFT/Concrete/Obligations.agda
@@ -9,7 +9,6 @@ open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.Abstract.Types.EpochConfig UID NodeId
 open import LibraBFT.Base.PKCS
 open import LibraBFT.Concrete.System.Parameters
-open import LibraBFT.Concrete.System
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Consensus.Types.EpochDep
 open import LibraBFT.Prelude

--- a/LibraBFT/Concrete/Obligations/PreferredRound.agda
+++ b/LibraBFT/Concrete/Obligations/PreferredRound.agda
@@ -180,7 +180,9 @@ module LibraBFT.Concrete.Obligations.PreferredRound
 
   -- Finally, we can prove the preferred round rule from the global version;
   proof : Type → PreferredRoundRule InSys
-  proof glob-inv α hα {q} {q'} q∈sys q'∈sys c3 va rc' va' hyp
+  proof glob-inv α hα {q} {q'} {rc} ais₀ c3 va {rc'} ais₁ va' hyp
+    with All-InSys⇒last-InSys ais₀ | All-InSys⇒last-InSys ais₁
+  ...| q∈sys   | q'∈sys
     with ∈QC⇒HasBeenSent q∈sys  hα va
        | ∈QC⇒HasBeenSent q'∈sys hα va'
   ...| sent-cv | sent-cv'

--- a/LibraBFT/Concrete/Obligations/PreferredRound.agda
+++ b/LibraBFT/Concrete/Obligations/PreferredRound.agda
@@ -78,29 +78,31 @@ module LibraBFT.Concrete.Obligations.PreferredRound
  Cand-3-chain-head-round c3cand =
     getRound (kchainBlock (suc zero) (is-2chain c3cand))
 
-  -- The preferred round rule states a fact about the /previous round/
-  -- of a vote; that is, the round of the parent of the block
-  -- being voted for; the implementation will have to
-  -- show it can construct this parent.
- data VoteParentData-BlockExt : Record → Set where
-    vpParent≡I : VoteParentData-BlockExt I
-    vpParent≡Q : ∀{b q} → B b ← Q q → VoteParentData-BlockExt (Q q)
-
-  -- TODO-2: it may be cleaner to specify this as a RC 2 vpParent vpQC,
-  -- and we should consider it once we address the issue in
-  -- Abstract.RecordChain (below the definition of transp-𝕂-chain)
-
-
- record VoteParentData (v : Vote) : Set where
-    field
-      vpExt        : voteExtends v
-      vpParent     : Record
-      vpExt'       : vpParent ← B (veBlock vpExt)
-      vpMaybeBlock : VoteParentData-BlockExt vpParent
- open VoteParentData public
-
  module _ {ℓ}(𝓢 : IntermediateSystemState ℓ) where
   open IntermediateSystemState 𝓢
+  open All-InSys-props InSys
+
+   -- The preferred round rule states a fact about the /previous round/
+   -- of a vote; that is, the round of the parent of the block
+   -- being voted for; the implementation will have to
+   -- show it can construct this parent.
+  data VoteParentData-BlockExt : Record → Set ℓ where
+     vpParent≡I : VoteParentData-BlockExt I
+     vpParent≡Q : ∀{b q} → B b ← Q q → InSys (B b) → VoteParentData-BlockExt (Q q)
+
+   -- TODO-2: it may be cleaner to specify this as a RC 2 vpParent vpQC,
+   -- and we should consider it once we address the issue in
+   -- Abstract.RecordChain (below the definition of transp-𝕂-chain)
+
+  record VoteParentData (v : Vote) : Set ℓ where
+    field
+      vpExt        : voteExtends v
+      vpBlock∈sys  : InSys (B (veBlock vpExt))
+      vpParent     : Record
+      vpParent∈sys : InSys vpParent
+      vpExt'       : vpParent ← B (veBlock vpExt)
+      vpMaybeBlock : VoteParentData-BlockExt vpParent
+  open VoteParentData public
 
   -- The setup for PreferredRoundRule is like thta for VotesOnce.
   -- Given two votes by an honest author α:
@@ -126,9 +128,9 @@ module LibraBFT.Concrete.Obligations.PreferredRound
                      → Cand-3-chain-vote (∈QC-Vote q v)
    make-cand-3-chain {q = q} (s-chain {suc (suc n)} {rc = rc} {b = b} ext₀@(Q←B h0 refl) _ ext₁@(B←Q h1 refl) c2) v
      with c2
-   ...| (s-chain {q = q₀} _ _ _ (s-chain _ _ _ c))
+   ...| (s-chain {q = q₀} _ _ _ _)
        = record { votesForB = mkVE b (All-lookup (qVotes-C2 q) (Any-lookup-correct v))
-                                      (trans (All-lookup (qVotes-C3 q) (Any-lookup-correct v)) h1)
+                                     (trans (All-lookup (qVotes-C3 q) (Any-lookup-correct v)) h1)
                 ; qc = q₀
                 ; qc←b = ext₀
                 ; rc = rc
@@ -139,29 +141,27 @@ module LibraBFT.Concrete.Obligations.PreferredRound
    -- It is important that the make-cand-3-chain lemma doesn't change the head of
    -- the 3-chain/cand-2-chain.
    make-cand-3-chain-lemma
-     : ∀{n α q}{rc : RecordChain (Q q)}
+     : ∀{n α q}{rc : RecordChain (Q q)} → All-InSys rc
      → (c3 : 𝕂-chain Contig (3 + n) rc)
      → (v  : α ∈QC q)
-     → NonInjective-≡ bId ⊎ kchainBlock (suc zero) (is-2chain (make-cand-3-chain c3 v)) ≡ kchainBlock (suc (suc zero)) c3
-   make-cand-3-chain-lemma {q = q} c3@(s-chain {suc (suc n)} {rc = rc} {b = b} ext₀@(Q←B h0 refl) _ ext₁@(B←Q h1 refl) c2) v
-     with (veBlock (Cand-3-chain-vote.votesForB (make-cand-3-chain c3 v))) ≟Block b
-   ...| no neq = inj₁ ((veBlock (Cand-3-chain-vote.votesForB (make-cand-3-chain c3 v)) , b)
-                      , neq
-                      , trans (sym (veId (votesForB (make-cand-3-chain c3 v))))
-                              (All-lookup (qVotes-C2 q) (∈QC-Vote-correct q v)))
-   ...| yes b≡
+     → kchainBlock (suc zero) (is-2chain (make-cand-3-chain c3 v)) ≡ kchainBlock (suc (suc zero)) c3
+   make-cand-3-chain-lemma {q = q} ais₀ c3@(s-chain {suc (suc n)} {rc = rc} {b = b} ext₀@(Q←B h0 refl) _ ext₁@(B←Q h1 refl) c2) v
      with c2
-   ...| (s-chain {q = q₀} _ _ _ (s-chain _ _ _ c)) rewrite b≡ = inj₂ refl
+   ...| (s-chain {q = q₀} _ _ _ (s-chain _ _ _ c)) = refl
 
    vdParent-prevRound-lemma
-      : ∀{α q}(rc : RecordChain (Q q))(va : α ∈QC q)
+      : ∀{α q}(rc : RecordChain (Q q)) → (All-InSys rc) → (va : α ∈QC q)
       → (vp : VoteParentData (∈QC-Vote q va))
-      → NonInjective-≡ bId ⊎ (round (vpParent vp) ≡ prevRound rc)
-   vdParent-prevRound-lemma {q = q} (step {r = B b} (step rc y) x@(B←Q refl refl)) va vp
+        -- These properties are still about abstract records, so we could still cook up a trivial
+        -- proof.  Therefore, if we need these properties, we need to connect the collision to
+        -- Records that are InSys
+      → NonInjective-≡-pred (InSys ∘ B) bId ⊎ (round (vpParent vp) ≡ prevRound rc)
+   vdParent-prevRound-lemma {q = q} (step {r = B b} (step rc y) x@(B←Q refl refl)) ais va vp
      with b ≟Block (veBlock (vpExt vp))
-   ...| no imp = inj₁ ( (b , veBlock (vpExt vp))
-                      , (imp , id-B∨Q-inj (cong id-B∨Q (trans (sym (All-lookup (qVotes-C2 q) (∈QC-Vote-correct q va)))
-                                                               (veId (vpExt vp))))))
+   ...| no imp = inj₁ (((b , veBlock (vpExt vp))
+                      , (imp , (id-B∨Q-inj (cong id-B∨Q (trans (sym (All-lookup (qVotes-C2 q) (∈QC-Vote-correct q va)))
+                                                               (veId (vpExt vp)))))))
+                      , (ais (there x here) , (vpBlock∈sys vp)))
    ...| yes refl
      with ←-inj y (vpExt' vp)
    ...| bSameId'
@@ -169,11 +169,14 @@ module LibraBFT.Concrete.Obligations.PreferredRound
    ...| I←B y0 y1   | I←B e0 e1   = inj₂ refl
    ...| Q←B y0 refl | Q←B e0 refl
      with vpMaybeBlock vp
-   ...| vpParent≡Q {b = bP} bP←qP
+   ...| vpParent≡Q {b = bP} bP←qP bp∈Sys
      with rc
    ...| step {r = B b'} rc' b←q
      with b' ≟Block bP
-   ...| no  imp = inj₁ ((b' , bP) , imp , id-B∨Q-inj (lemmaS1-2 (eq-Q refl) b←q bP←qP))
+   ...| no  imp = inj₁ (((b' , bP)
+                       , (imp , (id-B∨Q-inj (lemmaS1-2 (eq-Q refl) b←q bP←qP))))
+                       , (ais (there x (there (Q←B y0 refl) (there b←q here)))
+                         , bp∈Sys))
    ...| yes refl
      with bP←qP | b←q
    ...| B←Q refl refl | B←Q refl refl = inj₂ refl
@@ -194,13 +197,12 @@ module LibraBFT.Concrete.Obligations.PreferredRound
            (sym (∈QC-Member q' va')) sent-cv'
            cand hyp
   ...| va'Par , res
-    with vdParent-prevRound-lemma rc' va' va'Par
-  ...| inj₁ hb    = inj₁ (hb , obm-dangerous-magic' "TODO-3: connect to InSys")
+    with vdParent-prevRound-lemma rc' ais₁ va' va'Par
+  ...| inj₁ hb    = inj₁ hb
   ...| inj₂ final
-    with make-cand-3-chain-lemma c3 va
-  ...| inj₁ hb = inj₁ (hb , obm-dangerous-magic' "TODO-3: connect to InSys")
-  ...| inj₂ xx = inj₂ (subst₂ _≤_
-          (cong bRound (trans (cong (kchainBlock (suc zero) ∘ is-2chain) (sym R)) xx))
-          final
-          res)
+    with make-cand-3-chain-lemma ais₀ c3 va
+  ...| xx = inj₂ (subst₂ _≤_
+                   (cong bRound (trans (cong (kchainBlock (suc zero) ∘ is-2chain) (sym R)) xx))
+                   final
+                   res)
 

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -44,6 +44,26 @@ module LibraBFT.Concrete.Properties
   open        PerEpoch 𝓔
   open        PerState st
   open        PerReachableState r
+
+  {- Although the `Concrete` modules are currently specified in terms of the implementation types used by
+     the implementation we are proving correct, the important aspect of the `Concrete` modules is to
+     reduce implementation obligations specified in the `Abstract` modules to being about `Vote`s sent.
+     These properties are stated in terms of an `IntermediateSystemState`, which is derived from a
+     `ReachableSystemState` for an implementation-specific system configuration.
+
+     The `Concrete` modules could be refactored to enable verifying a broader range of implementations,
+     including those that use entirely different implementation types.  In more detail, the `Concrete`
+     modules would be parameterized by:
+
+       - `SystemTypeParameters`;
+       - a function from a `ReachableSystemState` of a system instantiated with
+         the provided `SystemTypeParameters` to an `IntermediateSystemState`;
+       - proof that the `InSys` predicate is stable for the given types.
+
+     TODO-3: Refactor Concrete so that it is independent of implementation types, thus making it more
+     general for a wider range of implementations.
+  -}
+
   open        IntermediateSystemState intSystemState
 
   -- This module parameter asserts that there are no hash collisions between Blocks *in the system*,

--- a/LibraBFT/Concrete/Properties.agda
+++ b/LibraBFT/Concrete/Properties.agda
@@ -41,9 +41,9 @@ module LibraBFT.Concrete.Properties
   open import LibraBFT.ImplShared.Util.HashCollisions iiah
 
   open        ImplObligations impl-correct
+  open        PerEpoch 𝓔
   open        PerState st
   open        PerReachableState r
-  open        PerEpoch 𝓔
   open        IntermediateSystemState intSystemState
 
   -- This module parameter asserts that there are no hash collisions between Blocks *in the system*,
@@ -62,8 +62,8 @@ module LibraBFT.Concrete.Properties
 
     validState : ValidSysState intSystemState
     validState = record
-      { vss-votes-once      = VO.Proof.voo iiah 𝓔 sps-cor bsvc bsvr v≢0 ∈BI? iro vo₂ st r
-      ; vss-preferred-round = PR.Proof.prr iiah 𝓔 sps-cor bsvr v≢0 ∈BI? iro pr₁ pr₂ st r
+      { vss-votes-once      = VO.Proof.voo iiah 𝓔 sps-cor bsvc bsvr v≢0 ∈BI? iro vo₂     r
+      ; vss-preferred-round = PR.Proof.prr iiah 𝓔 sps-cor bsvr      v≢0 ∈BI? iro pr₁ pr₂ r
       }
 
     open All-InSys-props InSys

--- a/LibraBFT/Concrete/Properties/PreferredRound.agda
+++ b/LibraBFT/Concrete/Properties/PreferredRound.agda
@@ -68,7 +68,7 @@ module LibraBFT.Concrete.Properties.PreferredRound (iiah : SystemInitAndHandlers
    → (c2 : Cand-3-chain-vote vabs)
    -- then the round of the block that v' votes for is at least the round of
    -- the grandparent of the block that v votes for (i.e., the preferred round rule)
-   → Σ (VoteParentData (PerState.intSystemState pre) v'abs)  -- TODO: require that vpBlock is InSys, may require reordering imports  Similar below
+   → Σ (VoteParentData (PerState.intSystemState pre) v'abs)
            (λ vp → Cand-3-chain-head-round c2 ≤ Abs.round (vpParent vp))
      ⊎ (VoteForRound∈ pk (v' ^∙ vRound) (v' ^∙ vEpoch) (v' ^∙ vProposedId) (msgPool pre))
 

--- a/LibraBFT/Concrete/Properties/PreferredRound.agda
+++ b/LibraBFT/Concrete/Properties/PreferredRound.agda
@@ -38,6 +38,7 @@ module LibraBFT.Concrete.Properties.PreferredRound (iiah : SystemInitAndHandlers
  open import LibraBFT.Yasm.Yasm ℓ-RoundManager ℓ-VSFP ConcSysParms iiah PeerCanSignForPK PeerCanSignForPK-stable
  open import LibraBFT.Concrete.Properties.Common iiah 𝓔
 
+ open PerEpoch 𝓔
  -- As with VotesOnce, we will have two implementation obligations, one for when v is sent by the
  -- step and v' has been sent before, and one for when both are sent by the step.
 
@@ -67,10 +68,9 @@ module LibraBFT.Concrete.Properties.PreferredRound (iiah : SystemInitAndHandlers
    → (c2 : Cand-3-chain-vote vabs)
    -- then the round of the block that v' votes for is at least the round of
    -- the grandparent of the block that v votes for (i.e., the preferred round rule)
-   → Σ (VoteParentData v'abs)
+   → Σ (VoteParentData (PerState.intSystemState pre) v'abs)  -- TODO: require that vpBlock is InSys, may require reordering imports  Similar below
            (λ vp → Cand-3-chain-head-round c2 ≤ Abs.round (vpParent vp))
      ⊎ (VoteForRound∈ pk (v' ^∙ vRound) (v' ^∙ vEpoch) (v' ^∙ vProposedId) (msgPool pre))
-
 
  -- Similarly in case the same step sends both v and v'
  ImplObligation₂ : Set (ℓ+1 ℓ-RoundManager)
@@ -98,29 +98,53 @@ module LibraBFT.Concrete.Properties.PreferredRound (iiah : SystemInitAndHandlers
    → α-ValidVote 𝓔 v  mbr ≡ vabs
    → α-ValidVote 𝓔 v' mbr ≡ v'abs
    → (c2 : Cand-3-chain-vote vabs)
-   → Σ (VoteParentData v'abs)
+   → Σ (VoteParentData (PerState.intSystemState pre) v'abs)
            (λ vp → Cand-3-chain-head-round c2 ≤ Abs.round (vpParent vp))
 
-  -- Next, we prove that given the necessary obligations,
+ module _ where
+   open InSys iiah
+
+   stepPreservesVoteParentData : ∀ {st0 st1 v}
+     → Step st0 st1
+     → (vpd : VoteParentData (PerState.intSystemState st0) v)
+     → Σ (VoteParentData (PerState.intSystemState st1) v)
+         λ vpd' → vpParent vpd' ≡ vpParent vpd
+   stepPreservesVoteParentData {st0} {st1} theStep vpd
+      with vpd
+   ...| (record { vpExt        = vpExt
+                ; vpBlock∈sys  = vpBlock∈sys
+                ; vpParent     = vpParent
+                ; vpParent∈sys = vpParent∈sys
+                ; vpExt'       = vpExt'
+                ; vpMaybeBlock = vpMaybeBlock
+                }) = (record
+                     { vpExt        = vpExt
+                     ; vpBlock∈sys  = stable theStep vpBlock∈sys
+                     ; vpParent     = vpParent
+                     ; vpParent∈sys = stable theStep vpParent∈sys
+                     ; vpExt'       = vpExt'
+                     ; vpMaybeBlock = transp-vpmb vpMaybeBlock
+                     }) , refl
+     where transp-vpmb : ∀ {r}
+                         → VoteParentData-BlockExt (PerState.intSystemState st0) r
+                         → VoteParentData-BlockExt (PerState.intSystemState st1) r
+           transp-vpmb vpParent≡I = vpParent≡I
+           transp-vpmb (vpParent≡Q x x₁) = vpParent≡Q x (stable theStep x₁)
+
  module Proof
-   (sps-corr : StepPeerState-AllValidParts)
+   (sps-corr : StepPeerState-AllValidParts)   -- Bring in newMsg⊎msgSentB4
    (Impl-bsvr : ImplObl-bootstrapVotesRound≡0)
    (Impl-nvr≢0 : ImplObl-NewVoteRound≢0)
    (Impl-∈BI? : (sig : Signature) → Dec (∈BootstrapInfo bootstrapInfo sig))
    (Impl-IRO : IncreasingRoundObligation)
    (Impl-PR1 : ImplObligation₁)
    (Impl-PR2 : ImplObligation₂)
-   where
-  -- Any reachable state satisfies the PR rule for any epoch in the system.
-  module _ (st : SystemState)(r : ReachableSystemState st) where
-   -- Bring in newMsg⊎msgSentB4
-   open Structural sps-corr
-   -- Bring in intSystemState
-   open        PerState st
+    where
+  module _ {st : SystemState}(r : ReachableSystemState st) where
    open        PerReachableState r
-   open        PerEpoch 𝓔
+   open        PerState st
+   open        Structural sps-corr
    open        ConcreteCommonProperties st r sps-corr Impl-bsvr Impl-nvr≢0
-
 
    α-ValidVote-trans : ∀ {pk mbr vabs pool} (v : Vote)
                      → α-ValidVote 𝓔 v mbr ≡ vabs
@@ -141,9 +165,10 @@ module LibraBFT.Concrete.Properties.PreferredRound (iiah : SystemInitAndHandlers
       → α-ValidVote 𝓔 (msgVote v₁) mbr ≡ v₁abs
       → α-ValidVote 𝓔 (msgVote v₂) mbr ≡ v₂abs
       → (c3 : Cand-3-chain-vote v₁abs)
-      → Σ (VoteParentData v₂abs)
+      → Σ (VoteParentData (PerState.intSystemState st) v₂abs)
             (λ vp → Cand-3-chain-head-round c3 ≤ Abs.round (vpParent vp))
-   PreferredRoundProof step@(step-s r theStep) pkH v₁ v₂ r₁<r₂ refl refl c3
+   PreferredRoundProof {pk}{round₁}{round₂}{epoch}{bId₁}{bId₂}{v₁abs}{v₂abs}{mbr}{st = post}
+                       step@(step-s {pre = pre} r theStep) pkH v₁ v₂ r₁<r₂ refl refl c3
       with msgRound≡ v₁ | msgEpoch≡ v₁ | msgBId≡ v₁
          | msgRound≡ v₂ | msgEpoch≡ v₂ | msgBId≡ v₂
    ...| refl | refl | refl | refl | refl | refl
@@ -159,49 +184,85 @@ module LibraBFT.Concrete.Properties.PreferredRound (iiah : SystemInitAndHandlers
                                   in ⊥-elim (<⇒≱ r₁<r₂ (subst (r₁ ≥_) 0≡r₂ z≤n))
    ...| no  ¬init₁ | no ¬init₂
       with theStep
-   ...| step-peer cheat@(step-cheat c)
-        = let m₁sb4 = ¬cheatForgeNewSig r cheat unit pkH (msgSigned v₁) (msg⊆ v₁) (msg∈pool v₁) ¬init₁
+   ...| step-peer cheat@(step-cheat c) = vpdPres
+      where
+              m₁sb4 = ¬cheatForgeNewSig r cheat unit pkH (msgSigned v₁) (msg⊆ v₁) (msg∈pool v₁) ¬init₁
               m₂sb4 = ¬cheatForgeNewSig r cheat unit pkH (msgSigned v₂) (msg⊆ v₂) (msg∈pool v₂) ¬init₂
               v₁sb4 = msgSentB4⇒VoteRound∈ (msgSigned v₁) m₁sb4
               v₂sb4 = msgSentB4⇒VoteRound∈ (msgSigned v₂) m₂sb4
-              v₁abs = α-ValidVote-trans (msgVote v₁) refl v₁sb4
-              v₂abs = α-ValidVote-trans (msgVote v₂) refl v₂sb4
-          in PreferredRoundProof r pkH v₁sb4 v₂sb4 r₁<r₂ v₁abs v₂abs c3
+              v₁abs' = α-ValidVote-trans {pk} {mbr} {pool = msgPool pre} (msgVote v₁) refl v₁sb4
+              v₂abs' = α-ValidVote-trans {pk} {mbr} {pool = msgPool pre} (msgVote v₂) refl v₂sb4
+
+              vpdPres : Σ (VoteParentData (PerState.intSystemState post) v₂abs)
+                          (λ vp → Cand-3-chain-head-round c3 ≤ Abs.round (vpParent vp))
+              vpdPres
+                 with PreferredRoundProof r pkH v₁sb4 v₂sb4 r₁<r₂ v₁abs' v₂abs' c3
+              ...| vpd , rnd≤
+                 with stepPreservesVoteParentData theStep vpd
+              ...| res , rnds≡ rewrite sym rnds≡ = res , rnd≤
    ...| step-peer (step-honest stP)
       with ⊎-map₂ (msgSentB4⇒VoteRound∈ (msgSigned v₁))
                   (newMsg⊎msgSentB4 r stP pkH (msgSigned v₁) ¬init₁  (msg⊆ v₁) (msg∈pool v₁))
          | ⊎-map₂ (msgSentB4⇒VoteRound∈ (msgSigned v₂))
                   (newMsg⊎msgSentB4 r stP pkH (msgSigned v₂) ¬init₂ (msg⊆ v₂) (msg∈pool v₂))
-   ...| inj₂ v₁sb4                | inj₂ v₂sb4
-        = let v₁abs = α-ValidVote-trans (msgVote v₁) refl v₁sb4
-              v₂abs = α-ValidVote-trans (msgVote v₂) refl v₂sb4
-          in PreferredRoundProof r pkH v₁sb4 v₂sb4 r₁<r₂ v₁abs v₂abs c3
-   ...| inj₁ (m₁∈outs , v₁pk , newV₁) | inj₁ (m₂∈outs , v₂pk , newV₂)
-        = Impl-PR2 r stP pkH (msg⊆ v₁) m₁∈outs (msgSigned v₁) ¬init₁ newV₁ v₁pk (msg⊆ v₂)
-                   m₂∈outs (msgSigned v₂) ¬init₂ newV₂ v₂pk refl r₁<r₂ refl refl c3
-   ...| inj₁ (m₁∈outs , v₁pk , v₁New) | inj₂ v₂sb4
-        = let round≡ = trans (msgRound≡ v₂sb4) (msgRound≡ v₂)
-              ¬bootstrapV₂ = ¬Bootstrap∧Round≡⇒¬Bootstrap step pkH v₂ ¬init₂ (msgSigned v₂sb4) round≡
-              epoch≡ = sym (msgEpoch≡ v₂sb4)
-          in either (λ r₂<r₁ → ⊥-elim (<⇒≯ r₁<r₂ (<-transʳ (≡⇒≤ (sym round≡)) r₂<r₁)))
-                    (λ v₁sb4 → let v₁abs = α-ValidVote-trans (msgVote v₁) refl v₁sb4
-                                   v₂abs = α-ValidVote-trans (msgVote v₂) refl v₂sb4
-                               in PreferredRoundProof r pkH v₁sb4 v₂sb4 r₁<r₂ v₁abs v₂abs c3)
-                    (Impl-IRO r stP pkH (msg⊆ v₁) m₁∈outs (msgSigned v₁) ¬init₁ v₁New v₁pk
-                              (msg⊆ v₂sb4) (msg∈pool v₂sb4) (msgSigned v₂sb4) ¬bootstrapV₂ epoch≡)
-   ...| inj₂ v₁sb4                | inj₁ (m₂∈outs , v₂pk , _)
-        = let rv₁<r₂ = <-transʳ (≡⇒≤ (msgRound≡ v₁sb4)) r₁<r₂
-              round≡ = trans (msgRound≡ v₁sb4) (msgRound≡ v₁)
-              ¬bootstrapV₁ = ¬Bootstrap∧Round≡⇒¬Bootstrap step pkH v₁ ¬init₁ (msgSigned v₁sb4) round≡
-              v₁abs = α-ValidVote-trans (msgVote v₁) refl v₁sb4
-          in either id
-                    (λ v₂sb4 → let v₁abs = α-ValidVote-trans (msgVote v₁) refl v₁sb4
-                                   v₂abs = α-ValidVote-trans (msgVote v₂) refl v₂sb4
-                               in PreferredRoundProof r pkH v₁sb4 v₂sb4 r₁<r₂ v₁abs v₂abs c3)
-                    (Impl-PR1 r stP pkH (msg⊆ v₂) m₂∈outs (msgSigned v₂) ¬init₂ v₂pk
-                              (msg⊆ v₁sb4) (msg∈pool v₁sb4) (msgSigned v₁sb4) ¬bootstrapV₁
-                              (msgEpoch≡ v₁sb4) rv₁<r₂ v₁abs refl c3)
+   ...| inj₂ v₁sb4                    | inj₂ v₂sb4
+        = vpdPres
+          where
+            v₁abs' = α-ValidVote-trans (msgVote v₁) refl v₁sb4
+            v₂abs' = α-ValidVote-trans (msgVote v₂) refl v₂sb4
 
+            vpdPres : _
+            vpdPres with PreferredRoundProof r pkH v₁sb4 v₂sb4 r₁<r₂ v₁abs' v₂abs' c3
+            ...| vpd , rnd≤
+               with stepPreservesVoteParentData theStep vpd
+            ...| res , pars≡ rewrite sym pars≡ =  res , rnd≤
+   ...| inj₁ (m₁∈outs , v₁pk , newV₁) | inj₁ (m₂∈outs , v₂pk , newV₂) = vpdPres
+          where
+            vpdPres : _
+            vpdPres
+              with Impl-PR2 r stP pkH (msg⊆ v₁) m₁∈outs (msgSigned v₁) ¬init₁ newV₁ v₁pk (msg⊆ v₂)
+                                                m₂∈outs (msgSigned v₂) ¬init₂ newV₂ v₂pk refl r₁<r₂ refl refl c3
+            ...| vpd , rnd≤
+               with stepPreservesVoteParentData theStep vpd
+            ...| res , pars≡ rewrite sym pars≡ = res , rnd≤
+   ...| inj₁ (m₁∈outs , v₁pk , v₁New) | inj₂ v₂sb4 = help
+        where
+          round≡ = trans (msgRound≡ v₂sb4) (msgRound≡ v₂)
+          ¬bootstrapV₂ = ¬Bootstrap∧Round≡⇒¬Bootstrap step pkH v₂ ¬init₂ (msgSigned v₂sb4) round≡
+          epoch≡ = sym (msgEpoch≡ v₂sb4)
+
+          implir0 : _
+          implir0 = Impl-IRO r stP pkH (msg⊆ v₁) m₁∈outs (msgSigned v₁) ¬init₁ v₁New v₁pk (msg⊆ v₂sb4)
+                                       (msg∈pool v₂sb4)  (msgSigned v₂sb4) ¬bootstrapV₂ epoch≡
+
+          help : _
+          help = either (λ r₂<r₁ → ⊥-elim (<⇒≯ r₁<r₂ (<-transʳ (≡⇒≤ (sym round≡)) r₂<r₁)))
+                        (λ v₁sb4 → let v₁abs = α-ValidVote-trans (msgVote v₁) refl v₁sb4
+                                       v₂abs = α-ValidVote-trans (msgVote v₂) refl v₂sb4
+                                       prp   = PreferredRoundProof r pkH v₁sb4 v₂sb4 r₁<r₂ v₁abs v₂abs c3
+                                       vpd'   = stepPreservesVoteParentData theStep (proj₁ prp)
+                                   in (proj₁ vpd') , (proj₂ prp))
+                        implir0
+   ...| inj₂ v₁sb4                    | inj₁ (m₂∈outs , v₂pk , _) = help
+        where
+          rv₁<r₂ = <-transʳ (≡⇒≤ (msgRound≡ v₁sb4)) r₁<r₂
+          round≡ = trans (msgRound≡ v₁sb4) (msgRound≡ v₁)
+          ¬bootstrapV₁ = ¬Bootstrap∧Round≡⇒¬Bootstrap step pkH v₁ ¬init₁ (msgSigned v₁sb4) round≡
+          v₁abs' = α-ValidVote-trans (msgVote v₁) refl v₁sb4
+
+          implir1 : _
+          implir1 = Impl-PR1 r stP pkH (msg⊆ v₂) m₂∈outs (msgSigned v₂) ¬init₂ v₂pk
+                                   (msg⊆ v₁sb4) (msg∈pool v₁sb4) (msgSigned v₁sb4) ¬bootstrapV₁
+                                   (msgEpoch≡ v₁sb4) rv₁<r₂ v₁abs' refl c3
+
+          help : _
+          help = either (λ x → let vpd' = stepPreservesVoteParentData theStep (proj₁ x)
+                               in proj₁ vpd' , proj₂ x)
+                        (λ v₂sb4 → let v₂abs' = α-ValidVote-trans (msgVote v₂) refl v₂sb4
+                                       prp    = PreferredRoundProof r pkH v₁sb4 v₂sb4 r₁<r₂ v₁abs' v₂abs' c3
+                                       vpd'   = stepPreservesVoteParentData theStep (proj₁ prp)
+                                   in (proj₁ vpd') , (proj₂ prp))
+                        implir1
 
    prr : Type intSystemState
    prr honα refl sv refl sv' c2 round<

--- a/LibraBFT/Concrete/Properties/VotesOnce.agda
+++ b/LibraBFT/Concrete/Properties/VotesOnce.agda
@@ -99,13 +99,13 @@ module LibraBFT.Concrete.Properties.VotesOnce (iiah : SystemInitAndHandlers ℓ-
    where
 
   -- Any reachable state satisfies the VO rule for any epoch in the system.
-  module _ (st : SystemState)(r : ReachableSystemState st) where
+  module _ {st : SystemState}(r : ReachableSystemState st) where
 
    open Structural sps-corr
    -- Bring in intSystemState
+   open PerEpoch 𝓔
    open PerState st
    open PerReachableState r
-   open PerEpoch 𝓔
    open ConcreteCommonProperties st r sps-corr Impl-bsvr Impl-nvr≢0
    open WithEC
 

--- a/LibraBFT/Concrete/System.agda
+++ b/LibraBFT/Concrete/System.agda
@@ -26,18 +26,18 @@ open EpochConfig
 -- best place to start understanding this.  Longer term, we will also need
 -- higher-level, cross-epoch properties.
 
+open import LibraBFT.Yasm.Base
+open import LibraBFT.Yasm.System ℓ-RoundManager ℓ-VSFP ConcSysParms
+
 module LibraBFT.Concrete.System where
 
- open import LibraBFT.Yasm.Base
- open import LibraBFT.Yasm.System ℓ-RoundManager ℓ-VSFP ConcSysParms
+ module PerEpoch (𝓔 : EpochConfig) where
+   open WithEC
+   open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs hiding (qcVotes; Vote)
+   open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
+   open import LibraBFT.Concrete.Records                        𝓔
 
- module PerState (st : SystemState) where
-    module PerEpoch (𝓔 : EpochConfig) where
-
-     open WithEC
-     open import LibraBFT.Abstract.Abstract     UID _≟UID_ NodeId 𝓔 (ConcreteVoteEvidence 𝓔) as Abs hiding (qcVotes; Vote)
-     open import LibraBFT.Concrete.Intermediate                   𝓔 (ConcreteVoteEvidence 𝓔)
-     open import LibraBFT.Concrete.Records                        𝓔
+   module PerState (st : SystemState) where
 
      -- * Auxiliary definitions;
      -- Here we capture the idea that there exists a vote message that
@@ -92,3 +92,11 @@ module LibraBFT.Concrete.System where
        ; HasBeenSent     = λ { v → ∃VoteMsgSentFor (msgPool st) v }
        ; ∈QC⇒HasBeenSent = ∈QC⇒sent {st = st}
        }
+
+   module InSys (siah : SystemInitAndHandlers ℓ-RoundManager ConcSysParms) where
+     open WithInitAndHandlers siah
+
+     stable : ∀ {st0 st1 : SystemState} → Step st0 st1 → {r : Abs.Record}
+                    → IntermediateSystemState.InSys (PerState.intSystemState st0) r
+                    → IntermediateSystemState.InSys (PerState.intSystemState st1) r
+     stable theStep (_α-Sent_.ws refl x₁ x₂) = _α-Sent_.ws refl (msgs-stable theStep x₁) x₂


### PR DESCRIPTION
This PR augments the proofs in the `Concrete` modules to ensure that any injectivity failures they
claim are accompanied by evidence that the `Block`s involved in that failure are "in the system"
(i.e., have actually been sent during the execution of the system).  Otherwise, it would be trivial
to prove these properties simply by constructing a pair of different abstract `Block`s that have the
same `Block` id, which is trivial.

The `Concrete.*` modules build on the `Abstract.*` modules to specify implementation obligations that
are closer to the actual implementation than the `Abstract` modules.  In particular, it reduces the
obligations to the level of obligations for honest peers sending `Vote`s, whereas the `Abstract` modules
specify obligations in terms of `Record`s (`Block`s and `QC`s).

One key obligation is that, if a peer sends a vote that could contribute to a `CommitRule` (meaning
that it votes to extend a contiguous `2-chain` to potentially form a contiguous `3-chain`), then
that peer ensures the conditions on the rounds necessary to prove the `PreferredRoundRule` for the
contiguous `3-chain` that would result.  

In more detail, this PR makes the following structural changes, and then fixes the affected proofs,
resulting in our top-level `Concrete` properties providing evidence that any claimed injectivity
failures are between `Block`s that are "in the system",

- `Abstract.RecordChain.*`
 
   - Weaken `PreferredRoundRule` assumption to apply only to `RecordChain`s whose `Record`s are all
     "in the system", and provide this information to the relevant properties.  This is needed so that
     these properties can provide evidence that any injectivity failures they find are between
     `Record`s that are "in the system".

 - `Concrete.System`

   - Prove that the "in the system" predicate (`InSys`) is stable.  That is, if a given abstract
     `Record` is "in the system" according to the `IntermediateSystemState` for one system state,
     then it is also "in the system" according to the `IntermediateSystemState` for the system state
     resulting from taking any step from the first system state.  This is needed so that we can
     prove the upgraded `PreferredRoundProof` inductively, ensuring that if we use an inductive
     hypothesis and receive evidence of an injectivity failure in the prestate, then we can also construct
     evidence of the same injectivity failure in the post state.

 - `Concrete.Obligations.PreferredRound`

    - We upgrade the important `VoteParentData` structure to include evidence that the `Record`s in
      it are "in the system".  This is needed to enable the proofs to provide evidence of any
      injectivity failures they produce being between `Block`s that are "in the system" (before this
      PR, these proofs were papered over using "obm-dangerous-magic" because the existing proofs did
      not provide evidence that the `Block`s involved in an injectivity failure were "in the
      system".

### Observation

Although the `Concrete` modules are currently specified in terms of the implementation types used by
the implementation we are proving correct, the essential aspect of the `Concrete` modules is to
reduce implementation obligations specified in the `Abstract` modules to being about `Vote`s sent.
These properties are stated in terms of an `IntermediateSystemState`, which is derived from a
`ReachableSystemState` for an implementation-specific system configuration.

The `Concrete` modules could be refactored to enable verifying a broader range of implementations,
including those that use entirely different implementation types.  In more detail, the `Concrete`
modules would be parameterized by:

  - `SystemTypeParameters`;
  - a function from a `ReachableSystemState` of a system instantiated with
    the provided `SystemTypeParameters` to an `IntermediateSystemState`;
  - proof that the `InSys` predicate is stable for the given types.

Therefore, the following comment has been added:

```
TODO-3: Refactor Concrete so that it is independent of implementation types, thus making it more
general for a wider range of implementations.
```

