### PR TITLE
Make `EitherD-[either|maybe]` consistent with traditional argument order

### DIFF
--- a/src/Dijkstra/EitherD.agda
+++ b/src/Dijkstra/EitherD.agda
@@ -157,5 +157,5 @@ EitherD-vacuous (EitherD-if (clause (b ≔ x) x₁)) = (const (EitherD-vacuous x
 EitherD-vacuous (EitherD-either x₁ x₂ x)         = (λ x₃ _ → EitherD-vacuous (x₁ x₃)) , (λ y _ → EitherD-vacuous (x₂ y))
 EitherD-vacuous (EitherD-maybe m x₁ x)           = (const (EitherD-vacuous m)) , λ j _ → EitherD-vacuous (x₁ j)
 EitherD-vacuous (EitherD-bind m x)               = EitherD-⇒-bind m (EitherD-vacuous m) λ { (Left  _) _ → unit
-                                                                            ; (Right _) _ → λ c _ → EitherD-vacuous (x c) }
+                                                                                          ; (Right _) _ → λ c _ → EitherD-vacuous (x c) }
 

--- a/src/Dijkstra/EitherD.agda
+++ b/src/Dijkstra/EitherD.agda
@@ -17,8 +17,8 @@ data EitherD (E : Set) : Set → Set₁ where
   EitherD-bail   : ∀ {A} → E → EitherD E A
   -- Branching conditionals (used for creating more convenient contracts)
   EitherD-if     : ∀ {A} → Guards (EitherD E A) → EitherD E A
-  EitherD-either : ∀ {A B C} → Either B C
-                   → (B → EitherD E A) → (C → EitherD E A) → EitherD E A
+  EitherD-either : ∀ {A B C}
+                   → (B → EitherD E A) → (C → EitherD E A) → Either B C → EitherD E A
   EitherD-maybe  : ∀ {A B} → Maybe A → EitherD E B → (A → EitherD E B) → EitherD E B
 
 pattern LeftD  x = EitherD-bail   x
@@ -40,8 +40,8 @@ EitherD-run (EitherD-if (clause (b ≔ c) gs)) =
   if toBool b then EitherD-run c else EitherD-run (EitherD-if gs)
 EitherD-run (EitherD-if (otherwise≔ c)) =
   EitherD-run c
-EitherD-run (EitherD-either (Left x) f₁ f₂) = EitherD-run (f₁ x)
-EitherD-run (EitherD-either (Right y) f₁ f₂) = EitherD-run (f₂ y)
+EitherD-run (EitherD-either f₁ f₂ (Left x))  = EitherD-run (f₁ x)
+EitherD-run (EitherD-either f₁ f₂ (Right y)) = EitherD-run (f₂ y)
 EitherD-run (EitherD-maybe nothing n s) = EitherD-run n
 EitherD-run (EitherD-maybe (just x) n s) = EitherD-run (s x)
 
@@ -69,7 +69,7 @@ EitherD-weakestPre (EitherD-if (clause (b ≔ c) gs)) P =
   × (toBool b ≡ false → EitherD-weakestPre (EitherD-if gs) P)
 EitherD-weakestPre (EitherD-if (otherwise≔ x)) P =
   EitherD-weakestPre x P
-EitherD-weakestPre (EitherD-either e f₁ f₂) P =
+EitherD-weakestPre (EitherD-either f₁ f₂ e) P =
   (∀ x → e ≡ Left x → EitherD-weakestPre (f₁ x) P)
   × (∀ y → e ≡ Right y → EitherD-weakestPre (f₂ y) P)
 EitherD-weakestPre (EitherD-maybe m n s) P =
@@ -104,9 +104,9 @@ EitherD-contract{E}{A} (EitherD-if gs) P wp =
   ... | false = EitherD-contract-if gs P (proj₂ wp refl)
   ... | true = EitherD-contract c P (proj₁ wp refl)
   EitherD-contract-if (otherwise≔ x) P wp = EitherD-contract x P wp
-EitherD-contract (EitherD-either (Left x) f₁ f₂) P wp =
+EitherD-contract (EitherD-either f₁ f₂ (Left x)) P wp =
   EitherD-contract (f₁ x) P (proj₁ wp x refl)
-EitherD-contract (EitherD-either (Right y) f₁ f₂) P wp =
+EitherD-contract (EitherD-either f₁ f₂ (Right y)) P wp =
   EitherD-contract (f₂ y) P (proj₂ wp y refl)
 EitherD-contract (EitherD-maybe nothing f₁ f₂) P wp =
   EitherD-contract f₁ P (proj₁ wp refl)
@@ -131,9 +131,9 @@ EitherD-⇒ {Post₁} {Post₂} (EitherD-if (otherwise≔ x)) pre pf = EitherD-�
 EitherD-⇒ {Post₁} {Post₂} (EitherD-if (clause (x ≔ x₂) x₁)) (pre₁ , pre₂) pf =
     (λ x≡true  → EitherD-⇒ x₂ (pre₁ x≡true) pf)
   , (λ x≡false → EitherD-⇒ (EitherD-if x₁) (pre₂ x≡false) pf)
-proj₁ (EitherD-⇒ {Post₁} {Post₂} (EitherD-either (Left  x) x₁ x₂) (pre₁ , pre₂) pf) .x refl =
+proj₁ (EitherD-⇒ {Post₁} {Post₂} (EitherD-either x₁ x₂ (Left  x)) (pre₁ , pre₂) pf) .x refl =
        EitherD-⇒ (x₁ x) (pre₁ x refl) pf
-proj₂ (EitherD-⇒ {Post₁} {Post₂} (EitherD-either (Right x) x₁ x₂) (pre₁ , pre₂) pf) .x refl =
+proj₂ (EitherD-⇒ {Post₁} {Post₂} (EitherD-either x₁ x₂ (Right x)) (pre₁ , pre₂) pf) .x refl =
        EitherD-⇒ (x₂ x) (pre₂ x refl) pf
 proj₁ (EitherD-⇒ {Post₁} {Post₂} (EitherD-maybe .nothing m x₁) (pre₁ , pre₂) pf) refl   =
        EitherD-⇒ m      (pre₁   refl) pf
@@ -154,7 +154,7 @@ EitherD-vacuous (LeftD x) = unit
 EitherD-vacuous (RightD x) = unit
 EitherD-vacuous (EitherD-if (otherwise≔ x)) = EitherD-vacuous x
 EitherD-vacuous (EitherD-if (clause (b ≔ x) x₁)) = (const (EitherD-vacuous x)) , (const (EitherD-vacuous (EitherD-if x₁)))
-EitherD-vacuous (EitherD-either x x₁ x₂) = (λ x₃ _ → EitherD-vacuous (x₁ x₃)) , (λ y _ → EitherD-vacuous (x₂ y))
+EitherD-vacuous (EitherD-either x₁ x₂ x) = (λ x₃ _ → EitherD-vacuous (x₁ x₃)) , (λ y _ → EitherD-vacuous (x₂ y))
 EitherD-vacuous (EitherD-maybe x m x₁) = (const (EitherD-vacuous m)) , λ j _ → EitherD-vacuous (x₁ j)
 EitherD-vacuous (EitherD-bind m x) = EitherD-⇒-bind m (EitherD-vacuous m) λ { (Left  _) _ → unit
                                                                             ; (Right _) _ → λ c _ → EitherD-vacuous (x c) }

--- a/src/Dijkstra/EitherD/Syntax.agda
+++ b/src/Dijkstra/EitherD/Syntax.agda
@@ -36,7 +36,7 @@ instance
 
   EitherD-MonadEitherD : MonadEitherD (EitherD E)
   MonadEitherD.monad    EitherD-MonadEitherD = Monad-EitherD
-  MonadEitherD.eitherSD EitherD-MonadEitherD = EitherD-either
+  MonadEitherD.eitherD  EitherD-MonadEitherD = EitherD-either
 
 -- `EitherD` is Either-like
 instance

--- a/src/Dijkstra/EitherD/Syntax.agda
+++ b/src/Dijkstra/EitherD/Syntax.agda
@@ -31,8 +31,8 @@ instance
   MonadIfD.ifD‖  EitherD-MonadIfD = EitherD-if
 
   EitherD-MonadMaybeD : MonadMaybeD (EitherD E)
-  MonadMaybeD.monad   EitherD-MonadMaybeD = Monad-EitherD
-  MonadMaybeD.maybeSD EitherD-MonadMaybeD = EitherD-maybe
+  MonadMaybeD.monad  EitherD-MonadMaybeD = Monad-EitherD
+  MonadMaybeD.maybeD EitherD-MonadMaybeD = EitherD-maybe
 
   EitherD-MonadEitherD : MonadEitherD (EitherD E)
   MonadEitherD.monad    EitherD-MonadEitherD = Monad-EitherD

--- a/src/Dijkstra/RWS.agda
+++ b/src/Dijkstra/RWS.agda
@@ -83,7 +83,7 @@ RWS-weakestPre (RWS-either f₁ f₂ e) P ev pre =
        RWS-weakestPre (f₂ y) P ev pre)
 RWS-weakestPre (RWS-ebind m f) P ev pre =
   RWS-weakestPre m (RWS-weakestPre-ebindPost ev f P) ev pre
