### PR TITLE
Generalization of EitherD, RWS

### DIFF
--- a/src/Dijkstra/AST.agda
+++ b/src/Dijkstra/AST.agda
@@ -10,6 +10,7 @@ open import Data.Empty
 open import Data.Fin
 open import Data.Product using (_×_ ; _,_)
 open import Data.Unit
+open import Function
 open import Haskell.Prelude
 import      Level
 open import Relation.Binary.PropositionalEquality
@@ -21,119 +22,327 @@ data AST (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set → Set
   -- effect operations
   ASTop : ∀ {A} → (c : C A) → (R A c → AST C R A) → AST C R A
 
+record ASTOpSemTypes : Set₁ where
+  constructor mkASTOpSemTypes
+  field
+    Input  : Set
+    Output : Set → Set
+
+record ASTOpSemImpl (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set₁ where
+  constructor mkASTOpSemImpl
+  field
+    -- Implementation
+    M          : Set → Set
+    ⦃ monadM ⦄ : Monad M
+    opM        : ∀ {A} → (c : C A) → (R A c → M A) → M A
+
+  runAST : ∀ {A} → AST C R A → M A
+  runAST (ASTreturn x) = return x
+  runAST (ASTbind p f) = runAST p >>= λ x → runAST (f x)
+  runAST (ASTop c f) = opM c (λ x → runAST (f x))
+
+
 record ASTOpSem (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set₁ where
   constructor mkASTOpSem
   field
-    M       : Set → Set
-    returnI : ∀ {A} → A → M A
-    bindI   : ∀ {A B} → M A → (A → M B) → M B
-    opI     : ∀ {A} → (c : C A) → (R A c → M A) → M A
-
-runAST : ∀ {C R A} → (i : ASTOpSem C R) → AST C R A → ASTOpSem.M i A
-runAST i (ASTreturn x) = ASTOpSem.returnI i x
-runAST i (ASTbind p f) = ASTOpSem.bindI i (runAST i p) (λ x → runAST i (f x))
-runAST i (ASTop c f) = ASTOpSem.opI i c (λ x → runAST i (f x))
-
-record ASTPredTrans (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set₂ where
-  constructor mkASTPredTrans
+    IO : ASTOpSemTypes
+  open ASTOpSemTypes IO public
   field
-    Pre  : Set₁
-    Post : (A : Set) → Set₁
+    impl : ASTOpSemImpl C R
+  open ASTOpSemImpl impl public
+  field
+    runM : ∀ {A} → M A → Input → Output A
 
-  PredTrans : (A : Set) → Set₁
-  PredTrans A = Post A → Pre
+  -- Coherence
+    runMIdLeft  : ∀ {A} (x : A) (f : A → AST C R A) (i : Input)
+                  →   runM (runAST (ASTbind (ASTreturn x) f)) i
+                    ≡ runM (runAST (f x)) i
+    runMIdRight : ∀ {A} (m : AST C R A) (i : Input)
+                  →   runM (runAST (ASTbind m ASTreturn)) i
+                    ≡ runM (runAST m) i
+    runMAssoc   : ∀ {A B₁ B₂} (m : AST C R A) (f : A → AST C R B₁) (g : B₁ → AST C R B₂) (i : Input)
+                  →   runM (runAST (ASTbind (ASTbind m f) g)) i
+                    ≡ runM (runAST (ASTbind m (λ x → ASTbind (f x) g))) i
+
+
+module SimpleASTOpSem
+  (I : Set) (O : Set → Set)
+  where
+
+  M : Set → Set
+  M A = I → O A
+
+  module _
+    (m : Monad M) (ml : MonadLaws M ⦃ m ⦄) where
+
+    os : ∀ {C R} → (opM : ∀ {A} → (c : C A) → (R A c → M A) → M A)
+         → ASTOpSem C R
+    ASTOpSemTypes.Input (ASTOpSem.IO (os opM)) = I
+    ASTOpSemTypes.Output (ASTOpSem.IO (os opM)) = O
+    ASTOpSemImpl.M (ASTOpSem.impl (os opM)) = M
+    ASTOpSemImpl.monadM (ASTOpSem.impl (os opM)) = m
+    ASTOpSemImpl.opM (ASTOpSem.impl (os opM)) = opM
+    ASTOpSem.runM (os opM) = id
+    ASTOpSem.runMIdLeft (os opM) x f i =
+      {!MonadLaws.idLeft ⦃ m = m ⦄ ml x ?!}
+    ASTOpSem.runMIdRight (os opM) = {!!}
+    ASTOpSem.runMAssoc (os opM) = {!!}
+
+
+  -- runM : ∀ {A} → M A → I → O A
+  -- runM m = m
+
+  -- impl : ⦃ _ : Monad O ⦄ → ASTOpSemImpl C R
+  -- ASTOpSemImpl.M impl = M
+  -- Monad.return (ASTOpSemImpl.monadM impl) x i = return x
+  -- Monad._>>=_ (ASTOpSemImpl.monadM impl) m f i =
+  --   let o = m i
+  --   in o >>= λ x → f x (step o)
+  -- ASTOpSemImpl.opM impl = {!!}
+
+  -- opSem : ⦃ _ : Monad O ⦄ → (ml : MonadLaws O) → ASTOpSem C R
+  -- ASTOpSemTypes.Input (ASTOpSem.IO (opSem ml)) = I
+  -- ASTOpSemTypes.Output (ASTOpSem.IO (opSem ml)) = O
+  -- ASTOpSem.impl (opSem ml) = impl
+  -- ASTOpSem.runM (opSem ml) = runM
+  -- ASTOpSem.runMIdLeft (opSem ml) x f i
+  --   =   (return x >>= λ y → ASTOpSemImpl.runAST impl (f y) (step (return x)))
+  --     ≡ {!!} ∋ {!!}
+  -- ASTOpSem.runMIdRight (opSem ml) = {!!}
+  -- ASTOpSem.runMAssoc (opSem ml) = {!!}
+
+-- simpleASTOpSem : ∀ {C R} → ASTOpSemTypes C R → ASTOpSem C R
+-- ASTOpSem.IO (simpleASTOpSem x) = x
+-- ASTOpSemImpl.M (ASTOpSem.impl (simpleASTOpSem x)) =
+--   λ A → ASTOpSemTypes.Input x → ASTOpSemTypes.Output x A
+-- ASTOpSemImpl.monadM (ASTOpSem.impl (simpleASTOpSem x)) = {!!}
+-- ASTOpSemImpl.opM (ASTOpSem.impl (simpleASTOpSem x)) = {!!}
+-- ASTOpSem.runM (simpleASTOpSem x) = {!!}
+-- ASTOpSem.runMLaw1 (simpleASTOpSem x) = {!!}
+
+-- -- record ASTPredTrans (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set₂ where
+-- --   constructor mkASTPredTrans
+-- --   field
+-- --     Input  : Set
+-- --     Output : Set → Set
+
+-- --   Pre : Set₁
+-- --   Pre = Input → Set
+
+-- --   Post : Set → Set₁
+-- --   Post A = Output A → Set
+
+-- --   PredTrans : (A : Set) → Set₁
+-- --   PredTrans A = Post A → Pre
   
-  field
-    returnPTS : ∀ {A} → A → PredTrans A
-    bindPTS   : ∀ {A B} → (A → PredTrans B) → Post B → Post A
-    opPTS     : ∀ {A} → (c : C A) → (R A c → PredTrans A) → PredTrans A
+-- --   field
+-- --     returnPTS : ∀ {A} → A → PredTrans A
+-- --     bindPTS   : ∀ {A B} → (A → PredTrans B) → Post B → Input → Post A
+-- --     opPTS     : ∀ {A} → (c : C A) → (R A c → PredTrans A) → PredTrans A
 
-wpAST : ∀ {C R A} → (pt : ASTPredTrans C R) → AST C R A → ASTPredTrans.PredTrans pt A
-wpAST pt (ASTreturn x) = ASTPredTrans.returnPTS pt x
-wpAST pt (ASTbind p f) Post = wpAST pt p (ASTPredTrans.bindPTS pt (λ x → wpAST pt (f x)) Post)
-wpAST pt (ASTop c f) Post = ASTPredTrans.opPTS pt c (λ r → wpAST pt (f r)) Post
+-- --   ptAST : ∀ {A} → AST C R A → PredTrans A
+-- --   ptAST (ASTreturn x) = returnPTS x
+-- --   ptAST (ASTbind p f) Post input =
+-- --     ptAST p (bindPTS (λ x → ptAST (f x)) Post input) input
+-- --   ptAST (ASTop c f) Post = opPTS c (λ r → ptAST (f r)) Post
+
+-- -- record ASTWeakestPre
+-- --   (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁)
+-- --   (os : ASTOpSem C R) (pt : ASTPredTrans C R) : Set₁ where
+-- --   constructor mkASTWeakestPre
+-- --   open ASTOpSem     os
+-- --   open ASTPredTrans pt
+-- --   field
+-- --     runM : ∀ {A} → M A → Input → Output A
+
+-- --   Sufficient : (A : Set) (m : AST C R A) (P : Post A) (i : Input) → Set
+-- --   Sufficient A m P i =
+-- --     ptAST m P i → P (runM (runAST m) i)
+
+-- --   field
+-- --     returnPT : ∀ {A} (x : A) {P} {i} → Sufficient A (ASTreturn x) P i
+-- --     bindPT   : ∀ {A B P} i (m : AST C R A) (f : A → AST C R B)
+-- --                → (wp : bindPTS (λ x → ptAST (f x)) P i (runM (runAST m) i))
+-- --                → (∀ x i' → Sufficient B (f x) P i')
+-- --                → P (runM (runAST (ASTbind m f)) i)
+-- --     opPT     : ∀ {A} (c : C A) (f : R A c → AST C R A)
+-- --                → ((P : Post A) (i : Input) (r : R A c) → Sufficient A (f r) P i)
+-- --                → (P : Post A) (i : Input)
+-- --                → opPTS c (λ r → ptAST (f r)) P i
+-- --                → P (runM (runAST (ASTop c f)) i)
+-- --                -- Sufficient A (ASTOp c f) P i
+-- --                -- → (m : AST C R A) (f : A → AST C R B)
+-- --                -- → Sufficient A m (bindPTS (λ x → ptAST (f x)) P i) i
+-- --                -- → (∀ x i' → Sufficient B (f x) P i')
+-- --                -- → Sufficient B (ASTbind m f) P i
+
+-- --   sufficient : ∀ {A} → (m : AST C R A) (P : Post A) (i : Input) → Sufficient A m P i
+-- --   sufficient (ASTreturn x) P i wp = returnPT x wp
+-- --   sufficient (ASTbind m f) P i wp
+-- --     with sufficient m (bindPTS (λ x → ptAST (f x)) P i) i wp
+-- --   ... | wp' = bindPT i m f wp' (λ x i' → sufficient (f x) P i')
+-- --   sufficient{A} (ASTop c f) P i wp =
+-- --     opPT c f ih P i wp
+-- --     where
+-- --     ih : (P : Post A) (i : Input) (r : R A c) → Sufficient A (f r) P i
+-- --     ih P i r = sufficient (f r) P i
+
+-- -- module RWS (Ev Wr St : Set) where
+
+-- --   data C (A : Set) : Set₁ where
+-- --     RWSgets  : (St → A) → C A
+-- --     RWSputs  : (St → St) → A ≡ Unit → C A
+-- --     RWSask   : (A ≡ Ev) → C A
+-- --     RWSlocal : (Ev → Ev) → C A
+-- --     RWStell  : List Wr → (A ≡ Unit) → C A
+
+-- --   R : (A : Set) (c : C A) → Set₁
+-- --   R A (RWSgets x) = Level.Lift _ ⊥
+-- --   R .Unit (RWSputs f refl) = Level.Lift _ ⊥
+-- --   R .Ev (RWSask refl) = Level.Lift _ ⊥
+-- --   R A (RWSlocal x) = Level.Lift _ ⊤
+-- --   R A (RWStell x refl) = Level.Lift _ ⊥
+
+-- --   RWSOpSem : ASTOpSem C R
+-- --   ASTOpSem.M       RWSOpSem A = (ev : Ev) (st : St) (log : List Wr) → A × St × List Wr
+-- --   ASTOpSem.monadM RWSOpSem = {!!}
+-- --   -- ASTOpSem.returnI RWSOpSem x ev st log = x , st , log
+-- --   -- ASTOpSem.bindI   RWSOpSem x f ev st outs =
+-- --   --   let (x₁ , st₁ , outs₁) = x ev st outs
+-- --   --       (x₂ , st₂ , outs₂) = f x₁ ev st₁ outs₁
+-- --   --   in x₂ , st₂ , outs₂
+-- --   ASTOpSem.opM     RWSOpSem (RWSgets g) f ev st outs =
+-- --     (g st) , st , outs
+-- --   ASTOpSem.opM     RWSOpSem (RWSputs p refl) f ev st outs =
+-- --     unit , p st , outs
+-- --   ASTOpSem.opM     RWSOpSem (RWSask refl) f ev st outs =
+-- --     ev , st , outs
+-- --   ASTOpSem.opM     RWSOpSem (RWSlocal l) f ev st outs =
+-- --     f (Level.lift _) (l ev) st outs
+-- --   ASTOpSem.opM     RWSOpSem (RWStell t refl) f ev st outs =
+-- --     unit , st , outs ++ t
+
+-- --   RWSPredTrans : ASTPredTrans C R
+-- --   ASTPredTrans.Input RWSPredTrans = Ev × St × List Wr
+-- --   ASTPredTrans.Output RWSPredTrans A = A × St × List Wr
+-- --   ASTPredTrans.returnPTS RWSPredTrans x Post (ev , pre , outs) =
+-- --     Post (x , pre , outs)
+-- --   ASTPredTrans.bindPTS RWSPredTrans wp Post (ev , st₀ , outs₀) (x₁ , st₁ , outs₁) =
+-- --     ∀ r → r ≡ x₁ → wp r Post (ev , st₁ , outs₁)
+-- --   ASTPredTrans.opPTS RWSPredTrans (RWSgets g) _ Post (ev , pre , outs) =
+-- --     Post (g pre , pre , outs)
+-- --   ASTPredTrans.opPTS RWSPredTrans (RWSputs p refl) x Post (ev , pre , outs) =
+-- --     Post (unit , p pre , outs)
+-- --   ASTPredTrans.opPTS RWSPredTrans (RWSask refl) _ Post (ev , pre , outs) =
+-- --     Post (ev , pre , outs)
+-- --   ASTPredTrans.opPTS RWSPredTrans (RWSlocal l) f Post (ev , pre , outs) =
+-- --     ∀ ev' → ev' ≡ l ev → f (Level.lift _) Post (l ev , pre , outs)
+-- --   ASTPredTrans.opPTS RWSPredTrans (RWStell outs refl) x Post (ev , pre , outs₀) =
+-- --     Post (unit , pre , outs₀ ++ outs)
+
+-- --   RWSWeakestPre : ASTWeakestPre C R RWSOpSem RWSPredTrans
+-- --   ASTWeakestPre.runM RWSWeakestPre f (ev , pre , outs) = f ev pre outs
+-- --   ASTWeakestPre.returnPT RWSWeakestPre x wp = wp
+-- --   ASTWeakestPre.bindPT RWSWeakestPre (ev , pre , outs) m f wp suf
+-- --     with ASTOpSem.runAST RWSOpSem m ev pre outs
+-- --   ... | (x , st₁ , outs₁) =
+-- --     suf x (ev , st₁ , outs₁) (wp x refl)
+-- --   ASTWeakestPre.opPT RWSWeakestPre (RWSgets g) f ih P i wp = wp
+-- --   ASTWeakestPre.opPT RWSWeakestPre (RWSputs p refl) f ih P i wp = wp
+-- --   ASTWeakestPre.opPT RWSWeakestPre (RWSask refl) f ih P i wp = wp
+-- --   ASTWeakestPre.opPT RWSWeakestPre (RWSlocal l) f ih P (ev , pre , outs₀) wp =
+-- --     ih P ((l ev , pre , outs₀)) (Level.lift tt) (wp _ refl)
+-- --   ASTWeakestPre.opPT RWSWeakestPre (RWStell outs refl) f ih P i wp = wp
+
+-- -- module Branching where
+-- --   data C (A : Set) : Set₁ where
+-- --     ASTif : Guards Unit → C A
+-- --     ASTeither : (A₁ A₂ : Set) → Either A₁ A₂ → C A
+-- --     ASTmaybe  : (A₁ : Set) → Maybe A₁ → C A
+
+-- --   R : (A : Set) (c : C A) → Set₁
+-- --   R A (ASTif gs) = Level.Lift _ (Fin (lengthGuards gs))
+-- --   R A (ASTeither A₁ A₂ _) = Level.Lift _ (Either A₁ A₂)
+-- --   R A (ASTmaybe A₁ _)     = Level.Lift _ (Maybe A₁)
+
+-- -- module BranchExtend
+-- --   (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁)
+-- --   where
+
+-- --   CBranch : Set → Set₁
+-- --   CBranch A = Either (C A) (Branching.C A)
+
+-- --   RBranch : (A : Set) (c : CBranch A) → Set₁
+-- --   RBranch A (Left x) = R A x
+-- --   RBranch A (Right y) = Branching.R A y
+
+-- --   module OpSem (interp : ASTOpSem C R) where
+
+-- --     interpGuards : ∀ {A : Set} (gs : Guards{b = Level.zero} Unit) (f : Level.Lift (Level.suc Level.zero) (Fin (lengthGuards gs)) → ASTOpSem.M interp A)
+-- --                    → ASTOpSem.M interp A
+-- --     interpGuards (otherwise≔ x) f = f (Level.lift zero)
+-- --     interpGuards (clause (x ≔ x₁) gs) f
+-- --       with toBool x
+-- --     ... | false = interpGuards gs λ { (Level.lift n) → f (Level.lift (suc n))}
+-- --     ... | true = f (Level.lift zero)
+
+-- --     BranchExtendOpSem : ASTOpSem CBranch RBranch
+-- --     ASTOpSem.M       BranchExtendOpSem = ASTOpSem.M interp
+-- --     ASTOpSem.monadM  BranchExtendOpSem = {!!}
+-- --     -- ASTOpSem.returnI BranchExtendOpSem = ASTOpSem.returnI interp
+-- --     -- ASTOpSem.bindI   BranchExtendOpSem = ASTOpSem.bindI interp
+-- --     ASTOpSem.opM     BranchExtendOpSem (Left c) f = ASTOpSem.opM interp c f
+-- --     ASTOpSem.opM     BranchExtendOpSem (Right (Branching.ASTif gs)) f = interpGuards gs f
+-- --     ASTOpSem.opM     BranchExtendOpSem (Right (Branching.ASTeither A₁ A₂ x₁)) f = f (Level.lift x₁)
+-- --     ASTOpSem.opM     BranchExtendOpSem (Right (Branching.ASTmaybe A₁ x₁)) f = f (Level.lift x₁)
+
+-- --   module PT (interp : ASTPredTrans C R) where
+-- --     open ASTPredTrans interp
+
+-- --     interpGuards : ∀ {A} → (gs : Guards{b = Level.zero} Unit) → (Level.Lift (Level.suc Level.0ℓ) (Fin (lengthGuards gs)) → PredTrans A) 
+-- --                    → PredTrans A
+-- --     interpGuards (otherwise≔ c) ih P i =
+-- --       ih (Level.lift Fin.zero) P i
+-- --     interpGuards (clause (b ≔ c) gs) ih P i =
+-- --         (toBool b ≡ true  → ih (Level.lift Fin.zero) P i)
+-- --       × (toBool b ≡ false →
+-- --         interpGuards gs (λ where (Level.lift i) → ih (Level.lift (Fin.suc i))) P i)
+
+-- --     BranchExtendPredTrans : ASTPredTrans CBranch RBranch
+-- --     ASTPredTrans.Input     BranchExtendPredTrans = Input
+-- --     ASTPredTrans.Output    BranchExtendPredTrans = Output
+-- --     ASTPredTrans.returnPTS BranchExtendPredTrans = returnPTS
+-- --     ASTPredTrans.bindPTS   BranchExtendPredTrans = bindPTS
+-- --     ASTPredTrans.opPTS BranchExtendPredTrans (Left c) ih P i =
+-- --       opPTS c ih P i
+-- --     ASTPredTrans.opPTS BranchExtendPredTrans (Right (Branching.ASTif gs)) ih P i =
+-- --       interpGuards gs ih P i
+-- --     ASTPredTrans.opPTS BranchExtendPredTrans (Right (Branching.ASTeither A₁ A₂ e)) ih P i =
+-- --         (∀ x → (e ≡ Left x ) → ih (Level.lift (Left  x)) P i)
+-- --       × (∀ y → (e ≡ Right y) → ih (Level.lift (Right y)) P i)
+-- --     ASTPredTrans.opPTS BranchExtendPredTrans (Right (Branching.ASTmaybe A₁ m)) ih P i =
+-- --         m ≡ nothing → ih (Level.lift nothing) P i
+-- --       × (∀ x → m ≡ just x → ih (Level.lift (just x)) P i)
 
 
-module RWS (Ev Wr St : Set) where
+-- --   module Sufficient
+-- --     (interpOS : ASTOpSem C R) (interpPT : ASTPredTrans C R)
+-- --     (suf : ASTWeakestPre C R interpOS interpPT)
+-- --     where
 
-  data C (A : Set) : Set₁ where
-    RWSgets  : (St → A) → C A
-    RWSputs  : (St → St) → A ≡ Unit → C A
-    RWSask   : (A ≡ Ev) → C A
-    RWSlocal : (Ev → Ev) → C A
-    RWStell  : List Wr → (A ≡ Unit) → C A
+-- --     open ASTOpSem      interpOS
+-- --     open OpSem         interpOS
+-- --     open ASTPredTrans  interpPT
+-- --     open PT            interpPT
+-- --     open ASTWeakestPre suf
 
-  R : (A : Set) (c : C A) → Set₁
-  R A (RWSgets x) = Level.Lift _ ⊥
-  R .Unit (RWSputs f refl) = Level.Lift _ ⊥
-  R .Ev (RWSask refl) = Level.Lift _ ⊥
-  R A (RWSlocal x) = Level.Lift _ ⊤
-  R A (RWStell x refl) = Level.Lift _ ⊥
+-- --     BranchExtendWeakestPre :
+-- --       ASTWeakestPre CBranch RBranch BranchExtendOpSem BranchExtendPredTrans
+-- --     ASTWeakestPre.runM     BranchExtendWeakestPre = runM
+-- --     ASTWeakestPre.returnPT BranchExtendWeakestPre = returnPT
 
-  RWSOpSem : ASTOpSem C R
-  ASTOpSem.M       RWSOpSem A = (ev : Ev) (st : St) → A × St × List Wr
-  ASTOpSem.returnI RWSOpSem x ev st = x , st , []
-  ASTOpSem.bindI   RWSOpSem x f ev st =
-    let (x₁ , st₁ , outs₁) = x ev st
-        (x₂ , st₂ , outs₂) = f x₁ ev st₁
-    in x₂ , st₂ , outs₁ ++ outs₂
-  ASTOpSem.opI     RWSOpSem (RWSgets g) f ev st =
-    (g st) , st , []
-  ASTOpSem.opI     RWSOpSem (RWSputs p refl) f ev st =
-    unit , p st , []
-  ASTOpSem.opI     RWSOpSem (RWSask refl) f ev st =
-    ev , st , []
-  ASTOpSem.opI     RWSOpSem (RWSlocal l) f ev st =
-    f (Level.lift _) (l ev) st
-  ASTOpSem.opI     RWSOpSem (RWStell t refl) f ev st =
-    unit , st , t
+-- --     ASTWeakestPre.bindPT BranchExtendWeakestPre i (ASTreturn x) f wp ih = {!!}
+-- --     ASTWeakestPre.bindPT BranchExtendWeakestPre i (ASTbind m x) f wp ih = {!!}
+-- --     ASTWeakestPre.bindPT BranchExtendWeakestPre i (ASTop c x) f wp ih = {!!}
 
-module Branching where
-  data C (A : Set) : Set₁ where
-    ASTif : Guards Unit → C A
-    ASTeither : (A₁ A₂ : Set) → Either A₁ A₂ → C A
-    ASTmaybe  : (A₁ : Set) → Maybe A₁ → C A
-
-  R : (A : Set) (c : C A) → Set₁
-  R A (ASTif gs) = Level.Lift _ (Fin (lengthGuards gs))
-  R A (ASTeither A₁ A₂ _) = Level.Lift _ (Either A₁ A₂)
-  R A (ASTmaybe A₁ _)     = Level.Lift _ (Maybe A₁)
-
--- module _ {X : Set → Set}
---   (r : ∀ {A} → A → X A) (b : ∀ {A B} → X A → (A → X B) → X B)
---   where
-
---   runAST : ∀ {C R A} → AST C R A → (∀ {A} → (c : C A) → (R A c → X A) → X A) → X A
---   runAST (ASTreturn x) op = r x
---   runAST (ASTbind x f) op = b (runAST x op) (λ y → runAST (f y) op)
---   runAST (ASTop c f)   op = op c (λ ret → runAST (f ret) op)
-
-private
-  module BranchExtend
-    (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁)
-    (interp : ASTOpSem C R)
-    where
-
-    CBranch : Set → Set₁
-    CBranch A = Either (C A) (Branching.C A)
-
-    RBranch : (A : Set) (c : CBranch A) → Set₁
-    RBranch A (Left x) = R A x
-    RBranch A (Right y) = Branching.R A y
-
-    interpGuards : ∀ {A : Set} (gs : Guards{b = Level.zero} Unit) (f : Level.Lift (Level.suc Level.zero) (Fin (lengthGuards gs)) → ASTOpSem.M interp A)
-                   → ASTOpSem.M interp A
-    interpGuards (otherwise≔ x) f = f (Level.lift zero)
-    interpGuards (clause (x ≔ x₁) gs) f
-      with toBool x
-    ... | false = interpGuards gs λ { (Level.lift n) → f (Level.lift (suc n))}
-    ... | true = f (Level.lift zero)
-
-    Interp : ASTOpSem CBranch RBranch
-    ASTOpSem.M       Interp = ASTOpSem.M interp
-    ASTOpSem.returnI Interp = ASTOpSem.returnI interp
-    ASTOpSem.bindI   Interp = ASTOpSem.bindI interp
-    ASTOpSem.opI     Interp (Left c) f = ASTOpSem.opI interp c f
-    ASTOpSem.opI     Interp (Right (Branching.ASTif gs)) f = interpGuards gs f
-    ASTOpSem.opI     Interp (Right (Branching.ASTeither A₁ A₂ x₁)) f = f (Level.lift x₁)
-    ASTOpSem.opI     Interp (Right (Branching.ASTmaybe A₁ x₁)) f = f (Level.lift x₁)
+-- --     ASTWeakestPre.opPT     BranchExtendWeakestPre = {!!}

--- a/src/Dijkstra/AST.agda
+++ b/src/Dijkstra/AST.agda
@@ -15,244 +15,250 @@ open import Haskell.Prelude
 import      Level
 open import Relation.Binary.PropositionalEquality
 
-data AST (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set → Set₁ where
+data AST
+  (Cₘ : Set) (Rₘ : Cₘ → Set → Set)
+  (Cₒ : Set → Set₁) (Rₒ : (A : Set) (c : Cₒ A) → Set₁) : Set → Set₁ where
   -- monadic operations
-  ASTreturn : ∀ {A} → A → AST C R A
-  ASTbind   : ∀ {A B} → AST C R A → (A → AST C R B) → AST C R B
+  ASTreturn : ∀ {A} → A → AST Cₘ Rₘ Cₒ Rₒ A
+  ASTbind   : ∀ {A B} → (c : Cₘ) (m : AST Cₘ Rₘ Cₒ Rₒ (Rₘ c A)) (f : A → AST Cₘ Rₘ Cₒ Rₒ B)
+              → AST Cₘ Rₘ Cₒ Rₒ B
   -- effect operations
-  ASTop : ∀ {A} → (c : C A) → (R A c → AST C R A) → AST C R A
+  ASTop : ∀ {A} → (c : Cₒ A) (f : Rₒ A c → AST Cₘ Rₘ Cₒ Rₒ A) → AST Cₘ Rₘ Cₒ Rₒ A
 
 record ASTOpSemTypes : Set₁ where
   constructor mkASTOpSemTypes
   field
     Input  : Set
-    Output : Set → Set
+    Output : (A : Set) → Set
 
-record ASTOpSemImpl (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set₁ where
-  constructor mkASTOpSemImpl
+record ASTImpl
+  (Cₘ : Set) (Rₘ : Cₘ → Set → Set)
+  (Cₒ : Set → Set₁) (Rₒ : (A : Set) (c : Cₒ A) → Set₁) : Set₁ where
+  constructor mkASTImpl
   field
-    -- Implementation
-    M          : Set → Set
-    ⦃ monadM ⦄ : Monad M
-    opM        : ∀ {A} → (c : C A) → (R A c → M A) → M A
+    M : Set → Set
+    runAST : ∀ {A} → AST Cₘ Rₘ Cₒ Rₒ A → M A
 
-  runAST : ∀ {A} → AST C R A → M A
-  runAST (ASTreturn x) = return x
-  runAST (ASTbind p f) = runAST p >>= λ x → runAST (f x)
-  runAST (ASTop c f) = opM c (λ x → runAST (f x))
+record MonadAST
+  (Cₘ : Set) (Rₘ : Cₘ → Set → Set)
+  (Cₒ : Set → Set₁) (Rₒ : (A : Set) (c : Cₒ A) → Set₁)
+  (M : Set → Set): Set₁ where
+  field
+    ret : ∀ {A} → A → M A
+    bind   : ∀ {A B} → (c : Cₘ) (m : M (Rₘ c A)) (f : A → M B) → M B
+    op     : ∀ {A}  → (c : Cₒ A) (f : Rₒ A c → M A) → M A
 
+  impl : ASTImpl Cₘ Rₘ Cₒ Rₒ
+  ASTImpl.M impl = M
+  ASTImpl.runAST impl (ASTreturn x) = ret x
+  ASTImpl.runAST impl (ASTbind c x f) = bind c (ASTImpl.runAST impl x) (ASTImpl.runAST impl ∘ f)
+  ASTImpl.runAST impl (ASTop c f) = op c (ASTImpl.runAST impl ∘ f)
+open MonadAST ⦃ ... ⦄ public
+  hiding (impl)
 
-record ASTOpSem (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set₁ where
+record ASTOpSem
+  (Cₘ : Set) (Rₘ : Cₘ → Set → Set)
+  (Cₒ : Set → Set₁) (Rₒ : (A : Set) (c : Cₒ A) → Set₁)
+  (Types : ASTOpSemTypes) : Set₁ where
   constructor mkASTOpSem
+  open ASTOpSemTypes Types public
   field
-    IO : ASTOpSemTypes
-  open ASTOpSemTypes IO public
-  field
-    impl : ASTOpSemImpl C R
-  open ASTOpSemImpl impl public
+    impl : ASTImpl Cₘ Rₘ Cₒ Rₒ
+  open ASTImpl impl public
   field
     runM : ∀ {A} → M A → Input → Output A
 
-  -- Coherence
-    runMIdLeft  : ∀ {A} (x : A) (f : A → AST C R A) (i : Input)
-                  →   runM (runAST (ASTbind (ASTreturn x) f)) i
-                    ≡ runM (runAST (f x)) i
-    runMIdRight : ∀ {A} (m : AST C R A) (i : Input)
-                  →   runM (runAST (ASTbind m ASTreturn)) i
-                    ≡ runM (runAST m) i
-    runMAssoc   : ∀ {A B₁ B₂} (m : AST C R A) (f : A → AST C R B₁) (g : B₁ → AST C R B₂) (i : Input)
-                  →   runM (runAST (ASTbind (ASTbind m f) g)) i
-                    ≡ runM (runAST (ASTbind m (λ x → ASTbind (f x) g))) i
+--   -- -- Coherence
+--   --   runMIdLeft  : ∀ {A} (x : A) (f : A → AST C R A) (i : Input)
+--   --                 →   runM (runAST (ASTbind (ASTreturn x) f)) i
+--   --                   ≡ runM (runAST (f x)) i
+--   --   runMIdRight : ∀ {A} (m : AST C R A) (i : Input)
+--   --                 →   runM (runAST (ASTbind m ASTreturn)) i
+--   --                   ≡ runM (runAST m) i
+--   --   runMAssoc   : ∀ {A B₁ B₂} (m : AST C R A) (f : A → AST C R B₁) (g : B₁ → AST C R B₂) (i : Input)
+--   --                 →   runM (runAST (ASTbind (ASTbind m f) g)) i
+--   --                   ≡ runM (runAST (ASTbind m (λ x → ASTbind (f x) g))) i
 
+
+module TrivASTBind where
+  Cₘ : Set
+  Cₘ = Unit
+
+  Rₘ : Cₘ → Set → Set
+  Rₘ _ = id
 
 module SimpleASTOpSem
-  (I : Set) (O : Set → Set)
-  where
+  (Cₘ : Set) (Rₘ : Cₘ → Set → Set)
+  (Cₒ : Set → Set₁) (Rₒ : (A : Set) (c : Cₒ A) → Set₁)
+  (Types : ASTOpSemTypes)
+  (monadOp : MonadAST Cₘ Rₘ Cₒ Rₒ λ A → ASTOpSemTypes.Input Types → ASTOpSemTypes.Output Types A) where
+
+  OS : ASTOpSem Cₘ Rₘ Cₒ Rₒ Types
+  ASTOpSem.impl OS = MonadAST.impl monadOp
+  ASTOpSem.runM OS = id
+
+record ASTPredTrans
+  (Cₘ : Set) (Rₘ : Cₘ → Set → Set)
+  (Cₒ : Set → Set₁) (Rₒ : (A : Set) (c : Cₒ A) → Set₁)
+  (Types : ASTOpSemTypes) : Set₂ where
+  constructor mkASTPredTrans
+  open ASTOpSemTypes Types public
+
+  Pre : Set₁
+  Pre = (i : Input) → Set
+
+  Post : Set → Set₁
+  Post A = Output A → Set
+
+  PredTrans : (A : Set) → Set₁
+  PredTrans A = (P : Post A) → Pre
+  
+  field
+    returnPTS : ∀ {A} → A → PredTrans A
+    bindPTS   : ∀ {A B} → (c : Cₘ) (f : A → PredTrans B) (i : Input) (P : Post B) → Post (Rₘ c A)
+    opPTS     : ∀ {A} → (c : Cₒ A) → (Rₒ A c → PredTrans A) → PredTrans A
+
+  ptAST : ∀ {A} → AST Cₘ Rₘ Cₒ Rₒ A → PredTrans A
+  ptAST (ASTreturn x) = returnPTS x
+  ptAST (ASTbind c p f) Post input =
+    ptAST p (bindPTS c (λ x → ptAST ((f x))) input Post) input
+  ptAST (ASTop c f) Post = opPTS c (λ r → ptAST (f r)) Post
+
+record ASTSufficientPre
+  (Cₘ : Set) (Rₘ : Cₘ → Set → Set)
+  (Cₒ : Set → Set₁) (Rₒ : (A : Set) (c : Cₒ A) → Set₁)
+  (Types : ASTOpSemTypes)
+  (os : ASTOpSem Cₘ Rₘ Cₒ Rₒ Types) (pt : ASTPredTrans Cₘ Rₘ Cₒ Rₒ Types) : Set₁ where
+  constructor mkASTSufficientPre
+  open ASTOpSem     os
+  open ASTPredTrans pt
+    hiding (Input ; Output)
+
+  Sufficient : (A : Set) (m : AST Cₘ Rₘ Cₒ Rₒ A) (P : Post A) (i : Input) → Set
+  Sufficient A m P i =
+    (wp : ptAST m P i) → P (runM (runAST m) i)
+
+  field
+    returnSuf : ∀ {A} (x : A) {P} {i} → Sufficient A (ASTreturn x) P i
+    bindSuf   : ∀ {A B} (c : Cₘ) (m : AST Cₘ Rₘ Cₒ Rₒ (Rₘ c A)) (f : A → AST Cₘ Rₘ Cₒ Rₒ B)
+                → (ih : ∀ x P i → Sufficient B (f x) P i)
+                → ∀ P i
+                → (bp : bindPTS c (λ x' → ptAST (f x')) i P (runM (runAST m) i))
+                → P (runM (runAST (ASTbind c m f)) i)
+    opSuf     : ∀ {A} (c : Cₒ A) (f : Rₒ A c → AST Cₘ Rₘ Cₒ Rₒ A)
+                → (ih : ∀ P i r → Sufficient A (f r) P i)
+                → ∀ P i
+                → (op : opPTS c (λ r → ptAST (f r)) P i)
+                → P (runM (runAST (ASTop c f)) i)
+
+  sufficient : ∀ {A} → (m : AST Cₘ Rₘ Cₒ Rₒ A) (P : Post A) (i : Input) → Sufficient A m P i
+  sufficient (ASTreturn x) P i wp = returnSuf x wp
+  sufficient (ASTbind c m f) P i wp
+    with sufficient m _ i wp
+  ... | wp' = bindSuf c m f (sufficient ∘ f) P i wp'
+  sufficient{A} (ASTop c f) P i wp =
+    opSuf c f ih P i wp
+    where
+    ih : (P : Post A) (i : Input) (r : Rₒ A c) → Sufficient A (f r) P i
+    ih P i r = sufficient (f r) P i
+
+module RWS (Ev Wr St : Set) where
+
+  data C (A : Set) : Set₁ where
+    RWSgets  : (g : St → A) → C A
+    RWSputs  : (p : St → St) → A ≡ Unit → C A
+    RWSask   : (A ≡ Ev) → C A
+    RWSlocal : (l : Ev → Ev) → C A
+    RWStell  : (outs : List Wr) → (A ≡ Unit) → C A
+
+  R : (A : Set) (c : C A) → Set₁
+  R A (RWSgets x) = Level.Lift _ ⊥
+  R .Unit (RWSputs f refl) = Level.Lift _ ⊥
+  R .Ev (RWSask refl) = Level.Lift _ ⊥
+  R A (RWSlocal x) = Level.Lift _ ⊤
+  R A (RWStell x refl) = Level.Lift _ ⊥
+
+  RWS : Set → Set₁
+  RWS = AST TrivASTBind.Cₘ TrivASTBind.Rₘ C R
+
+  Types : ASTOpSemTypes
+  ASTOpSemTypes.Input Types = Ev × St
+  ASTOpSemTypes.Output Types A = A × St × List Wr
 
   M : Set → Set
-  M A = I → O A
+  M A = ASTOpSemTypes.Input Types → ASTOpSemTypes.Output Types A
 
-  module _
-    (m : Monad M) (ml : MonadLaws M ⦃ m ⦄) where
+  monadAST : MonadAST TrivASTBind.Cₘ TrivASTBind.Rₘ C R M
+  MonadAST.ret monadAST x (ev , st) = x , st , []
+  MonadAST.bind monadAST _ m f i@(ev , st₀) =
+    let (x₁ , st₁ , outs₁) = m i
+        (x₂ , st₂ , outs₂) = f x₁ (ev , st₁)
+    in  (x₂ , st₂ , outs₁ ++ outs₂)
+  MonadAST.op monadAST (RWSgets g) _ i@(ev , st) =
+    g st , st , []
+  MonadAST.op monadAST (RWSputs p refl) _ i@(ev , st) =
+    unit , p st , []
+  MonadAST.op monadAST (RWSask refl) _ i@(ev , st) =
+    ev , st , []
+  MonadAST.op monadAST (RWSlocal l) f i@(ev , st) =
+    f (Level.lift tt) (l ev , st)
+  MonadAST.op monadAST (RWStell outs refl) _ i@(ev , st) =
+    unit , st , outs
 
-    os : ∀ {C R} → (opM : ∀ {A} → (c : C A) → (R A c → M A) → M A)
-         → ASTOpSem C R
-    ASTOpSemTypes.Input (ASTOpSem.IO (os opM)) = I
-    ASTOpSemTypes.Output (ASTOpSem.IO (os opM)) = O
-    ASTOpSemImpl.M (ASTOpSem.impl (os opM)) = M
-    ASTOpSemImpl.monadM (ASTOpSem.impl (os opM)) = m
-    ASTOpSemImpl.opM (ASTOpSem.impl (os opM)) = opM
-    ASTOpSem.runM (os opM) = id
-    ASTOpSem.runMIdLeft (os opM) x f i =
-      {!MonadLaws.idLeft ⦃ m = m ⦄ ml x ?!}
-    ASTOpSem.runMIdRight (os opM) = {!!}
-    ASTOpSem.runMAssoc (os opM) = {!!}
+  OS = SimpleASTOpSem.OS TrivASTBind.Cₘ TrivASTBind.Rₘ C R Types monadAST
 
+  RWSPredTrans = ASTPredTrans TrivASTBind.Cₘ TrivASTBind.Rₘ C R Types
 
-  -- runM : ∀ {A} → M A → I → O A
-  -- runM m = m
+  RWSbindPost : List Wr → {A : Set} → (A × St × List Wr → Set) → (A × St × List Wr → Set)
+  RWSbindPost outs P (x , st , outs') = P (x , st , outs ++ outs')
 
-  -- impl : ⦃ _ : Monad O ⦄ → ASTOpSemImpl C R
-  -- ASTOpSemImpl.M impl = M
-  -- Monad.return (ASTOpSemImpl.monadM impl) x i = return x
-  -- Monad._>>=_ (ASTOpSemImpl.monadM impl) m f i =
-  --   let o = m i
-  --   in o >>= λ x → f x (step o)
-  -- ASTOpSemImpl.opM impl = {!!}
+  PT : RWSPredTrans
+  ASTPredTrans.returnPTS PT x P (ev , st) =
+    P (x , st , [])
+  ASTPredTrans.bindPTS PT c f (ev , stₒ) P (x , st₁ , outs₁) =
+    ∀ r → r ≡ x → f r (RWSbindPost outs₁ P) (ev , st₁)
+  ASTPredTrans.opPTS PT (RWSgets g) f P (ev , pre) =
+    P (g pre , pre , [])
+  ASTPredTrans.opPTS PT (RWSputs p refl) f P (ev , pre) =
+    P (unit , p pre , [])
+  ASTPredTrans.opPTS PT (RWSask refl) f P (ev , pre) =
+    P (ev , pre , [])
+  ASTPredTrans.opPTS PT (RWSlocal l) f P (ev , pre) =
+    ∀ ev' → ev' ≡ l ev → f (Level.lift tt) P (ev' , pre)
+  ASTPredTrans.opPTS PT (RWStell outs refl) f P (ev , pre) =
+    P (unit , pre , outs)
 
-  -- opSem : ⦃ _ : Monad O ⦄ → (ml : MonadLaws O) → ASTOpSem C R
-  -- ASTOpSemTypes.Input (ASTOpSem.IO (opSem ml)) = I
-  -- ASTOpSemTypes.Output (ASTOpSem.IO (opSem ml)) = O
-  -- ASTOpSem.impl (opSem ml) = impl
-  -- ASTOpSem.runM (opSem ml) = runM
-  -- ASTOpSem.runMIdLeft (opSem ml) x f i
-  --   =   (return x >>= λ y → ASTOpSemImpl.runAST impl (f y) (step (return x)))
-  --     ≡ {!!} ∋ {!!}
-  -- ASTOpSem.runMIdRight (opSem ml) = {!!}
-  -- ASTOpSem.runMAssoc (opSem ml) = {!!}
+  RWSSufficientPre =
+    ASTSufficientPre TrivASTBind.Cₘ TrivASTBind.Rₘ C R Types OS PT
 
--- simpleASTOpSem : ∀ {C R} → ASTOpSemTypes C R → ASTOpSem C R
--- ASTOpSem.IO (simpleASTOpSem x) = x
--- ASTOpSemImpl.M (ASTOpSem.impl (simpleASTOpSem x)) =
---   λ A → ASTOpSemTypes.Input x → ASTOpSemTypes.Output x A
--- ASTOpSemImpl.monadM (ASTOpSem.impl (simpleASTOpSem x)) = {!!}
--- ASTOpSemImpl.opM (ASTOpSem.impl (simpleASTOpSem x)) = {!!}
--- ASTOpSem.runM (simpleASTOpSem x) = {!!}
--- ASTOpSem.runMLaw1 (simpleASTOpSem x) = {!!}
+  SufPre : RWSSufficientPre
+  ASTSufficientPre.returnSuf SufPre x wp = wp
+  ASTSufficientPre.bindSuf SufPre c m f suf P i@(ev , st₀) wp =
+    let (x₁ , st₁ , outs₁) = ASTOpSem.runAST OS m i
+    in suf x₁ (RWSbindPost outs₁ P) ((ev , st₁)) (wp x₁ refl)
+  ASTSufficientPre.opSuf SufPre (RWSgets g) f ih P i@(ev , st₀) op₁ =
+    op₁
+  ASTSufficientPre.opSuf SufPre (RWSputs p refl) f ih P i@(ev , st₀) op₁ =
+    op₁
+  ASTSufficientPre.opSuf SufPre (RWSask refl) f ih P i@(ev , st₀) op₁ = op₁
+  ASTSufficientPre.opSuf SufPre (RWSlocal l) f ih P i@(ev , st₀) op₁ =
+    ih P (l ev , st₀) (Level.lift tt) (op₁ (l ev) refl)
+  ASTSufficientPre.opSuf SufPre (RWStell outs refl) f ih P i@(ev , st₀) op₁ =
+    op₁
 
--- -- record ASTPredTrans (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set₂ where
--- --   constructor mkASTPredTrans
--- --   field
--- --     Input  : Set
--- --     Output : Set → Set
-
--- --   Pre : Set₁
--- --   Pre = Input → Set
-
--- --   Post : Set → Set₁
--- --   Post A = Output A → Set
-
--- --   PredTrans : (A : Set) → Set₁
--- --   PredTrans A = Post A → Pre
-  
--- --   field
--- --     returnPTS : ∀ {A} → A → PredTrans A
--- --     bindPTS   : ∀ {A B} → (A → PredTrans B) → Post B → Input → Post A
--- --     opPTS     : ∀ {A} → (c : C A) → (R A c → PredTrans A) → PredTrans A
-
--- --   ptAST : ∀ {A} → AST C R A → PredTrans A
--- --   ptAST (ASTreturn x) = returnPTS x
--- --   ptAST (ASTbind p f) Post input =
--- --     ptAST p (bindPTS (λ x → ptAST (f x)) Post input) input
--- --   ptAST (ASTop c f) Post = opPTS c (λ r → ptAST (f r)) Post
-
--- -- record ASTWeakestPre
--- --   (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁)
--- --   (os : ASTOpSem C R) (pt : ASTPredTrans C R) : Set₁ where
--- --   constructor mkASTWeakestPre
--- --   open ASTOpSem     os
--- --   open ASTPredTrans pt
--- --   field
--- --     runM : ∀ {A} → M A → Input → Output A
-
--- --   Sufficient : (A : Set) (m : AST C R A) (P : Post A) (i : Input) → Set
--- --   Sufficient A m P i =
--- --     ptAST m P i → P (runM (runAST m) i)
-
--- --   field
--- --     returnPT : ∀ {A} (x : A) {P} {i} → Sufficient A (ASTreturn x) P i
--- --     bindPT   : ∀ {A B P} i (m : AST C R A) (f : A → AST C R B)
--- --                → (wp : bindPTS (λ x → ptAST (f x)) P i (runM (runAST m) i))
--- --                → (∀ x i' → Sufficient B (f x) P i')
--- --                → P (runM (runAST (ASTbind m f)) i)
--- --     opPT     : ∀ {A} (c : C A) (f : R A c → AST C R A)
--- --                → ((P : Post A) (i : Input) (r : R A c) → Sufficient A (f r) P i)
--- --                → (P : Post A) (i : Input)
--- --                → opPTS c (λ r → ptAST (f r)) P i
--- --                → P (runM (runAST (ASTop c f)) i)
--- --                -- Sufficient A (ASTOp c f) P i
--- --                -- → (m : AST C R A) (f : A → AST C R B)
--- --                -- → Sufficient A m (bindPTS (λ x → ptAST (f x)) P i) i
--- --                -- → (∀ x i' → Sufficient B (f x) P i')
--- --                -- → Sufficient B (ASTbind m f) P i
-
--- --   sufficient : ∀ {A} → (m : AST C R A) (P : Post A) (i : Input) → Sufficient A m P i
--- --   sufficient (ASTreturn x) P i wp = returnPT x wp
--- --   sufficient (ASTbind m f) P i wp
--- --     with sufficient m (bindPTS (λ x → ptAST (f x)) P i) i wp
--- --   ... | wp' = bindPT i m f wp' (λ x i' → sufficient (f x) P i')
--- --   sufficient{A} (ASTop c f) P i wp =
--- --     opPT c f ih P i wp
--- --     where
--- --     ih : (P : Post A) (i : Input) (r : R A c) → Sufficient A (f r) P i
--- --     ih P i r = sufficient (f r) P i
-
--- -- module RWS (Ev Wr St : Set) where
-
--- --   data C (A : Set) : Set₁ where
--- --     RWSgets  : (St → A) → C A
--- --     RWSputs  : (St → St) → A ≡ Unit → C A
--- --     RWSask   : (A ≡ Ev) → C A
--- --     RWSlocal : (Ev → Ev) → C A
--- --     RWStell  : List Wr → (A ≡ Unit) → C A
-
--- --   R : (A : Set) (c : C A) → Set₁
--- --   R A (RWSgets x) = Level.Lift _ ⊥
--- --   R .Unit (RWSputs f refl) = Level.Lift _ ⊥
--- --   R .Ev (RWSask refl) = Level.Lift _ ⊥
--- --   R A (RWSlocal x) = Level.Lift _ ⊤
--- --   R A (RWStell x refl) = Level.Lift _ ⊥
-
--- --   RWSOpSem : ASTOpSem C R
--- --   ASTOpSem.M       RWSOpSem A = (ev : Ev) (st : St) (log : List Wr) → A × St × List Wr
--- --   ASTOpSem.monadM RWSOpSem = {!!}
--- --   -- ASTOpSem.returnI RWSOpSem x ev st log = x , st , log
--- --   -- ASTOpSem.bindI   RWSOpSem x f ev st outs =
--- --   --   let (x₁ , st₁ , outs₁) = x ev st outs
--- --   --       (x₂ , st₂ , outs₂) = f x₁ ev st₁ outs₁
--- --   --   in x₂ , st₂ , outs₂
--- --   ASTOpSem.opM     RWSOpSem (RWSgets g) f ev st outs =
--- --     (g st) , st , outs
--- --   ASTOpSem.opM     RWSOpSem (RWSputs p refl) f ev st outs =
--- --     unit , p st , outs
--- --   ASTOpSem.opM     RWSOpSem (RWSask refl) f ev st outs =
--- --     ev , st , outs
--- --   ASTOpSem.opM     RWSOpSem (RWSlocal l) f ev st outs =
--- --     f (Level.lift _) (l ev) st outs
--- --   ASTOpSem.opM     RWSOpSem (RWStell t refl) f ev st outs =
--- --     unit , st , outs ++ t
-
--- --   RWSPredTrans : ASTPredTrans C R
--- --   ASTPredTrans.Input RWSPredTrans = Ev × St × List Wr
--- --   ASTPredTrans.Output RWSPredTrans A = A × St × List Wr
--- --   ASTPredTrans.returnPTS RWSPredTrans x Post (ev , pre , outs) =
--- --     Post (x , pre , outs)
--- --   ASTPredTrans.bindPTS RWSPredTrans wp Post (ev , st₀ , outs₀) (x₁ , st₁ , outs₁) =
--- --     ∀ r → r ≡ x₁ → wp r Post (ev , st₁ , outs₁)
--- --   ASTPredTrans.opPTS RWSPredTrans (RWSgets g) _ Post (ev , pre , outs) =
--- --     Post (g pre , pre , outs)
--- --   ASTPredTrans.opPTS RWSPredTrans (RWSputs p refl) x Post (ev , pre , outs) =
--- --     Post (unit , p pre , outs)
--- --   ASTPredTrans.opPTS RWSPredTrans (RWSask refl) _ Post (ev , pre , outs) =
--- --     Post (ev , pre , outs)
--- --   ASTPredTrans.opPTS RWSPredTrans (RWSlocal l) f Post (ev , pre , outs) =
--- --     ∀ ev' → ev' ≡ l ev → f (Level.lift _) Post (l ev , pre , outs)
--- --   ASTPredTrans.opPTS RWSPredTrans (RWStell outs refl) x Post (ev , pre , outs₀) =
--- --     Post (unit , pre , outs₀ ++ outs)
-
--- --   RWSWeakestPre : ASTWeakestPre C R RWSOpSem RWSPredTrans
--- --   ASTWeakestPre.runM RWSWeakestPre f (ev , pre , outs) = f ev pre outs
--- --   ASTWeakestPre.returnPT RWSWeakestPre x wp = wp
--- --   ASTWeakestPre.bindPT RWSWeakestPre (ev , pre , outs) m f wp suf
--- --     with ASTOpSem.runAST RWSOpSem m ev pre outs
--- --   ... | (x , st₁ , outs₁) =
--- --     suf x (ev , st₁ , outs₁) (wp x refl)
--- --   ASTWeakestPre.opPT RWSWeakestPre (RWSgets g) f ih P i wp = wp
--- --   ASTWeakestPre.opPT RWSWeakestPre (RWSputs p refl) f ih P i wp = wp
--- --   ASTWeakestPre.opPT RWSWeakestPre (RWSask refl) f ih P i wp = wp
--- --   ASTWeakestPre.opPT RWSWeakestPre (RWSlocal l) f ih P (ev , pre , outs₀) wp =
--- --     ih P ((l ev , pre , outs₀)) (Level.lift tt) (wp _ refl)
--- --   ASTWeakestPre.opPT RWSWeakestPre (RWStell outs refl) f ih P i wp = wp
+-- --   RWSWeakestPre : ASTWeakestPre C R SimpleRWS.Types RWSOpSem RWSPredTrans
+-- --   ASTWeakestPre.returnPT RWSWeakestPre x pt = pt
+-- --   ASTWeakestPre.bindPT RWSWeakestPre (ev , pre) m f wp suf
+-- --     with ASTOpSem.runAST RWSOpSem m (ev , pre)
+-- --   ... | (x₁ , st₁ , outs₁) =
+-- --     suf _ x₁ (ev , st₁) (wp x₁ refl)
+-- --   ASTWeakestPre.opPT RWSWeakestPre (RWSgets g) f x P i wp = wp
+-- --   ASTWeakestPre.opPT RWSWeakestPre (RWSputs p refl) f x P i wp = wp
+-- --   ASTWeakestPre.opPT RWSWeakestPre (RWSask refl) f x P i wp = wp
+-- --   ASTWeakestPre.opPT RWSWeakestPre (RWSlocal l) f suf P (ev , pre) wp =
+-- --     let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift tt)) (l ev , pre)
+-- --     in suf P (l ev , pre) (Level.lift tt) (wp (l ev) refl)
+-- --   ASTWeakestPre.opPT RWSWeakestPre (RWStell outs refl) f x P i wp = wp
 
 -- -- module Branching where
 -- --   data C (A : Set) : Set₁ where
@@ -276,27 +282,56 @@ module SimpleASTOpSem
 -- --   RBranch A (Left x) = R A x
 -- --   RBranch A (Right y) = Branching.R A y
 
--- --   module OpSem (interp : ASTOpSem C R) where
+-- --   -- mutual
 
--- --     interpGuards : ∀ {A : Set} (gs : Guards{b = Level.zero} Unit) (f : Level.Lift (Level.suc Level.zero) (Fin (lengthGuards gs)) → ASTOpSem.M interp A)
--- --                    → ASTOpSem.M interp A
--- --     interpGuards (otherwise≔ x) f = f (Level.lift zero)
--- --     interpGuards (clause (x ≔ x₁) gs) f
--- --       with toBool x
--- --     ... | false = interpGuards gs λ { (Level.lift n) → f (Level.lift (suc n))}
--- --     ... | true = f (Level.lift zero)
+-- --   unextendGuards
+-- --     : ∀ {A} (gs : Guards{b = Level.zero} Unit)
+-- --         (f : Level.Lift (Level.suc (Level.zero)) (Fin (lengthGuards gs)) → AST C R A)
+-- --       → AST C R A
+-- --   unextendGuards (otherwise≔ x) f = f (Level.lift zero)
+-- --   unextendGuards (clause (b ≔ c) gs) f
+-- --     with toBool b
+-- --   ... | false = unextendGuards gs (λ where (Level.lift i) → f (Level.lift (suc i)))
+-- --   ... | true = f (Level.lift zero)
 
--- --     BranchExtendOpSem : ASTOpSem CBranch RBranch
--- --     ASTOpSem.M       BranchExtendOpSem = ASTOpSem.M interp
--- --     ASTOpSem.monadM  BranchExtendOpSem = {!!}
--- --     -- ASTOpSem.returnI BranchExtendOpSem = ASTOpSem.returnI interp
--- --     -- ASTOpSem.bindI   BranchExtendOpSem = ASTOpSem.bindI interp
--- --     ASTOpSem.opM     BranchExtendOpSem (Left c) f = ASTOpSem.opM interp c f
--- --     ASTOpSem.opM     BranchExtendOpSem (Right (Branching.ASTif gs)) f = interpGuards gs f
--- --     ASTOpSem.opM     BranchExtendOpSem (Right (Branching.ASTeither A₁ A₂ x₁)) f = f (Level.lift x₁)
--- --     ASTOpSem.opM     BranchExtendOpSem (Right (Branching.ASTmaybe A₁ x₁)) f = f (Level.lift x₁)
+-- --   unextendBranch : ∀ {A} → AST CBranch RBranch A → AST C R A
+-- --   unextendBranch (ASTreturn x) = ASTreturn x
+-- --   unextendBranch (ASTbind p f) = ASTbind (unextendBranch p) λ x → unextendBranch (f x)
+-- --   unextendBranch (ASTop (Left x) f) = ASTop x (λ r → unextendBranch (f r))
+-- --   unextendBranch (ASTop (Right (Branching.ASTif x)) f) =
+-- --     unextendGuards x λ i → unextendBranch (f i)
+-- --   unextendBranch (ASTop (Right (Branching.ASTeither A₁ A₂ x)) f) =
+-- --     unextendBranch (f (Level.lift x))
+-- --   unextendBranch (ASTop (Right (Branching.ASTmaybe A₁ x)) f) =
+-- --     unextendBranch (f (Level.lift x))
 
--- --   module PT (interp : ASTPredTrans C R) where
+-- --   module OpSem (Types : ASTOpSemTypes) (interp : ASTOpSem C R Types) where
+
+-- --     BranchExtendOpSemImpl : ASTOpSemImpl CBranch RBranch
+-- --     ASTOpSemImpl.M BranchExtendOpSemImpl = ASTOpSem.M interp
+-- --     ASTOpSemImpl.monadM BranchExtendOpSemImpl = ASTOpSem.monadM interp
+-- --     ASTOpSemImpl.opM BranchExtendOpSemImpl (Left c) f =
+-- --       ASTOpSem.opM interp c f
+-- --     ASTOpSemImpl.opM BranchExtendOpSemImpl (Right y) f = {!!}
+-- --     -- ASTOpSemImpl.opM BranchExtendOpSemImpl (Left x) f = ASTOpSem.opM interp x f
+-- --     -- ASTOpSemImpl.opM BranchExtendOpSemImpl (Right (Branching.ASTif gs)) f =
+-- --     --   interpGuards gs f
+-- --     -- ASTOpSemImpl.opM BranchExtendOpSemImpl (Right (Branching.ASTeither A₁ A₂ x)) f =
+-- --     --   f (Level.lift x)
+-- --     -- ASTOpSemImpl.opM BranchExtendOpSemImpl (Right (Branching.ASTmaybe A₁ x)) f =
+-- --     --   f (Level.lift x)
+
+-- --     -- BranchExtendOpSem : ASTOpSem CBranch RBranch Types
+-- --     -- ASTOpSem.impl BranchExtendOpSem = BranchExtendOpSemImpl
+-- --     -- ASTOpSem.runM BranchExtendOpSem = ASTOpSem.runM interp
+-- --     -- ASTOpSem.runMIdLeft BranchExtendOpSem x f i =
+-- --     --   ASTOpSem.runMIdLeft interp x {!!} {!!}
+-- --     -- ASTOpSem.runMIdRight BranchExtendOpSem = xxx
+-- --     --   where postulate xxx : _
+-- --     -- ASTOpSem.runMAssoc BranchExtendOpSem = xxx
+-- --     --   where postulate xxx : _
+
+-- --   module PT (Types : ASTOpSemTypes) (interp : ASTPredTrans C R Types) where
 -- --     open ASTPredTrans interp
 
 -- --     interpGuards : ∀ {A} → (gs : Guards{b = Level.zero} Unit) → (Level.Lift (Level.suc Level.0ℓ) (Fin (lengthGuards gs)) → PredTrans A) 
@@ -308,41 +343,41 @@ module SimpleASTOpSem
 -- --       × (toBool b ≡ false →
 -- --         interpGuards gs (λ where (Level.lift i) → ih (Level.lift (Fin.suc i))) P i)
 
--- --     BranchExtendPredTrans : ASTPredTrans CBranch RBranch
--- --     ASTPredTrans.Input     BranchExtendPredTrans = Input
--- --     ASTPredTrans.Output    BranchExtendPredTrans = Output
--- --     ASTPredTrans.returnPTS BranchExtendPredTrans = returnPTS
--- --     ASTPredTrans.bindPTS   BranchExtendPredTrans = bindPTS
--- --     ASTPredTrans.opPTS BranchExtendPredTrans (Left c) ih P i =
--- --       opPTS c ih P i
--- --     ASTPredTrans.opPTS BranchExtendPredTrans (Right (Branching.ASTif gs)) ih P i =
--- --       interpGuards gs ih P i
--- --     ASTPredTrans.opPTS BranchExtendPredTrans (Right (Branching.ASTeither A₁ A₂ e)) ih P i =
--- --         (∀ x → (e ≡ Left x ) → ih (Level.lift (Left  x)) P i)
--- --       × (∀ y → (e ≡ Right y) → ih (Level.lift (Right y)) P i)
--- --     ASTPredTrans.opPTS BranchExtendPredTrans (Right (Branching.ASTmaybe A₁ m)) ih P i =
--- --         m ≡ nothing → ih (Level.lift nothing) P i
--- --       × (∀ x → m ≡ just x → ih (Level.lift (just x)) P i)
+-- --     -- BranchExtendPredTrans : ASTPredTrans CBranch RBranch Types
+-- --     -- ASTPredTrans.Input     BranchExtendPredTrans = Input
+-- --     -- ASTPredTrans.Output    BranchExtendPredTrans = Output
+-- --     -- ASTPredTrans.returnPTS BranchExtendPredTrans = returnPTS
+-- --     -- ASTPredTrans.bindPTS   BranchExtendPredTrans = bindPTS
+-- --     -- ASTPredTrans.opPTS BranchExtendPredTrans (Left c) ih P i =
+-- --     --   opPTS c ih P i
+-- --     -- ASTPredTrans.opPTS BranchExtendPredTrans (Right (Branching.ASTif gs)) ih P i =
+-- --     --   interpGuards gs ih P i
+-- --     -- ASTPredTrans.opPTS BranchExtendPredTrans (Right (Branching.ASTeither A₁ A₂ e)) ih P i =
+-- --     --     (∀ x → (e ≡ Left x ) → ih (Level.lift (Left  x)) P i)
+-- --     --   × (∀ y → (e ≡ Right y) → ih (Level.lift (Right y)) P i)
+-- --     -- ASTPredTrans.opPTS BranchExtendPredTrans (Right (Branching.ASTmaybe A₁ m)) ih P i =
+-- --     --     m ≡ nothing → ih (Level.lift nothing) P i
+-- --     --   × (∀ x → m ≡ just x → ih (Level.lift (just x)) P i)
 
 
--- --   module Sufficient
--- --     (interpOS : ASTOpSem C R) (interpPT : ASTPredTrans C R)
--- --     (suf : ASTWeakestPre C R interpOS interpPT)
+-- --   module Sufficient (Types : ASTOpSemTypes)
+-- --     (interpOS : ASTOpSem C R Types) (interpPT : ASTPredTrans C R Types)
+-- --     (suf : ASTWeakestPre C R Types interpOS interpPT)
 -- --     where
 
--- --     open ASTOpSem      interpOS
--- --     open OpSem         interpOS
--- --     open ASTPredTrans  interpPT
--- --     open PT            interpPT
--- --     open ASTWeakestPre suf
+-- --     -- open ASTOpSem      interpOS
+-- --     -- open OpSem         interpOS
+-- --     -- open ASTPredTrans  interpPT
+-- --     -- open PT            interpPT
+-- --     -- open ASTWeakestPre suf
 
--- --     BranchExtendWeakestPre :
--- --       ASTWeakestPre CBranch RBranch BranchExtendOpSem BranchExtendPredTrans
--- --     ASTWeakestPre.runM     BranchExtendWeakestPre = runM
--- --     ASTWeakestPre.returnPT BranchExtendWeakestPre = returnPT
+-- --     -- BranchExtendWeakestPre :
+-- --     --   ASTWeakestPre CBranch RBranch BranchExtendOpSem BranchExtendPredTrans
+-- --     -- ASTWeakestPre.runM     BranchExtendWeakestPre = runM
+-- --     -- ASTWeakestPre.returnPT BranchExtendWeakestPre = returnPT
 
--- --     ASTWeakestPre.bindPT BranchExtendWeakestPre i (ASTreturn x) f wp ih = {!!}
--- --     ASTWeakestPre.bindPT BranchExtendWeakestPre i (ASTbind m x) f wp ih = {!!}
--- --     ASTWeakestPre.bindPT BranchExtendWeakestPre i (ASTop c x) f wp ih = {!!}
+-- --     -- ASTWeakestPre.bindPT BranchExtendWeakestPre i (ASTreturn x) f wp ih = {!!}
+-- --     -- ASTWeakestPre.bindPT BranchExtendWeakestPre i (ASTbind m x) f wp ih = {!!}
+-- --     -- ASTWeakestPre.bindPT BranchExtendWeakestPre i (ASTop c x) f wp ih = {!!}
 
--- --     ASTWeakestPre.opPT     BranchExtendWeakestPre = {!!}
+-- --     -- ASTWeakestPre.opPT     BranchExtendWeakestPre = {!!}

--- a/src/Dijkstra/AST.agda
+++ b/src/Dijkstra/AST.agda
@@ -1,0 +1,139 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+module Dijkstra.AST where
+
+open import Data.Empty
+open import Data.Fin
+open import Data.Product using (_×_ ; _,_)
+open import Data.Unit
+open import Haskell.Prelude
+import      Level
+open import Relation.Binary.PropositionalEquality
+
+data AST (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set → Set₁ where
+  -- monadic operations
+  ASTreturn : ∀ {A} → A → AST C R A
+  ASTbind   : ∀ {A B} → AST C R A → (A → AST C R B) → AST C R B
+  -- effect operations
+  ASTop : ∀ {A} → (c : C A) → (R A c → AST C R A) → AST C R A
+
+record ASTOpSem (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set₁ where
+  constructor mkASTOpSem
+  field
+    M       : Set → Set
+    returnI : ∀ {A} → A → M A
+    bindI   : ∀ {A B} → M A → (A → M B) → M B
+    opI     : ∀ {A} → (c : C A) → (R A c → M A) → M A
+
+runAST : ∀ {C R A} → (i : ASTOpSem C R) → AST C R A → ASTOpSem.M i A
+runAST i (ASTreturn x) = ASTOpSem.returnI i x
+runAST i (ASTbind p f) = ASTOpSem.bindI i (runAST i p) (λ x → runAST i (f x))
+runAST i (ASTop c f) = ASTOpSem.opI i c (λ x → runAST i (f x))
+
+record ASTPredTrans (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁) : Set₂ where
+  constructor mkASTPredTrans
+  field
+    Pre  : Set₁
+    Post : (A : Set) → Set₁
+
+  PredTrans : (A : Set) → Set₁
+  PredTrans A = Post A → Pre
+  
+  field
+    returnPTS : ∀ {A} → A → PredTrans A
+    bindPTS   : ∀ {A B} → (A → PredTrans B) → Post B → Post A
+    opPTS     : ∀ {A} → (c : C A) → (R A c → PredTrans A) → PredTrans A
+
+wpAST : ∀ {C R A} → (pt : ASTPredTrans C R) → AST C R A → ASTPredTrans.PredTrans pt A
+wpAST pt (ASTreturn x) = ASTPredTrans.returnPTS pt x
+wpAST pt (ASTbind p f) Post = wpAST pt p (ASTPredTrans.bindPTS pt (λ x → wpAST pt (f x)) Post)
+wpAST pt (ASTop c f) Post = ASTPredTrans.opPTS pt c (λ r → wpAST pt (f r)) Post
+
+
+module RWS (Ev Wr St : Set) where
+
+  data C (A : Set) : Set₁ where
+    RWSgets  : (St → A) → C A
+    RWSputs  : (St → St) → A ≡ Unit → C A
+    RWSask   : (A ≡ Ev) → C A
+    RWSlocal : (Ev → Ev) → C A
+    RWStell  : List Wr → (A ≡ Unit) → C A
+
+  R : (A : Set) (c : C A) → Set₁
+  R A (RWSgets x) = Level.Lift _ ⊥
+  R .Unit (RWSputs f refl) = Level.Lift _ ⊥
+  R .Ev (RWSask refl) = Level.Lift _ ⊥
+  R A (RWSlocal x) = Level.Lift _ ⊤
+  R A (RWStell x refl) = Level.Lift _ ⊥
+
+  RWSOpSem : ASTOpSem C R
+  ASTOpSem.M       RWSOpSem A = (ev : Ev) (st : St) → A × St × List Wr
+  ASTOpSem.returnI RWSOpSem x ev st = x , st , []
+  ASTOpSem.bindI   RWSOpSem x f ev st =
+    let (x₁ , st₁ , outs₁) = x ev st
+        (x₂ , st₂ , outs₂) = f x₁ ev st₁
+    in x₂ , st₂ , outs₁ ++ outs₂
+  ASTOpSem.opI     RWSOpSem (RWSgets g) f ev st =
+    (g st) , st , []
+  ASTOpSem.opI     RWSOpSem (RWSputs p refl) f ev st =
+    unit , p st , []
+  ASTOpSem.opI     RWSOpSem (RWSask refl) f ev st =
+    ev , st , []
+  ASTOpSem.opI     RWSOpSem (RWSlocal l) f ev st =
+    f (Level.lift _) (l ev) st
+  ASTOpSem.opI     RWSOpSem (RWStell t refl) f ev st =
+    unit , st , t
+
+module Branching where
+  data C (A : Set) : Set₁ where
+    ASTif : Guards Unit → C A
+    ASTeither : (A₁ A₂ : Set) → Either A₁ A₂ → C A
+    ASTmaybe  : (A₁ : Set) → Maybe A₁ → C A
+
+  R : (A : Set) (c : C A) → Set₁
+  R A (ASTif gs) = Level.Lift _ (Fin (lengthGuards gs))
+  R A (ASTeither A₁ A₂ _) = Level.Lift _ (Either A₁ A₂)
+  R A (ASTmaybe A₁ _)     = Level.Lift _ (Maybe A₁)
+
+-- module _ {X : Set → Set}
+--   (r : ∀ {A} → A → X A) (b : ∀ {A B} → X A → (A → X B) → X B)
+--   where
+
+--   runAST : ∀ {C R A} → AST C R A → (∀ {A} → (c : C A) → (R A c → X A) → X A) → X A
+--   runAST (ASTreturn x) op = r x
+--   runAST (ASTbind x f) op = b (runAST x op) (λ y → runAST (f y) op)
+--   runAST (ASTop c f)   op = op c (λ ret → runAST (f ret) op)
+
+private
+  module BranchExtend
+    (C : Set → Set₁) (R : (A : Set) (c : C A) → Set₁)
+    (interp : ASTOpSem C R)
+    where
+
+    CBranch : Set → Set₁
+    CBranch A = Either (C A) (Branching.C A)
+
+    RBranch : (A : Set) (c : CBranch A) → Set₁
+    RBranch A (Left x) = R A x
+    RBranch A (Right y) = Branching.R A y
+
+    interpGuards : ∀ {A : Set} (gs : Guards{b = Level.zero} Unit) (f : Level.Lift (Level.suc Level.zero) (Fin (lengthGuards gs)) → ASTOpSem.M interp A)
+                   → ASTOpSem.M interp A
+    interpGuards (otherwise≔ x) f = f (Level.lift zero)
+    interpGuards (clause (x ≔ x₁) gs) f
+      with toBool x
+    ... | false = interpGuards gs λ { (Level.lift n) → f (Level.lift (suc n))}
+    ... | true = f (Level.lift zero)
+
+    Interp : ASTOpSem CBranch RBranch
+    ASTOpSem.M       Interp = ASTOpSem.M interp
+    ASTOpSem.returnI Interp = ASTOpSem.returnI interp
+    ASTOpSem.bindI   Interp = ASTOpSem.bindI interp
+    ASTOpSem.opI     Interp (Left c) f = ASTOpSem.opI interp c f
+    ASTOpSem.opI     Interp (Right (Branching.ASTif gs)) f = interpGuards gs f
+    ASTOpSem.opI     Interp (Right (Branching.ASTeither A₁ A₂ x₁)) f = f (Level.lift x₁)
+    ASTOpSem.opI     Interp (Right (Branching.ASTmaybe A₁ x₁)) f = f (Level.lift x₁)

--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -21,22 +21,22 @@ data BranchCmd (A : Set) : Set₁ where
   BCif     : Bool → BranchCmd A
   BCeither : {B C : Set} → Either B C → BranchCmd A
 
-BranchArr : {A : Set} → BranchCmd A → Set₁
-BranchArr (BCif x) = Level.Lift _ Bool
-BranchArr (BCeither{B}{C} x) = Level.Lift _ (Either B C)
+BranchSubArg : {A : Set} → BranchCmd A → Set₁
+BranchSubArg (BCif x) = Level.Lift _ Bool
+BranchSubArg (BCeither{B}{C} x) = Level.Lift _ (Either B C)
 
-BranchSub : {A : Set} → BranchCmd A → Set
-BranchSub{A} (BCif x) = A
-BranchSub{A} (BCeither x) = A
+BranchSubRet : {A : Set} → BranchCmd A → Set
+BranchSubRet{A} (BCif x) = A
+BranchSubRet{A} (BCeither x) = A
 
 module ASTExtension (O : ASTOps) where
 
   BranchOps : ASTOps
   ASTOps.Cmd  BranchOps A = Either (ASTOps.Cmd O A) (BranchCmd A)
-  ASTOps.Arr BranchOps (Left x)  = ASTOps.Arr O x
-  ASTOps.Arr BranchOps (Right y) = BranchArr y
-  ASTOps.Sub  BranchOps  (Left x)  = ASTOps.Sub O x
-  ASTOps.Sub  BranchOps  (Right y) = BranchSub y
+  ASTOps.SubArg BranchOps (Left x)   = ASTOps.SubArg O x
+  ASTOps.SubArg BranchOps (Right y)  = BranchSubArg y
+  ASTOps.SubRet BranchOps  (Left x)  = ASTOps.SubRet O x
+  ASTOps.SubRet BranchOps  (Right y) = BranchSubRet y
 
   unextend : ∀ {A} → AST BranchOps A → AST O A
   unextend (ASTreturn x) = ASTreturn x

--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -1,0 +1,68 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+module Dijkstra.AST.Branching where
+
+open import Data.Empty
+open import Data.Fin
+open import Data.Product using (_×_ ; _,_ ; proj₁ ; proj₂)
+open import Data.Unit
+open import Dijkstra.AST.Core
+open import Function
+open import Haskell.Prelude
+import      Level
+import      Level.Literals as Level using (#_)
+open import Relation.Binary.PropositionalEquality
+
+data BranchCmd (A : Set) : Set₁ where
+  BCif     : Bool → BranchCmd A
+  BCeither : {B C : Set} → Either B C → BranchCmd A
+
+BranchResp : {A : Set} → BranchCmd A → Set₁
+BranchResp (BCif x) = Level.Lift _ Bool
+BranchResp (BCeither{B}{C} x) = Level.Lift _ (Either B C)
+
+BranchSub : {A : Set} → BranchCmd A → Set
+BranchSub{A} (BCif x) = A
+BranchSub{A} (BCeither x) = A
+
+module ASTExtension (O : ASTOps) where
+
+  BranchOps : ASTOps
+  ASTOps.Cmd  BranchOps A = Either (ASTOps.Cmd O A) (BranchCmd A)
+  ASTOps.Resp BranchOps (Left x)  = ASTOps.Resp O x
+  ASTOps.Resp BranchOps (Right y) = BranchResp y
+  ASTOps.Sub  BranchOps  (Left x)  = ASTOps.Sub O x
+  ASTOps.Sub  BranchOps  (Right y) = BranchSub y
+
+  unextend : ∀ {A} → AST BranchOps A → AST O A
+  unextend (ASTreturn x) = ASTreturn x
+  unextend (ASTbind m f) = ASTbind (unextend m) (unextend ∘ f)
+  unextend (ASTop (Left c) f) = ASTop c (unextend ∘ f)
+  unextend (ASTop (Right (BCif false)) f) = unextend (f (Level.lift false))
+  unextend (ASTop (Right (BCif true)) f) = unextend (f (Level.lift true))
+  unextend (ASTop (Right (BCeither (Left x))) f) = unextend (f (Level.lift (Left x)))
+  unextend (ASTop (Right (BCeither (Right y))) f) = unextend (f (Level.lift (Right y)))
+
+module OpSemExtension {O : ASTOps} {T : ASTTypes} (OpSem : ASTOpSem O T) where
+  open ASTExtension O
+
+  BranchOpSem : ASTOpSem BranchOps T
+  ASTOpSem.runAST BranchOpSem m i = ASTOpSem.runAST OpSem (unextend m) i
+
+module PredTransExtension {O : ASTOps} {T : ASTTypes} (PT : ASTPredTrans O T) where
+  open ASTExtension O
+
+  BranchPT : ASTPredTrans BranchOps T
+  ASTPredTrans.returnPT BranchPT  = ASTPredTrans.returnPT  PT
+  ASTPredTrans.bindPT BranchPT    = ASTPredTrans.bindPT    PT
+  ASTPredTrans.opPT BranchPT (Left x) = ASTPredTrans.opPT PT x
+  ASTPredTrans.opPT BranchPT (Right (BCif c)) f P i =
+      c ≡ true → f (Level.lift true) P i
+    × c ≡ false → f (Level.lift false) P i
+  ASTPredTrans.opPT BranchPT (Right (BCeither e)) f P i =
+      ∀ l → e ≡ Left  l → f (Level.lift (Left l))  P i
+    × ∀ r → e ≡ Right r → f (Level.lift (Right r)) P i

--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -25,18 +25,18 @@ BranchSubArg : {A : Set} → BranchCmd A → Set₁
 BranchSubArg (BCif x) = Level.Lift _ Bool
 BranchSubArg (BCeither{B}{C} x) = Level.Lift _ (Either B C)
 
-BranchSubRet : {A : Set} → BranchCmd A → Set
-BranchSubRet{A} (BCif x) = A
-BranchSubRet{A} (BCeither x) = A
+BranchSubRet : {A : Set} {c : BranchCmd A} → BranchSubArg c → Set
+BranchSubRet{A} {BCif x} _ = A
+BranchSubRet{A} {BCeither x} _ = A
 
 module ASTExtension (O : ASTOps) where
 
   BranchOps : ASTOps
   ASTOps.Cmd  BranchOps A = Either (ASTOps.Cmd O A) (BranchCmd A)
-  ASTOps.SubArg BranchOps (Left x)   = ASTOps.SubArg O x
-  ASTOps.SubArg BranchOps (Right y)  = BranchSubArg y
-  ASTOps.SubRet BranchOps  (Left x)  = ASTOps.SubRet O x
-  ASTOps.SubRet BranchOps  (Right y) = BranchSubRet y
+  ASTOps.SubArg BranchOps{_} (Left x)   = ASTOps.SubArg O x
+  ASTOps.SubArg BranchOps{_} (Right y)  = BranchSubArg y
+  ASTOps.SubRet BranchOps{_} {(Left x)} r  = ASTOps.SubRet O r
+  ASTOps.SubRet BranchOps{_} {(Right y)} r = BranchSubRet r
 
   unextend : ∀ {A} → AST BranchOps A → AST O A
   unextend (ASTreturn x) = ASTreturn x

--- a/src/Dijkstra/AST/Core.agda
+++ b/src/Dijkstra/AST/Core.agda
@@ -19,7 +19,7 @@ open import Relation.Binary.PropositionalEquality
 record ASTOps : Set₂ where
   field
     Cmd  : (A : Set) → Set₁
-    Resp : {A : Set} (c : Cmd A) → Set₁
+    Arr : {A : Set} (c : Cmd A) → Set₁
     Sub  : {A : Set} (c : Cmd A) →  Set
 open ASTOps
 
@@ -27,7 +27,7 @@ data AST (OP : ASTOps) : Set → Set₁ where
   ASTreturn : ∀ {A} → A → AST OP A
   ASTbind   : ∀ {A B} → (m : AST OP A) (f : A → AST OP B)
               → AST OP B
-  ASTop : ∀ {A} → (c : Cmd OP A) (f : Resp OP c → AST OP (Sub OP c)) → AST OP A
+  ASTop : ∀ {A} → (c : Cmd OP A) (f : Arr OP c → AST OP (Sub OP c)) → AST OP A
 
 record ASTTypes : Set₁ where
   constructor mkASTTypes
@@ -72,7 +72,7 @@ record ASTPredTrans (OP : ASTOps) (Ty : ASTTypes) : Set₂ where
     returnPT : ∀ {A} → A → PredTrans A
     bindPT   : ∀ {A B} → (f : A → PredTrans B) (i : Input)
                 → (P : Post B) → Post A
-    opPT     : ∀ {A} → (c : Cmd OP A) → (Resp OP c → PredTrans (Sub OP c)) → PredTrans A
+    opPT     : ∀ {A} → (c : Cmd OP A) → (Arr OP c → PredTrans (Sub OP c)) → PredTrans A
 
   predTrans : ∀ {A} → AST OP A → PredTrans A
   predTrans (ASTreturn x) P i =
@@ -93,10 +93,10 @@ record ASTPredTransMono {OP : ASTOps} {Ty : ASTTypes} (PT : ASTPredTrans OP Ty) 
     bindPTMono₂  : ∀ {A B} → (f₁ f₂ : A → PredTrans B)
                    → (f₁⊑f₂ : ∀ x → f₁ x ⊑ f₂ x)
                    → ∀ i P → bindPT f₁ i  P ⊆ₒ bindPT f₂ i P
-    opPTMono₁    : ∀ {A} (c : Cmd OP A) (f : Resp OP c → PredTrans (Sub OP c))
+    opPTMono₁    : ∀ {A} (c : Cmd OP A) (f : Arr OP c → PredTrans (Sub OP c))
                    → (∀ r → MonoPredTrans (f r))
                    → ∀ P₁ P₂ → P₁ ⊆ₒ P₂ → opPT c f P₁ ⊆ᵢ opPT c f P₂
-    opPTMono₂    : ∀ {A} (c : Cmd OP A) (f₁ f₂ : Resp OP c → PredTrans (Sub OP c))
+    opPTMono₂    : ∀ {A} (c : Cmd OP A) (f₁ f₂ : Arr OP c → PredTrans (Sub OP c))
                    → (f₁⊑f₂ : ∀ r → f₁ r ⊑ f₂ r)
                    → opPT c f₁ ⊑ opPT c f₂
 
@@ -128,7 +128,7 @@ record ASTSufficientPT
                 → (mSuf : Sufficient A m)
                 → (fSuf : ∀ x → Sufficient B (f x))
                 → Sufficient B (ASTbind m f)
-    opSuf     : ∀ {A} → (c : Cmd OP A) (f : Resp OP c → AST OP (Sub OP c))
+    opSuf     : ∀ {A} → (c : Cmd OP A) (f : Arr OP c → AST OP (Sub OP c))
                 → (fSuf : ∀ r → Sufficient (Sub OP c) (f r))
                 → Sufficient A (ASTop c f)
 

--- a/src/Dijkstra/AST/Core.agda
+++ b/src/Dijkstra/AST/Core.agda
@@ -18,16 +18,16 @@ open import Relation.Binary.PropositionalEquality
 
 record ASTOps : Set₂ where
   field
-    Cmd  : (A : Set) → Set₁
-    Arr : {A : Set} (c : Cmd A) → Set₁
-    Sub  : {A : Set} (c : Cmd A) →  Set
+    Cmd     : (A : Set) → Set₁
+    SubArg  : {A : Set} (c : Cmd A) → Set₁
+    SubRet  : {A : Set} (c : Cmd A) →  Set
 open ASTOps
 
 data AST (OP : ASTOps) : Set → Set₁ where
   ASTreturn : ∀ {A} → A → AST OP A
   ASTbind   : ∀ {A B} → (m : AST OP A) (f : A → AST OP B)
               → AST OP B
-  ASTop : ∀ {A} → (c : Cmd OP A) (f : Arr OP c → AST OP (Sub OP c)) → AST OP A
+  ASTop : ∀ {A} → (c : Cmd OP A) (f : SubArg OP c → AST OP (SubRet OP c)) → AST OP A
 
 record ASTTypes : Set₁ where
   constructor mkASTTypes
@@ -72,7 +72,7 @@ record ASTPredTrans (OP : ASTOps) (Ty : ASTTypes) : Set₂ where
     returnPT : ∀ {A} → A → PredTrans A
     bindPT   : ∀ {A B} → (f : A → PredTrans B) (i : Input)
                 → (P : Post B) → Post A
-    opPT     : ∀ {A} → (c : Cmd OP A) → (Arr OP c → PredTrans (Sub OP c)) → PredTrans A
+    opPT     : ∀ {A} → (c : Cmd OP A) → (SubArg OP c → PredTrans (SubRet OP c)) → PredTrans A
 
   predTrans : ∀ {A} → AST OP A → PredTrans A
   predTrans (ASTreturn x) P i =
@@ -93,10 +93,10 @@ record ASTPredTransMono {OP : ASTOps} {Ty : ASTTypes} (PT : ASTPredTrans OP Ty) 
     bindPTMono₂  : ∀ {A B} → (f₁ f₂ : A → PredTrans B)
                    → (f₁⊑f₂ : ∀ x → f₁ x ⊑ f₂ x)
                    → ∀ i P → bindPT f₁ i  P ⊆ₒ bindPT f₂ i P
-    opPTMono₁    : ∀ {A} (c : Cmd OP A) (f : Arr OP c → PredTrans (Sub OP c))
+    opPTMono₁    : ∀ {A} (c : Cmd OP A) (f : SubArg OP c → PredTrans (SubRet OP c))
                    → (∀ r → MonoPredTrans (f r))
                    → ∀ P₁ P₂ → P₁ ⊆ₒ P₂ → opPT c f P₁ ⊆ᵢ opPT c f P₂
-    opPTMono₂    : ∀ {A} (c : Cmd OP A) (f₁ f₂ : Arr OP c → PredTrans (Sub OP c))
+    opPTMono₂    : ∀ {A} (c : Cmd OP A) (f₁ f₂ : SubArg OP c → PredTrans (SubRet OP c))
                    → (f₁⊑f₂ : ∀ r → f₁ r ⊑ f₂ r)
                    → opPT c f₁ ⊑ opPT c f₂
 
@@ -128,8 +128,8 @@ record ASTSufficientPT
                 → (mSuf : Sufficient A m)
                 → (fSuf : ∀ x → Sufficient B (f x))
                 → Sufficient B (ASTbind m f)
-    opSuf     : ∀ {A} → (c : Cmd OP A) (f : Arr OP c → AST OP (Sub OP c))
-                → (fSuf : ∀ r → Sufficient (Sub OP c) (f r))
+    opSuf     : ∀ {A} → (c : Cmd OP A) (f : SubArg OP c → AST OP (SubRet OP c))
+                → (fSuf : ∀ r → Sufficient (SubRet OP c) (f r))
                 → Sufficient A (ASTop c f)
 
   sufficient : ∀ {A} → (m : AST OP A) → Sufficient A m

--- a/src/Dijkstra/AST/Core.agda
+++ b/src/Dijkstra/AST/Core.agda
@@ -1,0 +1,142 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+module Dijkstra.AST.Core where
+
+open import Data.Empty
+open import Data.Fin
+open import Data.Product using (_×_ ; _,_ ; proj₁ ; proj₂)
+open import Data.Unit
+open import Function
+open import Haskell.Prelude
+import      Level
+import      Level.Literals as Level using (#_)
+open import Relation.Binary.PropositionalEquality
+
+record ASTOps : Set₂ where
+  field
+    Cmd  : (A : Set) → Set₁
+    Resp : {A : Set} (c : Cmd A) → Set₁
+    Sub  : {A : Set} (c : Cmd A) →  Set
+open ASTOps
+
+data AST (OP : ASTOps) : Set → Set₁ where
+  ASTreturn : ∀ {A} → A → AST OP A
+  ASTbind   : ∀ {A B} → (m : AST OP A) (f : A → AST OP B)
+              → AST OP B
+  ASTop : ∀ {A} → (c : Cmd OP A) (f : Resp OP c → AST OP (Sub OP c)) → AST OP A
+
+record ASTTypes : Set₁ where
+  constructor mkASTTypes
+  field
+    Input  : Set
+    Output : (A : Set) → Set
+
+  M : Set → Set
+  M A = (i : Input) → Output A
+
+  Pre : Set₁
+  Pre = (i : Input) → Set
+
+  Post : Set → Set₁
+  Post A = (o : Output A) → Set
+
+  PredTrans : (A : Set) → Set₁
+  PredTrans A = (P : Post A) → Pre
+
+  _⊆ᵢ_ : (P₁ P₂ : Pre) → Set
+  P₁ ⊆ᵢ P₂ = ∀ i → P₁ i → P₂ i
+
+  _⊆ₒ_ : ∀ {A} → (P₁ P₂ : Post A) → Set
+  P₁ ⊆ₒ P₂ = ∀ o → P₁ o → P₂ o
+
+  _⊑_ : {A : Set} → (pt₁ pt₂ : PredTrans A) → Set₁
+  pt₁ ⊑ pt₂ = ∀ P → pt₁ P ⊆ᵢ pt₂ P
+
+  MonoPredTrans : ∀ {A} → PredTrans A → Set₁
+  MonoPredTrans pt = ∀ P₁ P₂ → (P₁⊆ₒP₂ : P₁ ⊆ₒ P₂) → pt P₁ ⊆ᵢ pt P₂
+
+record ASTOpSem (OP : ASTOps) (Ty : ASTTypes) : Set₁ where
+  constructor mkASTOpSem
+  open ASTTypes Ty
+  field
+    runAST : ∀ {A} → (m : AST OP A) → M A
+
+record ASTPredTrans (OP : ASTOps) (Ty : ASTTypes) : Set₂ where
+  constructor mkASTPredTrans
+  open ASTTypes Ty
+  field
+    returnPT : ∀ {A} → A → PredTrans A
+    bindPT   : ∀ {A B} → (f : A → PredTrans B) (i : Input)
+                → (P : Post B) → Post A
+    opPT     : ∀ {A} → (c : Cmd OP A) → (Resp OP c → PredTrans (Sub OP c)) → PredTrans A
+
+  predTrans : ∀ {A} → AST OP A → PredTrans A
+  predTrans (ASTreturn x) P i =
+    returnPT x P i
+  predTrans (ASTbind x f) P i =
+    predTrans x (bindPT (predTrans ∘ f) i P) i
+  predTrans (ASTop c f) P i =
+    opPT c (predTrans ∘ f) P i
+
+record ASTPredTransMono {OP : ASTOps} {Ty : ASTTypes} (PT : ASTPredTrans OP Ty) : Set₂ where
+  open ASTTypes Ty
+  open ASTPredTrans PT
+  field
+    returnPTMono : ∀ {A} → (x : A) → MonoPredTrans (returnPT x)
+    bindPTMono₁  : ∀ {A B} → (f : A → PredTrans B)
+                   → (∀ x → MonoPredTrans (f x))
+                   → ∀ i P₁ P₂ → P₁ ⊆ₒ P₂ → bindPT f i P₁ ⊆ₒ bindPT f i P₂
+    bindPTMono₂  : ∀ {A B} → (f₁ f₂ : A → PredTrans B)
+                   → (f₁⊑f₂ : ∀ x → f₁ x ⊑ f₂ x)
+                   → ∀ i P → bindPT f₁ i  P ⊆ₒ bindPT f₂ i P
+    opPTMono₁    : ∀ {A} (c : Cmd OP A) (f : Resp OP c → PredTrans (Sub OP c))
+                   → (∀ r → MonoPredTrans (f r))
+                   → ∀ P₁ P₂ → P₁ ⊆ₒ P₂ → opPT c f P₁ ⊆ᵢ opPT c f P₂
+    opPTMono₂    : ∀ {A} (c : Cmd OP A) (f₁ f₂ : Resp OP c → PredTrans (Sub OP c))
+                   → (f₁⊑f₂ : ∀ r → f₁ r ⊑ f₂ r)
+                   → opPT c f₁ ⊑ opPT c f₂
+
+  predTransMono : ∀ {A} (m : AST OP A)
+                  → MonoPredTrans (predTrans m)
+  predTransMono (ASTreturn x) =
+    returnPTMono x
+  predTransMono (ASTbind m f) P₁ P₂ P₁⊆P₂ i x₁ =
+    predTransMono  m _ _
+      (bindPTMono₁ (predTrans ∘ f) (predTransMono ∘ f) i _ _ P₁⊆P₂) i x₁
+  predTransMono (ASTop c f) P₁ P₂ P₁⊆P₂ i wp =
+    opPTMono₁ c (predTrans ∘ f) (predTransMono ∘ f) _ _ P₁⊆P₂ i wp
+
+record ASTSufficientPT
+  {OP : ASTOps} {Ty : ASTTypes}
+  (OpSem : ASTOpSem OP Ty) (PT : ASTPredTrans OP Ty) : Set₁ where
+  constructor mkASTSufficientPT
+  open ASTTypes     Ty
+  open ASTOpSem     OpSem
+  open ASTPredTrans PT
+
+  Sufficient : (A : Set) (m : AST OP A) → Set₁
+  Sufficient A m =
+    ∀ P i → (wp : predTrans m P i) → P (runAST m i)
+
+  field
+    returnSuf : ∀ {A} x → Sufficient A (ASTreturn x)
+    bindSuf   : ∀ {A B} (m : AST OP A) (f : A → AST OP B)
+                → (mSuf : Sufficient A m)
+                → (fSuf : ∀ x → Sufficient B (f x))
+                → Sufficient B (ASTbind m f)
+    opSuf     : ∀ {A} → (c : Cmd OP A) (f : Resp OP c → AST OP (Sub OP c))
+                → (fSuf : ∀ r → Sufficient (Sub OP c) (f r))
+                → Sufficient A (ASTop c f)
+
+  sufficient : ∀ {A} → (m : AST OP A) → Sufficient A m
+  sufficient (ASTreturn x) =
+    returnSuf x
+  sufficient (ASTbind m f) =
+    bindSuf m f (sufficient m) (sufficient ∘ f)
+  sufficient (ASTop c f) =
+    opSuf c f (sufficient ∘ f)
+

--- a/src/Dijkstra/AST/Example.agda
+++ b/src/Dijkstra/AST/Example.agda
@@ -1,0 +1,267 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+module Dijkstra.AST.Example (Ev Wr St : Set) where
+
+open import Data.Empty
+open import Data.Fin
+open import Data.Product using (_×_ ; _,_ ; proj₁ ; proj₂)
+open import Data.Unit
+open import Dijkstra.AST.Core
+open import Function
+open import Haskell.Prelude
+  hiding (maybe)
+import      Level
+import      Level.Literals as Level using (#_)
+open import Relation.Binary.PropositionalEquality
+  hiding ([_])
+
+data RWSCmd (A : Set) : Set₁ where
+  RWSgets   : (g : St → A) → RWSCmd A
+  RWStell   : (out : List Wr) → (A ≡ Unit) → RWSCmd A
+  RWSpass   : RWSCmd A
+  RWSmaybe  : ∀ {B} → Maybe B → RWSCmd A
+
+RWSSubArg : {A : Set} (c : RWSCmd A) → Set₁
+RWSSubArg (RWSgets g)         = Level.Lift _ Void
+RWSSubArg (RWStell out refl)  = Level.Lift _ Void
+RWSSubArg RWSpass             = Level.Lift _ Unit
+RWSSubArg (RWSmaybe{B} x)     = Level.Lift _ (Maybe B)
+
+RWSSubRet : {A : Set} (c : RWSCmd A) → Set
+RWSSubRet (RWSgets g) = Unit
+RWSSubRet{A} (RWStell out x) = ⊥
+RWSSubRet{A} RWSpass = A × (List Wr → List Wr)
+RWSSubRet{A} (RWSmaybe x) = A
+
+RWSOps : ASTOps
+ASTOps.Cmd RWSOps     = RWSCmd
+ASTOps.SubArg RWSOps  = RWSSubArg
+ASTOps.SubRet RWSOps  = RWSSubRet
+
+RWS = AST RWSOps
+
+module Syntax where
+  open import Dijkstra.AST.Syntax public
+
+  gets : ∀ {A} → (St → A) → RWS A
+  gets f = ASTop (RWSgets f) λ ()
+
+  tell : List Wr → RWS Unit
+  tell outs = ASTop (RWStell outs refl) (λ ())
+
+  pass : ∀ {A} → RWS (A × (List Wr → List Wr)) → RWS A
+  pass m = ASTop RWSpass (λ where (Level.lift unit) → m)
+
+  maybe : ∀ {A B} → Maybe B → RWS A → (B → RWS A) → RWS A
+  maybe m c₁ c₂ = ASTop (RWSmaybe m) λ where
+    (Level.lift nothing)  → c₁
+    (Level.lift (just x)) → c₂ x
+
+private
+  module Prog where
+    module Raw where
+      prog : (St → Maybe Wr) → RWS Unit
+      prog f =
+        ASTop RWSpass λ _ →
+          ASTbind (ASTop (RWSgets f) λ ()) λ m →
+          ASTop (RWSmaybe m) λ where
+            (Level.lift nothing)  → ASTreturn (unit , λ x → x ++ x)
+            (Level.lift (just w)) →
+              ASTbind (ASTop (RWStell (w ∷ []) refl) (λ ())) λ _ →
+              ASTreturn (unit , λ _ → [])
+
+    module Sugar where
+      open Syntax
+      prog : (St → Maybe Wr) → RWS Unit
+      prog f =
+        pass $ do
+          m ← gets f
+          maybe m (return (unit , λ x → x ++ x))
+            λ w → do
+              tell (w ∷ [])
+              return (unit , λ _ → [])
+
+RWSTypes : ASTTypes
+ASTTypes.Input  RWSTypes    = Ev × St
+ASTTypes.Output RWSTypes A  = A × St × List Wr
+
+open ASTTypes RWSTypes
+
+RWSOpSem : ASTOpSem RWSOps RWSTypes
+ASTOpSem.runAST RWSOpSem (ASTreturn x) (ev , st) = x , st , []
+ASTOpSem.runAST RWSOpSem (ASTbind m f) (ev , st₀) =
+  let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem m (ev , st₀)
+      (x₂ , st₂ , outs₂) = ASTOpSem.runAST RWSOpSem (f x₁) (ev , st₁)
+  in (x₂ , st₂ , outs₁ ++ outs₂)
+ASTOpSem.runAST RWSOpSem (ASTop (RWSgets g) f) (ev , st) =
+  g st , st , []
+ASTOpSem.runAST RWSOpSem (ASTop (RWStell out refl) f) (ev , st) =
+  unit , st , out
+ASTOpSem.runAST RWSOpSem (ASTop RWSpass f) (ev , st) =
+  let ((x₁ , wf) , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (ev , st)
+  in x₁ , st₁ , wf outs₁
+ASTOpSem.runAST RWSOpSem (ASTop (RWSmaybe m) f) (ev , st) =
+  ASTOpSem.runAST RWSOpSem (f (Level.lift m)) (ev , st)
+
+runRWS = ASTOpSem.runAST RWSOpSem
+
+RWSbindPost : (outs : List Wr) {A : Set} → Post A → Post A
+RWSbindPost outs P (x , st , outs') = P (x , st , outs ++ outs')
+
+RWSpassPost : ∀ {A} → Post A → Post (A × (List Wr → List Wr))
+RWSpassPost P ((x , f) , s , o) = ∀ o' → o' ≡ f o → P (x , s , o')
+
+RWSPredTrans : ASTPredTrans RWSOps RWSTypes
+ASTPredTrans.returnPT RWSPredTrans x P (ev , st) =
+  P (x , st , [])
+ASTPredTrans.bindPT RWSPredTrans f (ev , st) P (x , st' , outs) =
+  ∀ r → r ≡ x → f r (RWSbindPost outs P) (ev , st')
+ASTPredTrans.opPT RWSPredTrans (RWSgets g) f P (ev , st) =
+  P (g st , st , [])
+ASTPredTrans.opPT RWSPredTrans (RWStell out refl) f P (ev , st) =
+  P (unit , st , out)
+ASTPredTrans.opPT RWSPredTrans{A} RWSpass f P (ev , st) =
+  f (Level.lift unit) (RWSpassPost P) (ev , st)
+ASTPredTrans.opPT RWSPredTrans{A} (RWSmaybe m) f P (ev , st) =
+    (nothing ≡ m → f (Level.lift nothing) P (ev , st))
+  × (∀ x → just x ≡ m → f (Level.lift (just x)) P (ev , st))
+
+RWSPT = ASTPredTrans.predTrans RWSPredTrans
+
+private
+  module ProgPost where
+    open Prog.Sugar
+    ProgPost : Input → Post Unit
+    ProgPost (_ , s1) (_ , s2 , o) = s1 ≡ s2 × length o ≡ 0
+
+    wpProgPost : ∀ f i → RWSPT (prog f) (ProgPost i) i
+    proj₁ (wpProgPost f i m mEq) _ o refl = refl , {!!}
+    proj₂ (wpProgPost f i m mEq) = {!!}
+    -- proj₁ (wpProgPost f i m mEq) refl [] refl = refl , refl
+    -- proj₂ (wpProgPost f i m mEq) x refl _ _ [] refl = refl , refl
+{-
+Goal: (r : Maybe Wr) →
+      r ≡ f (proj₂ i) →
+      (nothing ≡ r →
+       RWSbindPost [] (RWSpassPost (ProgPost i))
+       ((unit , (λ x → x ++ x)) , proj₂ i , []))
+      ×
+      ((x : Wr) →
+       just x ≡ r →
+       (r₁ : Unit) →
+       r₁ ≡ unit →
+       RWSbindPost (x ∷ []) (RWSbindPost [] (RWSpassPost (ProgPost i)))
+       ((unit , (λ _ → [])) , proj₂ i , []))
+————————————————————————————————————————————————————————————
+i  : Input
+f  : St → Maybe Wr
+St : Set
+Wr : Set
+Ev : Set
+-}
+
+    progPost' : ∀ f i → ProgPost i (runRWS (prog f) i)
+    progPost' f (e , s)
+      with f s
+    ... | nothing = refl , refl
+    ... | just x  = refl , refl
+
+{-
+Goal: Data.Product.Σ
+      (proj₂ i ≡
+       proj₁
+       (proj₂
+        (ASTOpSem.runAST RWSOpSem
+         ((λ { (Level.lift nothing) → ASTreturn (unit , (λ x → x ++ x))
+             ; (Level.lift (just x))
+                 → ASTbind (ASTop (RWStell (x ∷ []) refl) (λ ()))
+                   (λ _ → ASTreturn (unit , (λ _ → [])))
+             })
+          (Level.lift (f (proj₂ i))))
+         (proj₁ i , proj₂ i))))
+      (λ x →
+         foldr (λ _ → Agda.Builtin.Nat.Nat.suc) 0
+         (proj₂
+          (proj₁
+           (ASTOpSem.runAST RWSOpSem
+            ((λ { (Level.lift nothing) → ASTreturn (unit , (λ x₁ → x₁ ++ x₁))
+                ; (Level.lift (just x))
+                    → ASTbind (ASTop (RWStell (x ∷ []) refl) (λ ()))
+                      (λ _ → ASTreturn (unit , (λ _ → [])))
+                })
+             (Level.lift (f (proj₂ i))))
+            (proj₁ i , proj₂ i)))
+          (proj₂
+           (proj₂
+            (ASTOpSem.runAST RWSOpSem
+             ((λ { (Level.lift nothing) → ASTreturn (unit , (λ x₁ → x₁ ++ x₁))
+                 ; (Level.lift (just x))
+                     → ASTbind (ASTop (RWStell (x ∷ []) refl) (λ ()))
+                       (λ _ → ASTreturn (unit , (λ _ → [])))
+                 })
+              (Level.lift (f (proj₂ i))))
+             (proj₁ i , proj₂ i)))))
+         ≡ 0)
+
+-}
+
+
+  -- wpTwoOuts : ∀ f i → ASTPredTrans.predTrans RWSPT (prog₁ f) TwoOuts i
+  -- wpTwoOuts f (e , s) w w= unit refl .(w ∷ w ∷ []) refl = refl
+
+-- RWSPTMono : ASTPredTransMono RWSPT
+-- ASTPredTransMono.returnPTMono RWSPTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
+--   P₁⊆ₒP₂ _ wp
+-- ASTPredTransMono.bindPTMono₁ RWSPTMono f monoF (ev , st) P₁ P₂ P₁⊆ₒP₂ (x₁ , st₁ , outs₁) wp .x₁ refl =
+--   monoF _ _ _ (λ o' pf' → P₁⊆ₒP₂ _ pf') (ev , st₁) (wp _ refl)
+-- ASTPredTransMono.bindPTMono₂ RWSPTMono f₁ f₂ f₁⊑f₂ (ev , st) P (x₁ , st₁ , outs₁) wp .x₁ refl =
+--   f₁⊑f₂ x₁ (RWSbindPost outs₁ P) (ev , st₁) (wp x₁ refl)
+-- ASTPredTransMono.opPTMono₁ RWSPTMono (RWSgets g) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+--   P₁⊆ₒP₂ _ wp
+-- ASTPredTransMono.opPTMono₁ RWSPTMono (RWSask refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+--   P₁⊆ₒP₂ _ wp
+-- ASTPredTransMono.opPTMono₁ RWSPTMono (RWStell out refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+--   P₁⊆ₒP₂ _ wp
+-- ASTPredTransMono.opPTMono₁ RWSPTMono RWSpass f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+--   monoF (Level.lift unit) _ _ (λ where ((x' , w') , st' , o') pf₁ ._ refl → P₁⊆ₒP₂ _ (pf₁ _ refl)) (ev , st) wp
+-- proj₁ (ASTPredTransMono.opPTMono₁ RWSPTMono (RWSif c) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp) refl =
+--   monoF (Level.lift true) _ _ P₁⊆ₒP₂ _ (proj₁ wp refl)
+-- proj₂ (ASTPredTransMono.opPTMono₁ RWSPTMono (RWSif c) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp) refl =
+--   monoF (Level.lift false) _ _ P₁⊆ₒP₂ _ (proj₂ wp refl)
+-- ASTPredTransMono.opPTMono₂ RWSPTMono (RWSgets g) f₁ f₂ f₁⊑f₂ P i wp =
+--   wp
+-- ASTPredTransMono.opPTMono₂ RWSPTMono (RWSask refl) f₁ f₂ f₁⊑f₂ P i wp =
+--   wp
+-- ASTPredTransMono.opPTMono₂ RWSPTMono (RWStell out refl) f₁ f₂ f₁⊑f₂ P i wp =
+--   wp
+-- ASTPredTransMono.opPTMono₂ RWSPTMono RWSpass f₁ f₂ f₁⊑f₂ P i wp =
+--   f₁⊑f₂ _ _ _ wp
+-- proj₁ (ASTPredTransMono.opPTMono₂ RWSPTMono (RWSif c) f₁ f₂ f₁⊑f₂ P i wp) refl =
+--   f₁⊑f₂ (Level.lift true) _ _ (proj₁ wp refl)
+-- proj₂ (ASTPredTransMono.opPTMono₂ RWSPTMono (RWSif c) f₁ f₂ f₁⊑f₂ P i wp) refl =
+--   f₁⊑f₂ (Level.lift false) _ _ (proj₂ wp refl )
+
+-- RWSSuf : ASTSufficientPT RWSOpSem RWSPT
+-- ASTSufficientPT.returnSuf RWSSuf x P i wp = wp
+-- ASTSufficientPT.bindSuf RWSSuf m f mSuf fSuf P (e , s₀) wp =
+--   let (x₁ , s₁ , o₁) = ASTOpSem.runAST RWSOpSem m (e , s₀)
+--       wpₘ = mSuf _ (e , s₀) wp _ refl
+--   in fSuf x₁ _ (e , s₁) wpₘ
+-- ASTSufficientPT.opSuf RWSSuf (RWSgets g) f fSuf P i wp = wp
+-- ASTSufficientPT.opSuf RWSSuf (RWSask refl) f fSuf P i wp = wp
+-- ASTSufficientPT.opSuf RWSSuf (RWStell out refl) f fSuf P i wp = wp
+-- ASTSufficientPT.opSuf RWSSuf RWSpass f fSuf P i wp =
+--   let ((x₁ , g) , s₁ , o₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) i
+--   in fSuf (Level.lift unit) (RWSpassPost P) i wp (g o₁) refl
+-- ASTSufficientPT.opSuf RWSSuf (RWSif false) f fSuf P i wp =
+--   fSuf (Level.lift false) _ _ (proj₂ wp refl)
+-- ASTSufficientPT.opSuf RWSSuf (RWSif true) f fSuf P i wp =
+--   fSuf (Level.lift true) _ _ (proj₁ wp refl)
+
+-- private
+--   twoOuts : ∀ f i → TwoOuts (runRWS (prog₁ f) i)
+--   twoOuts f i = ASTSufficientPT.sufficient RWSSuf (prog₁ f) TwoOuts i (wpTwoOuts f i)

--- a/src/Dijkstra/AST/Example.agda
+++ b/src/Dijkstra/AST/Example.agda
@@ -8,6 +8,7 @@ module Dijkstra.AST.Example (Ev Wr St : Set) where
 
 open import Data.Empty
 open import Data.Fin
+open import Data.List using ([_])
 open import Data.Product using (_×_ ; _,_ ; proj₁ ; proj₂)
 open import Data.Unit
 open import Dijkstra.AST.Core
@@ -71,7 +72,7 @@ private
           ASTop (RWSmaybe m) λ where
             (Level.lift nothing)  → ASTreturn (unit , λ x → x ++ x)
             (Level.lift (just w)) →
-              ASTbind (ASTop (RWStell (w ∷ []) refl) (λ ())) λ _ →
+              ASTbind (ASTop (RWStell ([ w ]) refl) (λ ())) λ _ →
               ASTreturn (unit , λ _ → [])
 
     module Sugar where
@@ -82,7 +83,7 @@ private
           m ← gets f
           maybe m (return (unit , λ x → x ++ x))
             λ w → do
-              tell (w ∷ [])
+              tell [ w ]
               return (unit , λ _ → [])
 
 RWSTypes : ASTTypes

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -1,0 +1,179 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+module Dijkstra.AST.RWS (Ev Wr St : Set) where
+
+open import Data.Empty
+open import Data.Fin
+open import Data.Product using (_×_ ; _,_ ; proj₁ ; proj₂)
+open import Data.Unit
+open import Dijkstra.AST.Core
+open import Function
+open import Haskell.Prelude
+import      Level
+import      Level.Literals as Level using (#_)
+open import Relation.Binary.PropositionalEquality
+
+data RWSCmd (A : Set) : Set₁ where
+  RWSgets   : (g : St → A)                 → RWSCmd A
+  RWSputs   : (p : St → St) → (A ≡ Unit)   → RWSCmd A
+  RWSask    : (A ≡ Ev)                     → RWSCmd A
+  RWSlocal  : (l : Ev → Ev)                → RWSCmd A
+  RWStell   : (out : List Wr) → (A ≡ Unit) → RWSCmd A
+  RWSlisten : {A' : Set} → (A ≡ (A' × List Wr)) → RWSCmd A
+  RWSpass   :                                RWSCmd A
+
+RWSResp : {A : Set} (c : RWSCmd A) → Set₁
+RWSResp (RWSgets g)          = Level.Lift _ ⊥
+RWSResp (RWSputs p refl)     = Level.Lift _ ⊥
+RWSResp (RWSask refl)        = Level.Lift _ ⊥
+RWSResp (RWSlocal l)         = Level.Lift _ ⊤
+RWSResp (RWStell out refl)   = Level.Lift _ ⊥
+RWSResp (RWSlisten{A'} refl) = Level.Lift _ ⊤
+RWSResp  RWSpass             = Level.Lift _ ⊤
+
+RWSSub : {A : Set} (c : RWSCmd A) → Set
+RWSSub{A} (RWSgets g) = A
+RWSSub{A} (RWSputs p x) = A
+RWSSub{A} (RWSask x) = A
+RWSSub{A} (RWSlocal l) = A
+RWSSub{A} (RWStell out x) = A
+RWSSub {.(_ × List Wr)} (RWSlisten{A'} refl) = A'
+RWSSub{A} RWSpass = A × (List Wr → List Wr)
+
+RWSOps : ASTOps
+ASTOps.Cmd RWSOps  = RWSCmd
+ASTOps.Resp RWSOps = RWSResp
+ASTOps.Sub  RWSOps = RWSSub
+
+RWS = AST RWSOps
+
+private
+  module _ where
+
+    prog₁ : (St → Wr) → RWS ⊤
+    prog₁ f =
+      ASTop RWSpass λ _ →
+        ASTbind (ASTop (RWSgets f) λ ()) λ w →
+        ASTbind (ASTop (RWStell (w ∷ []) refl) λ ()) λ _ →
+        ASTreturn (tt , λ o → o ++ o)
+
+RWSTypes : ASTTypes
+ASTTypes.Input  RWSTypes    = Ev × St
+ASTTypes.Output RWSTypes A  = A × St × List Wr
+
+open ASTTypes RWSTypes
+
+RWSOpSem : ASTOpSem RWSOps RWSTypes
+ASTOpSem.runAST RWSOpSem (ASTreturn x) (ev , st) = x , st , []
+ASTOpSem.runAST RWSOpSem (ASTbind m f) (ev , st₀) =
+  let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem m (ev , st₀)
+      (x₂ , st₂ , outs₂) = ASTOpSem.runAST RWSOpSem (f x₁) (ev , st₁)
+  in (x₂ , st₂ , outs₁ ++ outs₂)
+ASTOpSem.runAST RWSOpSem (ASTop (RWSgets g) f) (ev , st) =
+  g st , st , []
+ASTOpSem.runAST RWSOpSem (ASTop (RWSputs p refl) f) (ev , st) =
+  unit , p st , []
+ASTOpSem.runAST RWSOpSem (ASTop (RWSask refl) f) (ev , st) =
+  ev , st , []
+ASTOpSem.runAST RWSOpSem (ASTop (RWSlocal l) f) (ev , st) =
+  ASTOpSem.runAST RWSOpSem (f (Level.lift tt)) (l ev , st)
+ASTOpSem.runAST RWSOpSem (ASTop (RWStell out refl) f) (ev , st) =
+  unit , st , out
+ASTOpSem.runAST RWSOpSem (ASTop (RWSlisten refl) f) (ev , st) =
+  let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift tt)) (ev , st)
+  in (x₁ , outs₁) , st₁ , outs₁
+ASTOpSem.runAST RWSOpSem (ASTop RWSpass f) (ev , st) =
+  let ((x₁ , wf) , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift tt)) (ev , st)
+  in x₁ , st₁ , wf outs₁
+
+RWSbindPost : (outs : List Wr) {A : Set} → Post A → Post A
+RWSbindPost outs P (x , st , outs') = P (x , st , outs ++ outs')
+
+RWSpassPost : ∀ {A} → Post A → Post (A × (List Wr → List Wr))
+RWSpassPost P ((x , f) , s , o) = ∀ o' → o' ≡ f o → P (x , s , o')
+
+RWSPT : ASTPredTrans RWSOps RWSTypes
+ASTPredTrans.returnPT RWSPT x P (ev , st) =
+  P (x , st , [])
+ASTPredTrans.bindPT RWSPT f (ev , st) P (x , st' , outs) =
+  ∀ r → r ≡ x → f r (RWSbindPost outs P) (ev , st')
+ASTPredTrans.opPT RWSPT (RWSgets g) f P (ev , st) =
+  P (g st , st , [])
+ASTPredTrans.opPT RWSPT (RWSputs p refl) f P (ev , st) =
+  P (unit , p st , [])
+ASTPredTrans.opPT RWSPT (RWSask refl) f P (ev , st) =
+  P (ev , st , [])
+ASTPredTrans.opPT RWSPT (RWSlocal l) f P (ev , st) =
+  ∀ ev' → ev' ≡ l ev → f (Level.lift tt) P (ev' , st)
+ASTPredTrans.opPT RWSPT (RWStell out refl) f P (ev , st) =
+  P (unit , st , out)
+ASTPredTrans.opPT RWSPT (RWSlisten{A'} refl) f P (ev , st) =
+  f (Level.lift tt) Q (ev , st)
+  where
+  Q : Post A'
+  Q (x' , st' , outs') = P ((x' , outs') , st' , outs')
+ASTPredTrans.opPT RWSPT{A} RWSpass f P (ev , st) =
+  f (Level.lift tt) (RWSpassPost P) (ev , st)
+
+private
+  module _ where
+
+    Post₁ : Post ⊤
+    Post₁ (_ , _ , o) = length o ≡ 2
+
+    wpPost₁ : ∀ f i → ASTPredTrans.predTrans RWSPT (prog₁ f) Post₁ i
+    wpPost₁ f (e , s) w w= ._ refl o' refl = refl
+
+RWSPTMono : ASTPredTransMono RWSPT
+ASTPredTransMono.returnPTMono RWSPTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
+  P₁⊆ₒP₂ _ wp
+ASTPredTransMono.bindPTMono₁ RWSPTMono f monoF (ev , st) P₁ P₂ P₁⊆ₒP₂ (x₁ , st₁ , outs₁) wp .x₁ refl =
+  monoF _ _ _ (λ o' pf' → P₁⊆ₒP₂ _ pf') (ev , st₁) (wp _ refl)
+ASTPredTransMono.bindPTMono₂ RWSPTMono f₁ f₂ f₁⊑f₂ (ev , st) P (x₁ , st₁ , outs₁) wp .x₁ refl =
+  f₁⊑f₂ x₁ (RWSbindPost outs₁ P) (ev , st₁) (wp x₁ refl)
+ASTPredTransMono.opPTMono₁ RWSPTMono (RWSgets g) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+  P₁⊆ₒP₂ _ wp
+ASTPredTransMono.opPTMono₁ RWSPTMono (RWSputs p refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+  P₁⊆ₒP₂ _ wp
+ASTPredTransMono.opPTMono₁ RWSPTMono (RWSask refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+  P₁⊆ₒP₂ _ wp
+ASTPredTransMono.opPTMono₁ RWSPTMono (RWSlocal l) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp .(l ev) refl =
+  monoF (Level.lift tt) _ _ P₁⊆ₒP₂ (l ev , st) (wp _ refl)
+ASTPredTransMono.opPTMono₁ RWSPTMono (RWStell out refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+  P₁⊆ₒP₂ _ wp
+ASTPredTransMono.opPTMono₁ RWSPTMono (RWSlisten refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+  monoF (Level.lift tt) _ _ (λ where (x' , st' , o') → P₁⊆ₒP₂ _) (ev , st) wp
+ASTPredTransMono.opPTMono₁ RWSPTMono RWSpass f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+  monoF (Level.lift tt) _ _ (λ where ((x' , w') , st' , o') pf₁ ._ refl → P₁⊆ₒP₂ _ (pf₁ _ refl)) (ev , st) wp
+ASTPredTransMono.opPTMono₂ RWSPTMono (RWSgets g) f₁ f₂ f₁⊑f₂ P i wp =
+  wp
+ASTPredTransMono.opPTMono₂ RWSPTMono (RWSputs p refl) f₁ f₂ f₁⊑f₂ P i wp =
+  wp
+ASTPredTransMono.opPTMono₂ RWSPTMono (RWSask refl) f₁ f₂ f₁⊑f₂ P i wp =
+  wp
+ASTPredTransMono.opPTMono₂ RWSPTMono (RWSlocal l) f₁ f₂ f₁⊑f₂ P (ev , st) wp .(l ev) refl =
+  f₁⊑f₂ (Level.lift tt) _ _ (wp _ refl)
+ASTPredTransMono.opPTMono₂ RWSPTMono (RWStell out refl) f₁ f₂ f₁⊑f₂ P i wp =
+  wp
+ASTPredTransMono.opPTMono₂ RWSPTMono (RWSlisten refl) f₁ f₂ f₁⊑f₂ P i wp =
+  {!!}
+ASTPredTransMono.opPTMono₂ RWSPTMono RWSpass f₂ f₁⊑f₂ P i wp =
+  {!!}
+
+-- RWSSuf : ASTSufficientPT RWSOpSem RWSPT
+-- ASTSufficientPT.returnSuf RWSSuf x P i wp = wp
+-- ASTSufficientPT.bindSuf RWSSuf m f mSuf fSuf P i@(ev , st) wp =
+--   let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem m i
+--       wp' = mSuf _ i wp _ refl
+--   in
+--   fSuf x₁ _ (ev , st₁) wp'
+-- ASTSufficientPT.opSuf RWSSuf (RWSgets g) f fSuf P i wp = wp
+-- ASTSufficientPT.opSuf RWSSuf (RWSputs p refl) f fSuf P i wp = wp
+-- ASTSufficientPT.opSuf RWSSuf (RWSask refl) f fSuf P i wp = wp
+-- ASTSufficientPT.opSuf RWSSuf (RWSlocal l) f fSuf P (ev , st) wp =
+--   fSuf (Level.lift tt) _ (l ev , st) (wp _ refl)
+-- ASTSufficientPT.opSuf RWSSuf (RWStell out refl) f fSuf P i wp = wp

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -37,14 +37,14 @@ RWSSubArg (RWStell out refl)   = Level.Lift _ Void
 RWSSubArg (RWSlisten{A'} refl) = Level.Lift _ Unit
 RWSSubArg  RWSpass             = Level.Lift _ Unit
 
-RWSSubRet : {A : Set} (c : RWSCmd A) → Set
-RWSSubRet (RWSgets g) = Unit
-RWSSubRet (RWSputs p x) = Unit
-RWSSubRet (RWSask x) = Unit
-RWSSubRet{A} (RWSlocal l) = A
-RWSSubRet{A} (RWStell out x) = A
-RWSSubRet {.(_ × List Wr)} (RWSlisten{A'} refl) = A'
-RWSSubRet{A} RWSpass = A × (List Wr → List Wr)
+RWSSubRet : {A : Set} {c : RWSCmd A} (r : RWSSubArg c) → Set
+RWSSubRet{_} {RWSgets g} _ = Void
+RWSSubRet{_} {RWSputs p x} _ = Void
+RWSSubRet{_} {RWSask x} _ = Void
+RWSSubRet{A} {RWSlocal l} _ = A
+RWSSubRet{_} {RWStell out x} _ = Void
+RWSSubRet {.(_ × List Wr)} {RWSlisten{A'} refl} _ = A'
+RWSSubRet{A} {RWSpass} _ = A × (List Wr → List Wr)
 
 RWSOps : ASTOps
 ASTOps.Cmd RWSOps     = RWSCmd

--- a/src/Dijkstra/AST/Syntax.agda
+++ b/src/Dijkstra/AST/Syntax.agda
@@ -1,0 +1,21 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+module Dijkstra.AST.Syntax where
+
+open import Data.Empty
+open import Data.Product using (_×_ ; _,_ ; proj₁ ; proj₂)
+open import Data.Unit
+open import Dijkstra.AST.Core
+open import Function
+open import Haskell.Prelude
+import      Level
+import      Level.Literals as Level using (#_)
+
+instance
+  MonadAST : ∀ {OP : ASTOps} → Monad (AST OP)
+  Monad.return MonadAST = ASTreturn
+  Monad._>>=_ MonadAST = ASTbind

--- a/src/Dijkstra/RWS.agda
+++ b/src/Dijkstra/RWS.agda
@@ -70,6 +70,8 @@ RWS-weakestPre (RWS-bind m f) P ev pre =
 RWS-weakestPre (RWS-gets f) P ev pre = P (f pre) pre []
 RWS-weakestPre (RWS-put post) P ev pre = P unit post []
 RWS-weakestPre RWS-ask P ev pre = P ev pre []
+RWS-weakestPre (RWS-local f m) P ev pre =
+  ∀ ev' → ev' ≡ f ev → RWS-weakestPre m P ev' pre
 RWS-weakestPre (RWS-tell outs) P ev pre = P unit pre outs
 RWS-weakestPre (RWS-if (clause (b ≔ c) gs)) P ev pre =
   (toBool b ≡ true → RWS-weakestPre c P ev pre)
@@ -127,6 +129,8 @@ RWS-contract (RWS-bind m f) P ev pre wp
 RWS-contract (RWS-gets f) P ev pre wp = wp
 RWS-contract (RWS-put x₁) P ev pre wp = wp
 RWS-contract RWS-ask P ev pre wp = wp
+RWS-contract (RWS-local f m) P ev pre wp =
+  RWS-contract m P (f ev) pre (wp _ refl)
 RWS-contract (RWS-tell x₁) P ev pre wp = wp
 RWS-contract{Ev}{Wr}{St}{A} (RWS-if gs) P ev pre wp = RWS-contract-if gs P ev pre wp
   where
@@ -172,6 +176,8 @@ RWS-⇒ (RWS-bind m f) ev st pre pf =
 RWS-⇒ (RWS-gets f) ev st pre pf = pf _ _ _ pre
 RWS-⇒ (RWS-put x)  ev st pre pf = pf _ _ _ pre
 RWS-⇒ RWS-ask      ev st pre pf = pf _ _ _ pre
+RWS-⇒ (RWS-local f m) ev st pre pf _ refl =
+  RWS-⇒ m (f ev) st (pre _ refl) pf
 RWS-⇒ (RWS-tell x) ev st pre pf = pf _ _ _ pre
 RWS-⇒ (RWS-if (otherwise≔ x)) ev st pre pf = RWS-⇒ x ev st pre pf
 RWS-⇒ (RWS-if (clause (b ≔ c) cs)) ev st (pre₁ , pre₂) pf =

--- a/src/Haskell/Modules/FunctorApplicativeMonad.agda
+++ b/src/Haskell/Modules/FunctorApplicativeMonad.agda
@@ -47,7 +47,7 @@ record MonadLaws
   field
     idLeft  : ∀ {A B : Set ℓ₁} → (x : A) (f : A → M B)
               → (return x >>= f) ~ f x
-    idRight : ∀ {A B : Set ℓ₁} → (m : M A)
+    idRight : ∀ {A : Set ℓ₁} → (m : M A)
               → (m >>= return) ~ m
     assoc   : ∀ {A B C : Set ℓ₁} → (m : M A) (f : A → M B) (g : B → M C)
               → ((m >>= f) >>= g) ~ (m >>= (λ x → f x >>= g))

--- a/src/Haskell/Modules/FunctorApplicativeMonad.agda
+++ b/src/Haskell/Modules/FunctorApplicativeMonad.agda
@@ -12,6 +12,7 @@ open import Data.List
 open import Data.Maybe renaming (_>>=_ to _Maybe->>=_)
 open import Function
 open import Level renaming (suc to ℓ+1; zero to ℓ0; _⊔_ to _ℓ⊔_)
+open import Relation.Binary.PropositionalEquality
 
 record Functor  {ℓ₁ ℓ₂ : Level} (F : Set ℓ₁ → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
   infixl 4 _<$>_
@@ -39,6 +40,18 @@ record Monad {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) : Set (ℓ�
   _>>_ : ∀ {A B : Set ℓ₁} → M A → M B → M B
   m₁ >> m₂ = m₁ >>= λ _ → m₂
 open Monad ⦃ ... ⦄ public
+
+record MonadLaws
+  {ℓ₁ ℓ₂ : Level} (M : Set ℓ₁ → Set ℓ₂) ⦃ m : Monad M ⦄
+  (_~_ : {A : Set ℓ₁} → M A → M A → Set ℓ₂) : Set (ℓ₂ ℓ⊔ ℓ+1 ℓ₁) where
+  field
+    idLeft  : ∀ {A B : Set ℓ₁} → (x : A) (f : A → M B)
+              → (return x >>= f) ~ f x
+    idRight : ∀ {A B : Set ℓ₁} → (m : M A)
+              → (m >>= return) ~ m
+    assoc   : ∀ {A B C : Set ℓ₁} → (m : M A) (f : A → M B) (g : B → M C)
+              → ((m >>= f) >>= g) ~ (m >>= (λ x → f x >>= g))
+
 instance
   MonadApplicative : ∀ {ℓ₁ ℓ₂} {M : Set ℓ₁ → Set ℓ₂} ⦃ _ : Monad M ⦄ → Applicative M
   Applicative.pure  MonadApplicative       = return

--- a/src/Haskell/Modules/RWS.agda
+++ b/src/Haskell/Modules/RWS.agda
@@ -14,7 +14,7 @@ open import Haskell.Prelude
 ------------------------------------------------------------------------------
 open import Data.Product using (_×_; _,_)
 
--- (free) RWS : the AST of computations with state `St` reading from an environment
+-- RWS : the AST of computations with state `St` reading from an environment
 -- `Ev` and producing a list of outputs of type `Wr`
 data RWS (Ev Wr St : Set) : Set → Set₁ where
   -- Primitive combinators
@@ -23,6 +23,7 @@ data RWS (Ev Wr St : Set) : Set → Set₁ where
   RWS-gets   : ∀ {A} → (St → A)                                  → RWS Ev Wr St A
   RWS-put    : St                                                → RWS Ev Wr St Unit
   RWS-ask    :                                                     RWS Ev Wr St Ev
+  RWS-local  : ∀ {A} → (Ev → Ev) → RWS Ev Wr St A                → RWS Ev Wr St A
   RWS-tell   : List Wr                                           → RWS Ev Wr St Unit
   -- Branching combinators (used for creating more convenient contracts)
   RWS-if     : ∀ {A} → Guards (RWS Ev Wr St A)                   → RWS Ev Wr St A
@@ -83,6 +84,7 @@ RWS-run (RWS-bind m f)               ev st
 RWS-run (RWS-gets f)                 ev st = f st , st , []
 RWS-run (RWS-put st)                 ev _  = unit , st , []
 RWS-run RWS-ask                      ev st = ev , st , []
+RWS-run (RWS-local f m)              ev st = RWS-run m (f ev) st
 RWS-run (RWS-tell outs)              ev st = unit , st , outs
 RWS-run (RWS-if (clause (b ≔ c) gs)) ev st =
   if toBool b then RWS-run c ev st else RWS-run (RWS-if gs) ev st

--- a/src/Haskell/Prelude.agda
+++ b/src/Haskell/Prelude.agda
@@ -87,6 +87,10 @@ grd‖_ : ∀{a}{b}{A : Set a} → Guards{a}{b} A → A
 grd‖_ (otherwise≔ a) = a
 grd‖_ (clause (b ≔ a) g)  = if toBool b then a else (grd‖ g)
 
+lengthGuards : ∀ {a}{b}{A : Set a} → Guards{a}{b} A → DN.ℕ
+lengthGuards (otherwise≔ x) = 1
+lengthGuards (clause x x₁) = 1 DN.+ lengthGuards x₁
+
 ------------------------------------------------------------------------------
 -- List
 

--- a/src/Haskell/Prelude.agda
+++ b/src/Haskell/Prelude.agda
@@ -16,6 +16,9 @@ open import Level
 open import Data.Bool
   hiding (not; _≟_; _<_; _<?_; _≤_; _≤?_)
   public
+open import Data.Empty
+  renaming (⊥ to Void)
+  public
 open import Data.List
   hiding (map; filter; lookup; tabulate; foldl; fromMaybe; [_])
   public


### PR DESCRIPTION
This PR contains a POC generalization of the repo's current approach to program verification. A single datatype, `AST`, can be instantiated to a type equivalent to the existing `RWS` or to one equivalent to `EitherD`. Furthermore, the work of adding predicate transformers for branching operations need not be repeated for each such instance (as is done in the code currently), but can be generically added to a set of `AST` operations. 