-RWS-weakestPre (RWS-maybe m f₁ f₂) P ev pre =
+RWS-weakestPre (RWS-maybe f₁ f₂ m) P ev pre =
   (m ≡ nothing → RWS-weakestPre f₁ P ev pre)
   × (∀ j → m ≡ just j → RWS-weakestPre (f₂ j) P ev pre)
 
@@ -147,9 +147,9 @@ RWS-contract (RWS-ebind m f) P ev pre wp
    with runRWS m ev pre
 ... | Left x , st₁ , outs₁ = con
 ... | Right y , st₁ , outs₁ = RWS-contract (f y) _ ev st₁ (con y refl)
-RWS-contract (RWS-maybe nothing f₁ f₂) P ev pre (wp₁ , wp₂)
+RWS-contract (RWS-maybe f₁ f₂ nothing) P ev pre (wp₁ , wp₂)
   = RWS-contract f₁ _ ev pre (wp₁ refl)
-RWS-contract (RWS-maybe (just x) f₁ f₂) P ev pre (wp₁ , wp₂) =
+RWS-contract (RWS-maybe f₁ f₂ (just x)) P ev pre (wp₁ , wp₂) =
   RWS-contract (f₂ x) _ ev pre (wp₂ x refl)
 
 -- This helper function is primarily used to take a proof concerning one
@@ -188,8 +188,8 @@ RWS-⇒ (RWS-ebind m f) ev st pre pf =
         (λ { (Left x₁) st₁ outs x → pf _ _ _ x
              ; (Right y) st₁ outs x → λ c x₁ →
                  RWS-⇒ (f c) ev st₁ (x c x₁) (λ r st₂ outs₁ x₂ → pf r st₂ (outs ++ outs₁) x₂) })
-proj₁ (RWS-⇒ (RWS-maybe x m f) ev st (pre₁ , pre₂) pf) ≡nothing = RWS-⇒ m ev st (pre₁ ≡nothing) pf
-proj₂ (RWS-⇒ (RWS-maybe x m f) ev st (pre₁ , pre₂) pf) b b≡     = RWS-⇒ (f b) ev st (pre₂ b b≡) pf
+proj₁ (RWS-⇒ (RWS-maybe m f x) ev st (pre₁ , pre₂) pf) ≡nothing = RWS-⇒ m ev st (pre₁ ≡nothing) pf
+proj₂ (RWS-⇒ (RWS-maybe m f x) ev st (pre₁ , pre₂) pf) b b≡     = RWS-⇒ (f b) ev st (pre₂ b b≡) pf
 
 RWS-⇒-bind
   : ∀ {P : RWS-Post Wr St A}

--- a/src/Dijkstra/RWS.agda
+++ b/src/Dijkstra/RWS.agda
@@ -76,7 +76,7 @@ RWS-weakestPre (RWS-if (clause (b ≔ c) gs)) P ev pre =
   × (toBool b ≡ false → RWS-weakestPre (RWS-if gs) P ev pre)
 RWS-weakestPre (RWS-if (otherwise≔ c)) P ev pre =
   RWS-weakestPre c P ev pre
-RWS-weakestPre (RWS-either e f₁ f₂) P ev pre =
+RWS-weakestPre (RWS-either f₁ f₂ e) P ev pre =
     (∀ x → (e ≡ Left x) →
       RWS-weakestPre (f₁ x) P ev pre)
   × (∀ y → (e ≡ Right y) →
@@ -137,9 +137,9 @@ RWS-contract{Ev}{Wr}{St}{A} (RWS-if gs) P ev pre wp = RWS-contract-if gs P ev pr
   ...| false = RWS-contract-if gs _ ev pre (wp₂ refl)
   RWS-contract-if (otherwise≔ x) P ev pre wp =
     RWS-contract x P ev pre wp
-RWS-contract (RWS-either (Left x) f₁ f₂) P ev pre (wp₁ , wp₂) =
+RWS-contract (RWS-either f₁ f₂ (Left x)) P ev pre (wp₁ , wp₂) =
   RWS-contract (f₁ x) _ ev pre (wp₁ x refl)
-RWS-contract (RWS-either (Right y) f₁ f₂) P ev pre (wp₁ , wp₂) =
+RWS-contract (RWS-either f₁ f₂ (Right y)) P ev pre (wp₁ , wp₂) =
   RWS-contract (f₂ y) _ ev pre (wp₂ y refl)
 RWS-contract (RWS-ebind m f) P ev pre wp
    with RWS-contract m _ ev pre wp
@@ -177,11 +177,11 @@ RWS-⇒ (RWS-if (otherwise≔ x)) ev st pre pf = RWS-⇒ x ev st pre pf
 RWS-⇒ (RWS-if (clause (b ≔ c) cs)) ev st (pre₁ , pre₂) pf =
   (λ pf' → RWS-⇒ c ev st (pre₁ pf') pf)
   , λ pf' → RWS-⇒ (RWS-if cs) ev st (pre₂ pf') pf
-proj₁ (RWS-⇒ (RWS-either (Left x) f₁ f₂) ev st (pre₁ , pre₂) pf) x₁ x₁≡ =
+proj₁ (RWS-⇒ (RWS-either f₁ f₂ (Left x)) ev st (pre₁ , pre₂) pf) x₁ x₁≡ =
   RWS-⇒ (f₁ x₁) ev st (pre₁ x₁ x₁≡) pf
-proj₂ (RWS-⇒ (RWS-either (Left x)  f₁ f₂) ev st (pre₁ , pre₂) pf) y ()
-proj₁ (RWS-⇒ (RWS-either (Right y) f₁ f₂) ev st (pre₁ , pre₂) pf) y₁ ()
-proj₂ (RWS-⇒ (RWS-either (Right y) f₁ f₂) ev st (pre₁ , pre₂) pf) y₁ y₁≡ =
+proj₂ (RWS-⇒ (RWS-either f₁ f₂ (Left x) ) ev st (pre₁ , pre₂) pf) y ()
+proj₁ (RWS-⇒ (RWS-either f₁ f₂ (Right y)) ev st (pre₁ , pre₂) pf) y₁ ()
+proj₂ (RWS-⇒ (RWS-either f₁ f₂ (Right y)) ev st (pre₁ , pre₂) pf) y₁ y₁≡ =
   RWS-⇒ (f₂ y₁) ev st (pre₂ y₁ y₁≡) pf
 RWS-⇒ (RWS-ebind m f) ev st pre pf =
   RWS-⇒ m ev st pre

--- a/src/Dijkstra/RWS/Syntax.agda
+++ b/src/Dijkstra/RWS/Syntax.agda
@@ -34,23 +34,24 @@ instance
   MonadIfD.ifD‖  RWS-MonadIfD = RWS-if
 
   RWS-MonadMaybeD : MonadMaybeD (RWS Ev Wr St)
-  MonadMaybeD.monad   RWS-MonadMaybeD = RWS-Monad
-  MonadMaybeD.maybeSD RWS-MonadMaybeD = RWS-maybe
+  MonadMaybeD.monad  RWS-MonadMaybeD = RWS-Monad
+  MonadMaybeD.maybeD RWS-MonadMaybeD = RWS-maybe
 
   RWS-MonadEitherD : MonadEitherD (RWS Ev Wr St)
   MonadEitherD.monad   RWS-MonadEitherD = RWS-Monad
   MonadEitherD.eitherD RWS-MonadEitherD = RWS-either
 
-maybeSM : RWS Ev Wr St (Maybe A) → RWS Ev Wr St B → (A → RWS Ev Wr St B) → RWS Ev Wr St B
-maybeSM mma mb f = do
+maybeM : RWS Ev Wr St B → (A → RWS Ev Wr St B) → RWS Ev Wr St (Maybe A) → RWS Ev Wr St B
+maybeM mb f mma = do
   x ← mma
   caseMD x of λ where
     nothing  → mb
     (just j) → f j
 
-maybeSMP-RWS : RWS Ev Wr St (Maybe A) → B → (A → RWS Ev Wr St B)
+maybeMP-RWS : B → (A → RWS Ev Wr St B)
+              → RWS Ev Wr St (Maybe A)
               → RWS Ev Wr St B
-maybeSMP-RWS ma b f = do
+maybeMP-RWS b f ma = do
   x ← ma
   caseMD x of λ where
     nothing  → pure b

--- a/src/Dijkstra/RWS/Syntax.agda
+++ b/src/Dijkstra/RWS/Syntax.agda
@@ -38,8 +38,8 @@ instance
   MonadMaybeD.maybeSD RWS-MonadMaybeD = RWS-maybe
 
   RWS-MonadEitherD : MonadEitherD (RWS Ev Wr St)
-  MonadEitherD.monad    RWS-MonadEitherD = RWS-Monad
-  MonadEitherD.eitherSD RWS-MonadEitherD = RWS-either
+  MonadEitherD.monad   RWS-MonadEitherD = RWS-Monad
+  MonadEitherD.eitherD RWS-MonadEitherD = RWS-either
 
 maybeSM : RWS Ev Wr St (Maybe A) → RWS Ev Wr St B → (A → RWS Ev Wr St B) → RWS Ev Wr St B
 maybeSM mma mb f = do

--- a/src/Dijkstra/Syntax.agda
+++ b/src/Dijkstra/Syntax.agda
@@ -63,13 +63,13 @@ module _ {ℓ₁ ℓ₂} {M : Set ℓ₁ → Set ℓ₂} where
 record MonadMaybeD {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
   field
     ⦃ monad ⦄ : Monad M
-    maybeSD : ∀ {A B : Set ℓ₁} → Maybe A → M B → (A → M B) → M B
+    maybeD : ∀ {A B : Set ℓ₁} → M B → (A → M B) → Maybe A → M B
 
 open MonadMaybeD ⦃ ... ⦄ public
 
 infix 0 caseMD_of_
 caseMD_of_ : ∀ {ℓ₁ ℓ₂} {M : Set ℓ₁ → Set ℓ₂} ⦃ _ : MonadMaybeD M ⦄ {A B : Set ℓ₁} → Maybe A → (Maybe A → M B) → M B
-caseMD m of f = maybeSD m (f nothing) (f ∘ just)
+caseMD m of f = maybeD (f nothing) (f ∘ just) m
 
 record MonadEitherD {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
   field

--- a/src/Dijkstra/Syntax.agda
+++ b/src/Dijkstra/Syntax.agda
@@ -74,20 +74,20 @@ caseMD m of f = maybeSD m (f nothing) (f ∘ just)
 record MonadEitherD {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
   field
     ⦃ monad ⦄ : Monad M
-    eitherSD : ∀ {E A B : Set ℓ₁} → Either E A → (E → M B) → (A → M B) → M B
+    eitherD : ∀ {E A B : Set ℓ₁} → (E → M B) → (A → M B) → Either E A → M B
 
-open MonadEitherD ⦃ ... ⦄ public hiding (eitherSD)
+open MonadEitherD ⦃ ... ⦄ public hiding (eitherD)
 
-eitherSD
+eitherD
   : ∀ {ℓ₁ ℓ₂ ℓ₃} {M : Set ℓ₁ → Set ℓ₂} ⦃ med : MonadEitherD M ⦄ →
     ∀ {EL : Set ℓ₁ → Set ℓ₁ → Set ℓ₃} ⦃ _ : EitherLike EL ⦄ →
-    ∀ {E A B : Set ℓ₁} → EL E A → (E → M B) → (A → M B) → M B
-eitherSD ⦃ med = med ⦄ e f₁ f₂ =
-  MonadEitherD.eitherSD med (toEither e) f₁ f₂
+    ∀ {E A B : Set ℓ₁} → (E → M B) → (A → M B) → EL E A → M B
+eitherD ⦃ med = med ⦄ f₁ f₂ e =
+  MonadEitherD.eitherD med f₁ f₂ (toEither e)
 
 infix 0 case⊎D_of_
 case⊎D_of_
   : ∀ {ℓ₁ ℓ₂ ℓ₃} {M : Set ℓ₁ → Set ℓ₂} ⦃ _ : MonadEitherD M ⦄ →
     ∀ {EL : Set ℓ₁ → Set ℓ₁ → Set ℓ₃} ⦃ _ : EitherLike EL ⦄ →
     ∀ {E A B : Set ℓ₁} → EL E A → (EL E A → M B) → M B
-case⊎D e of f = eitherSD e (f ∘ fromEither ∘ Left) (f ∘ fromEither ∘ Right)
+case⊎D e of f = eitherD (f ∘ fromEither ∘ Left) (f ∘ fromEither ∘ Right) e

--- a/src/Haskell/Modules/RWS.agda
+++ b/src/Haskell/Modules/RWS.agda
@@ -32,8 +32,8 @@ data RWS (Ev Wr St : Set) : Set → Set₁ where
   RWS-ebind  : ∀ {A B C}
              → RWS Ev Wr St (Either C A)
              → (A → RWS Ev Wr St (Either C B))                   → RWS Ev Wr St (Either C B)
-  RWS-maybe  : ∀ {A B} → Maybe B
-             → (RWS Ev Wr St A) → (B → RWS Ev Wr St A)           → RWS Ev Wr St A
+  RWS-maybe  : ∀ {A B}
+             → (RWS Ev Wr St A) → (B → RWS Ev Wr St A) → Maybe B → RWS Ev Wr St A
 
 private
   variable
@@ -95,8 +95,8 @@ runRWS (RWS-ebind m f)              ev st
 ...| Right a , st₁ , outs₁
    with runRWS (f a) ev st₁
 ...|       r , st₂ , outs₂                = r , st₂ , outs₁ ++ outs₂
-runRWS (RWS-maybe nothing  f₁ f₂)   ev st = runRWS f₁ ev st
-runRWS (RWS-maybe (just x) f₁ f₂)   ev st = runRWS (f₂ x) ev st
+runRWS (RWS-maybe f₁ f₂ nothing )   ev st = runRWS f₁ ev st
+runRWS (RWS-maybe f₁ f₂ (just x))   ev st = runRWS (f₂ x) ev st
 
 -- Accessors for the result, poststate, and outputs.
 RWS-result : RWS Ev Wr St A → Ev → St → A

--- a/src/Haskell/Modules/RWS.agda
+++ b/src/Haskell/Modules/RWS.agda
@@ -26,8 +26,9 @@ data RWS (Ev Wr St : Set) : Set → Set₁ where
   RWS-tell   : List Wr                                           → RWS Ev Wr St Unit
   -- Branching combinators (used for creating more convenient contracts)
   RWS-if     : ∀ {A} → Guards (RWS Ev Wr St A)                   → RWS Ev Wr St A
-  RWS-either : ∀ {A B C} → Either B C
-             → (B → RWS Ev Wr St A) → (C → RWS Ev Wr St A)       → RWS Ev Wr St A
+  RWS-either : ∀ {A B C}
+             → (B → RWS Ev Wr St A) → (C → RWS Ev Wr St A)
+             → Either B C                                        → RWS Ev Wr St A
   RWS-ebind  : ∀ {A B C}
              → RWS Ev Wr St (Either C A)
              → (A → RWS Ev Wr St (Either C B))                   → RWS Ev Wr St (Either C B)
@@ -86,8 +87,8 @@ runRWS (RWS-tell outs)              ev st = unit , st , outs
 runRWS (RWS-if (clause (b ≔ c) gs)) ev st =
   if toBool b then runRWS c ev st else runRWS (RWS-if gs) ev st
 runRWS (RWS-if (otherwise≔ c))      ev st = runRWS c ev st
-runRWS (RWS-either (Left x)  f₁ f₂) ev st = runRWS (f₁ x) ev st
-runRWS (RWS-either (Right y) f₁ f₂) ev st = runRWS (f₂ y) ev st
+runRWS (RWS-either f₁ f₂ (Left x) ) ev st = runRWS (f₁ x) ev st
+runRWS (RWS-either f₁ f₂ (Right y)) ev st = runRWS (f₂ y) ev st
 runRWS (RWS-ebind m f)              ev st
    with runRWS m ev st
 ...| Left  c , st₁ , outs₁ = Left c , st₁ , outs₁

--- a/src/LibraBFT/Prelude.agda
+++ b/src/LibraBFT/Prelude.agda
@@ -150,8 +150,8 @@ module LibraBFT.Prelude where
     hiding (align; alignWith; zipWith)
     public
 
-  -- a non-dependent eliminator; note the traditional argument order
-  -- is "switched", hence the 'S'
+  -- a non-dependent eliminator
+  -- note the traditional argument order is "switched", hence the 'S'
   maybeS : ∀ {a b} {A : Set a} {B : Set b} →
            (x : Maybe A) → B → ((x : A) → B) → B
   maybeS {B = B} x f t = Maybe-maybe {B = const B} t f x
@@ -378,8 +378,8 @@ module LibraBFT.Prelude where
   (inj₁ x) ⊎⟫= _ = inj₁ x
   (inj₂ a) ⊎⟫= f = f a
 
-  -- a non-dependent eliminator; note the traditional argument order
-  -- is "switched", hence the 'S'
+  -- a non-dependent eliminator
+  -- note the traditional argument order is "switched", hence the 'S'
   eitherS : ∀ {a b c} {A : Set a} {B : Set b} {C : Set c}
             (x : Either A B) → ((x : A) → C) → ((x : B) → C) → C
   eitherS eab fa fb = case eab of λ where

--- a/src/LibraBFT/Prelude.agda
+++ b/src/LibraBFT/Prelude.agda
@@ -10,6 +10,7 @@
 module LibraBFT.Prelude where
 
   open import Haskell.Prelude public
+  open import Dijkstra.All public
 
   open import Level
     renaming (suc to ℓ+1; zero to ℓ0; _⊔_ to _ℓ⊔_)
@@ -363,12 +364,20 @@ module LibraBFT.Prelude where
   (inj₁ x) ⊎⟫= _ = inj₁ x
   (inj₂ a) ⊎⟫= f = f a
 
-  -- a non-dependent eliminator
+  -- a non-dependent eliminator; note the traditional argument order
+  -- is "switched", hence the 'S'
   eitherS : ∀ {a b c} {A : Set a} {B : Set b} {C : Set c}
             (x : Either A B) → ((x : A) → C) → ((x : B) → C) → C
   eitherS eab fa fb = case eab of λ where
     (Left  a) → fa a
     (Right b) → fb b
+
+  -- A Dijkstra version of eitherS, implemented using the version in
+  -- Dijkstra.EitherD which has traditional argument order
+  eitherSD : ∀ {ℓ₁ ℓ₂ ℓ₃} {M : Set ℓ₁ → Set ℓ₂} ⦃ med : MonadEitherD M ⦄
+           → ∀ {EL : Set ℓ₁ → Set ℓ₁ → Set ℓ₃} ⦃ _ : EitherLike EL ⦄
+           → ∀ {E A B : Set ℓ₁} → EL E A → (E → M B) → (A → M B) → M B
+  eitherSD ⦃ med ⦄ ⦃ el ⦄ x y z = eitherD ⦃ med ⦄ ⦃ el ⦄ y z x
 
   open import Data.String as String
     hiding (_==_ ; _≟_ ; concat)

--- a/src/LibraBFT/Prelude.agda
+++ b/src/LibraBFT/Prelude.agda
@@ -150,10 +150,24 @@ module LibraBFT.Prelude where
     hiding (align; alignWith; zipWith)
     public
 
-  -- a non-dependent eliminator
+  -- a non-dependent eliminator; note the traditional argument order
+  -- is "switched", hence the 'S'
   maybeS : ∀ {a b} {A : Set a} {B : Set b} →
            (x : Maybe A) → B → ((x : A) → B) → B
   maybeS {B = B} x f t = Maybe-maybe {B = const B} t f x
+
+  -- A Dijkstra version of maybeS, implemented using the version in
+  -- Dijkstra.Syntax which has traditional argument order
+  maybeSD : ∀ {ℓ₁ ℓ₂} {M : Set ℓ₁ → Set ℓ₂} ⦃ mmd : MonadMaybeD M ⦄
+           → ∀ {A B : Set ℓ₁} → Maybe A → M B → (A → M B) → M B
+  maybeSD ⦃ mmd ⦄ x y z = maybeD y z x
+
+  module _ {Ev Wr St A B : Set} where
+    maybeSMP-RWS : RWS Ev Wr St (Maybe A)
+                 → B
+                 → (A → RWS Ev Wr St B)
+                 → RWS Ev Wr St B
+    maybeSMP-RWS x y z = maybeMP-RWS y z x
 
   open import Data.Maybe.Relation.Unary.Any
     renaming (Any to Maybe-Any; dec to Maybe-Any-dec)
@@ -373,11 +387,11 @@ module LibraBFT.Prelude where
     (Right b) → fb b
 
   -- A Dijkstra version of eitherS, implemented using the version in
-  -- Dijkstra.EitherD which has traditional argument order
+  -- Dijkstra.Syntax which has traditional argument order
   eitherSD : ∀ {ℓ₁ ℓ₂ ℓ₃} {M : Set ℓ₁ → Set ℓ₂} ⦃ med : MonadEitherD M ⦄
            → ∀ {EL : Set ℓ₁ → Set ℓ₁ → Set ℓ₃} ⦃ _ : EitherLike EL ⦄
            → ∀ {E A B : Set ℓ₁} → EL E A → (E → M B) → (A → M B) → M B
-  eitherSD ⦃ med ⦄ ⦃ el ⦄ x y z = eitherD ⦃ med ⦄ ⦃ el ⦄ y z x
+  eitherSD ⦃ med ⦄ ⦃ el ⦄ x y z = eitherD y z x
 
   open import Data.String as String
     hiding (_==_ ; _≟_ ; concat)


### PR DESCRIPTION
Our preference for switched argument order for `eitherSD` and `maybeSD` is application-specific, and inconsistent with traditional Haskell order.  This pull request will clean this up by making the `Haskell` and `Dijkstra` "sub repos" consistent with traditional order.

Note: so far, only `eitherSD` -> `eitherD` has been done.  I'm seeking feedback first.  @haroldcarr 