### PR TITLE
Add ASTs for `Either` and `Maybe`, along with examples and proofs

### DIFF
--- a/src/Dijkstra/AST/Either.agda
+++ b/src/Dijkstra/AST/Either.agda
@@ -79,9 +79,10 @@ EitherbindPost f P (Right y) = f y P unit
 
 EitherPT : ASTPredTrans EitherOps EitherTypes
 ASTPredTrans.returnPT EitherPT x P i = P (Right x)
-ASTPredTrans.bindPT EitherPT {A} {B} f unit Post x =
+ASTPredTrans.bindPT EitherPT {A} {B} f i Post x =
   ∀ r → r ≡ x → EitherbindPost f Post r
 ASTPredTrans.opPT EitherPT (Either-bail a) f Post i = Post (Left a)
+open ASTPredTrans EitherPT
 
 private
   -- If Either-bail did not work (e.g., if it were a noop), prog₁ would return Right a and the proof

--- a/src/Dijkstra/AST/Either.agda
+++ b/src/Dijkstra/AST/Either.agda
@@ -1,0 +1,127 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+-- As we are interested in using Either for error handling (and providing the Either-bail command
+-- for this purpose), we call the Left type "Err"
+module Dijkstra.AST.Either (Err : Set) where
+
+open import Data.Empty
+open import Data.Product using (_×_) -- ; _,_ ; proj₁ ; proj₂)
+open import Data.Unit
+open import Dijkstra.AST.Core
+open import Haskell.Prelude
+import      Level
+import      Level.Literals as Level using (#_)
+open import Relation.Binary.PropositionalEquality
+
+data EitherCmd (A : Set) : Set₁ where
+  Either-bail : Err → EitherCmd A
+
+EitherSubArg : {A : Set} (a : EitherCmd A) → Set₁
+EitherSubArg (Either-bail _) = Level.Lift _ Void
+
+EitherSubRet : {A : Set} {c : EitherCmd A} (r : EitherSubArg c) → Set
+EitherSubRet {c = Either-bail _} _ = Void
+
+EitherOps : ASTOps
+ASTOps.Cmd    EitherOps  = EitherCmd
+ASTOps.SubArg EitherOps  = EitherSubArg
+ASTOps.SubRet EitherOps  = EitherSubRet
+
+EitherD = AST EitherOps
+
+module Syntax where
+  open import Dijkstra.AST.Syntax public
+
+  bail : ∀ {A} → Err → EitherD A
+  bail a = ASTop (Either-bail a) λ ()
+
+private
+  prog₁ : ∀ {A} → Err → A → EitherD A
+  prog₁ e a =
+    -- Either-bail always returns left, so Agda cannot infer the
+    -- type that it would return if it were to return Right, so
+    -- we provide a type explicitly (Unit, in this case)
+    ASTbind (ASTop (Either-bail {Unit} e) λ ()) λ _ →
+      ASTreturn a
+
+  module prog₁ where
+    open Syntax
+    prog₁' : ∀ {A} → Err → A → EitherD A
+    prog₁' {A} e a = do
+      bail {Void} e
+      return a
+
+EitherTypes : ASTTypes
+ASTTypes.Input  EitherTypes   = Unit -- We can always run an Either program.  In contrast, for an
+                                     -- RWS program, we need environment and prestate (Ev and St,
+                                     -- respectively)
+ASTTypes.Output EitherTypes A = Either Err A
+
+open ASTTypes EitherTypes
+
+EitherOpSem : ASTOpSem EitherOps EitherTypes
+ASTOpSem.runAST EitherOpSem (ASTreturn x) _ = Right x
+ASTOpSem.runAST EitherOpSem (ASTbind m f) i
+  with ASTOpSem.runAST EitherOpSem m i
+...| Left a = Left a
+...| Right x = ASTOpSem.runAST EitherOpSem (f x) i
+ASTOpSem.runAST EitherOpSem (ASTop (Either-bail a) f) i = Left a
+
+runEither = ASTOpSem.runAST EitherOpSem
+
+EitherbindPost : ∀ {A B} → (A → PredTrans B) → Post B → Post A
+EitherbindPost _ P (Left x)  = P (Left x)
+EitherbindPost f P (Right y) = f y P unit
+
+EitherPT : ASTPredTrans EitherOps EitherTypes
+ASTPredTrans.returnPT EitherPT x P i = P (Right x)
+ASTPredTrans.bindPT EitherPT {A} {B} f unit Post x =
+  ∀ r → r ≡ x → EitherbindPost f Post r
+ASTPredTrans.opPT EitherPT (Either-bail a) f Post i = Post (Left a)
+
+private
+  -- If Either-bail did not work (e.g., if it were a noop), prog₁ would return Right a and the proof
+  -- would fail
+  BailWorks : ∀ {A : Set} → Err → Post A
+  BailWorks e = _≡ Left e
+
+  bailWorks : ∀ e i {A : Set} → (a : A) → ASTPredTrans.predTrans EitherPT (prog₁ e a) (BailWorks e) i
+  bailWorks e unit _ _ refl = refl
+
+EitherPTMono : ASTPredTransMono EitherPT
+ASTPredTransMono.returnPTMono EitherPTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
+   P₁⊆ₒP₂ _ wp
+
+ASTPredTransMono.bindPTMono₁ EitherPTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ (Left x ) wp .(Left x ) refl =
+  P₁⊆ₒP₂ (Left x) (wp (Left x) refl)
+ASTPredTransMono.bindPTMono₁ EitherPTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ (Right y) wp .(Right y) refl =
+  monoF y P₁ P₂ P₁⊆ₒP₂ unit (wp (Right y) refl)
+
+ASTPredTransMono.bindPTMono₂ EitherPTMono {B1} {B2} f₁ f₂ f₁⊑f₂ unit P (Left x)  wp .(Left x) refl =
+  wp (Left x) refl
+ASTPredTransMono.bindPTMono₂ EitherPTMono f₁ f₂ f₁⊑f₂ unit P (Right y) wp .(Right y) refl =
+  f₁⊑f₂ y _ unit (wp (Right y) refl)
+
+ASTPredTransMono.opPTMono₁ EitherPTMono (Either-bail x) f monoF P₁ P₂ P₁⊆ₒP₂ unit wp =
+  P₁⊆ₒP₂ (Left x) wp
+
+ASTPredTransMono.opPTMono₂ EitherPTMono (Either-bail x) f₁ f₂ f₁⊑f₂ P i wp =
+  wp
+
+EitherSuf : ASTSufficientPT EitherOpSem EitherPT
+ASTSufficientPT.returnSuf EitherSuf x P i wp = wp
+ASTSufficientPT.bindSuf EitherSuf {A} {B} m f mSuf fSuf P unit wp
+   with  ASTOpSem.runAST EitherOpSem m  unit  | inspect
+        (ASTOpSem.runAST EitherOpSem m) unit
+... | Left  x | [ R ] = mSuf _ unit wp (Left x) (sym R)
+... | Right y | [ R ] = let wp' = mSuf _ unit wp (Right y) (sym R)
+                         in fSuf y P unit wp'
+ASTSufficientPT.opSuf EitherSuf (Either-bail x) f fSuf P i wp = wp
+
+private
+  bailWorksSuf : ∀ e {A : Set} (a : A) i → (runEither (prog₁ e a) i ≡ Left e)
+  bailWorksSuf e a i = ASTSufficientPT.sufficient EitherSuf (prog₁ e a) (BailWorks e) unit (bailWorks e unit a )

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -69,8 +69,9 @@ MaybebindPost f P (just y) = f y P unit
 
 MaybePT : ASTPredTrans MaybeOps MaybeTypes
 ASTPredTrans.returnPT MaybePT x P i               = P (just x)
-ASTPredTrans.bindPT   MaybePT f unit Post x       = ∀ r → r ≡ x → MaybebindPost f Post r
+ASTPredTrans.bindPT   MaybePT f i Post x       = ∀ r → r ≡ x → MaybebindPost f Post r
 ASTPredTrans.opPT     MaybePT Maybe-bail f Post i = Post nothing
+open ASTPredTrans MaybePT
 
 private
   BailWorks : ∀ {A} -> Post A
@@ -217,17 +218,11 @@ module Partiality where
   divWorks1 (Val x)     i sd  = ⇓Base
   divWorks1 (Div el er) i (erz , (sdel , sder))
     with ⟦ el ⟧ | ⟦ er ⟧ | divWorks1 el i sdel | divWorks1 er i sder
-  ... | ASTreturn Zero     | ASTreturn Zero     | dwl | dwr = ⊥-elim (erz dwr)
-  ... | ASTreturn Zero     | ASTreturn (Succ x) | dwl | dwr = xxx
-        where
-         xxx : _
-         xxx with ⇓Step dwl dwr
-         ... | xx = {!!}  -- Back at the same old goal shape that I'm running into and not knowing
-                          -- how to proceed, no matter which approach I take.
-  ... | ASTreturn (Succ x) | ASTreturn x₁       | dwl | dwr = {!!}
-  ... | ASTbind l f        | r                  | dwl | dwr = {!!}
-  ... | ASTop Maybe-bail f | r                  | dwl | dwr = {!!}
-  ... | ASTreturn Zero     | ASTbind w₂ f       | dwl | dwr = {!!}
-  ... | ASTreturn Zero     | ASTop Maybe-bail f | dwl | dwr = {!!}
-  ... | ASTreturn (Succ x) | ASTbind w₂ f       | dwl | dwr = {!!}
-  ... | ASTreturn (Succ x) | ASTop Maybe-bail f | dwl | dwr = {!!}
+  ... | _                  | ASTreturn Zero     | dwl | dwr = ⊥-elim (erz dwr)
+  ... | _                  | ASTop Maybe-bail _ | _   | ()
+  ... | ASTop Maybe-bail _ | _                  | ()  | _
+  ... | ASTreturn x1       | ASTreturn (Succ x) | dwl | dwr =
+      λ where ._ refl ._ refl → ⇓Step dwl dwr
+  ... | ASTbind m f        | ASTreturn (Succ x) | dwl | dwr = {!!}
+  ... | ASTbind m1 f1      | ASTbind m2 f2      | dwl | dwr = {!!}
+  ... | ASTreturn x        | ASTbind m f        | dwl | dwr = {!!}

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -1,0 +1,181 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+module Dijkstra.AST.Maybe where
+
+open import Dijkstra.AST.Core
+open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; return; Unit; unit; Void)
+import      Level
+open import Relation.Binary.PropositionalEquality
+
+data MaybeCmd (C : Set) : Set₁ where
+  Maybe-bail : MaybeCmd C
+
+MaybeSubArg : {C : Set} (c : MaybeCmd C) → Set₁
+MaybeSubArg Maybe-bail = Level.Lift _ Void
+
+MaybeSubRet : {A : Set} {c : MaybeCmd A} (r : MaybeSubArg c) → Set
+MaybeSubRet {c = Maybe-bail} ()
+
+MaybeOps : ASTOps
+ASTOps.Cmd    MaybeOps = MaybeCmd
+ASTOps.SubArg MaybeOps = MaybeSubArg
+ASTOps.SubRet MaybeOps = MaybeSubRet
+
+MaybeD = AST MaybeOps
+
+module Syntax where
+  open import Dijkstra.AST.Syntax public
+
+  bail : ∀ {A} → MaybeD A
+  bail = ASTop Maybe-bail (λ ())
+
+private
+
+  prog₁ : ∀ {A} → A → MaybeD A
+  prog₁ a =
+    ASTbind (ASTop (Maybe-bail {Void}) (λ ()))
+            (λ _ → ASTreturn  a)
+
+  module prog₁ where
+    open Syntax
+    prog₁' : ∀ {A} → A → MaybeD A
+    prog₁' a = do
+      bail {Void}
+      return a
+
+MaybeTypes : ASTTypes
+ASTTypes.Input  MaybeTypes   = Unit
+ASTTypes.Output MaybeTypes A = Maybe A
+
+open ASTTypes MaybeTypes
+
+MaybeOpSem : ASTOpSem MaybeOps MaybeTypes
+ASTOpSem.runAST MaybeOpSem (ASTreturn x) _ = just x
+ASTOpSem.runAST MaybeOpSem (ASTbind m f) i
+  with ASTOpSem.runAST MaybeOpSem m i
+...| nothing = nothing
+...| just x  = ASTOpSem.runAST MaybeOpSem (f x) i
+ASTOpSem.runAST MaybeOpSem (ASTop Maybe-bail f) i = nothing
+
+runMaybe = ASTOpSem.runAST MaybeOpSem
+
+MaybebindPost : ∀ {A B} → (A → PredTrans B) → Post B → Post A
+MaybebindPost _ P nothing  = P nothing
+MaybebindPost f P (just y) = f y P unit
+
+MaybePT : ASTPredTrans MaybeOps MaybeTypes
+ASTPredTrans.returnPT MaybePT x P i               = P (just x)
+ASTPredTrans.bindPT   MaybePT f unit Post x       = ∀ r → r ≡ x → MaybebindPost f Post r
+ASTPredTrans.opPT     MaybePT Maybe-bail f Post i = Post nothing
+
+private
+  BailWorks : ∀ {A} -> Post A
+  BailWorks o = o ≡ nothing
+
+  bailWorks : ∀ {A} (a : A) i → ASTPredTrans.predTrans MaybePT (prog₁ a) BailWorks i
+  bailWorks a unit maybeVoid maybeVoid≡nothing
+                             -- MaybebindPost (λ x P i → P (just a)) BailWorks           maybeVoid
+    with maybeVoid | maybeVoid≡nothing
+  ... | n | n≡nothing        -- MaybebindPost (λ x P i → P (just a)) (λ o → o ≡ nothing) n
+    rewrite n≡nothing        -- MaybebindPost (λ x P i → P (just a)) (λ o → o ≡ nothing) nothing
+    = refl
+
+MaybePTMono : ASTPredTransMono MaybePT
+ASTPredTransMono.returnPTMono MaybePTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
+  P₁⊆ₒP₂ _ wp
+
+ASTPredTransMono.bindPTMono₁  MaybePTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ nothing  wp .nothing  refl =
+  P₁⊆ₒP₂ nothing (wp nothing refl)
+ASTPredTransMono.bindPTMono₁  MaybePTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ (just y) wp .(just y) refl =
+  monoF y P₁ P₂ P₁⊆ₒP₂ unit (wp (just y) refl)
+
+ASTPredTransMono.bindPTMono₂  MaybePTMono {B1} {B2} f₁ f₂ f₁⊑f₂ unit P nothing wp .nothing refl =
+  wp nothing refl
+ASTPredTransMono.bindPTMono₂  MaybePTMono f₁ f₂ f₁⊑f₂ unit P (just y) wp .(just y) refl =
+  f₁⊑f₂ y _ unit (wp (just y) refl)
+
+ASTPredTransMono.opPTMono₁    MaybePTMono Maybe-bail f monoF P₁ P₂ P₁⊆ₒP₂ unit wp =
+  P₁⊆ₒP₂ nothing wp
+ASTPredTransMono.opPTMono₂    MaybePTMono Maybe-bail f₁ f₂ f₁⊑f₂ P i wp =
+  wp
+
+MaybeSuf : ASTSufficientPT MaybeOpSem MaybePT
+ASTSufficientPT.returnSuf MaybeSuf x P i wp = wp
+ASTSufficientPT.bindSuf   MaybeSuf {A} {B} m f mSuf fSuf P unit wp
+  with ASTOpSem.runAST MaybeOpSem m unit | inspect (ASTOpSem.runAST MaybeOpSem m) unit
+... | nothing | [ eq ] = mSuf _ unit wp nothing (sym eq)
+... | just y  | [ eq ] = let wp' = mSuf _ unit wp (just y) (sym eq)
+                          in fSuf y P unit wp'
+ASTSufficientPT.opSuf     MaybeSuf Maybe-bail f fSuf P i wp = wp
+
+private
+  bailWorksSuf : ∀ {A : Set} (a : A) i → (runMaybe (prog₁ a) i ≡ nothing)
+--bailWorksSuf a i =
+--  ASTSufficientPT.sufficient MaybeSuf (prog₁ a) BailWorks unit (bailWorks a unit)
+  bailWorksSuf a i
+    with runMaybe (prog₁ a) i
+  ... | x≡x = refl
+
+------------------------------------------------------------------------------
+
+module Partiality where
+  {- from "A predicate transformer semantics for effects"
+     https://webspace.science.uu.nl/~swier004/publications/2019-icfp-submission-a.pdf
+  -}
+  open Syntax
+  open import Agda.Builtin.Unit using (⊤; tt)
+  open import Data.Empty using (⊥)
+  open import Data.Nat public using () renaming (ℕ to Nat; zero to Zero; suc to Succ)
+  open import Data.Nat.DivMod
+
+  data Expr : Set where
+    Val : Nat  -> Expr
+    Div : Expr -> Expr -> Expr
+
+  data _⇓_ : Expr -> Nat -> Set where
+    ⇓Base : forall {n}
+         -> Val n ⇓ n
+    ⇓Step : forall {el er n1 n2}
+         ->     el    ⇓  n1
+         ->        er ⇓         (Succ n2) -- divisor is non-zero
+         -> Div el er ⇓ (n1 div (Succ n2))
+
+  _÷_ : Nat -> Nat -> MaybeD Nat
+  n ÷ Zero     = bail
+  n ÷ (Succ k) = return (n div (Succ k))
+
+  ⟦_⟧ : Expr -> MaybeD Nat
+  ⟦ Val x ⟧     = return x
+  ⟦ Div e1 e2 ⟧ = ⟦ e1 ⟧ >>= \v1 ->
+                  ⟦ e2 ⟧ >>= \v2 ->
+                  v1 ÷ v2
+
+  record Pair {l l'} (a : Set l) (b : Set l') : Set (l Level.⊔ l') where
+    constructor _,_
+    field
+      fst : a
+      snd : b
+
+  _∧_ : ∀ {l l'} -> Set l -> Set l' -> Set (l Level.⊔ l')
+  _∧_ A B = Pair A B
+  infixr 1 _∧_
+
+  SafeDiv : Expr -> Set
+  SafeDiv (Val x)     = ⊤
+  SafeDiv (Div e1 e2) = (e2 ⇓ Zero -> ⊥) ∧ SafeDiv e1 ∧ SafeDiv e2
+
+  -- everything below this point COULD BE WRONG
+
+  -- TODO: Is this the right way to integrate SafeDiv into our system?
+  PN : Expr → Post Nat
+  PN e nothing  = SafeDiv e
+  PN e (just _) = SafeDiv e
+
+  -- this is like 'bailWorks' above
+  divWorks : ∀ (e : Expr) i → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
+  divWorks (Val x)     unit = tt
+  divWorks (Div el er) unit = {!!}

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -69,7 +69,7 @@ MaybebindPost f P (just y) = f y P unit
 
 MaybePT : ASTPredTrans MaybeOps MaybeTypes
 ASTPredTrans.returnPT MaybePT x P i               = P (just x)
-ASTPredTrans.bindPT   MaybePT f i Post x       = ∀ r → r ≡ x → MaybebindPost f Post r
+ASTPredTrans.bindPT   MaybePT f i Post x          = ∀ r → r ≡ x → MaybebindPost f Post r
 ASTPredTrans.opPT     MaybePT Maybe-bail f Post i = Post nothing
 open ASTPredTrans MaybePT
 
@@ -225,4 +225,5 @@ module Partiality where
       λ where ._ refl ._ refl → ⇓Step dwl dwr
   ... | ASTbind m f        | ASTreturn (Succ x) | dwl | dwr = {!!}
   ... | ASTbind m1 f1      | ASTbind m2 f2      | dwl | dwr = {!!}
-  ... | ASTreturn x        | ASTbind m f        | dwl | dwr = {!!}
+  ... | ASTreturn x        | ASTbind m f        | dwl | dwr =
+      λ where ._ refl → {!!}


### PR DESCRIPTION
This combines work done by @mark-moir, @haroldcarr and @cwjnkins to add `Either` and `Maybe` AST versions and prove required properties plus some examples.  I'm proposing to merge this to branch `chris-pr-189`, where we can continue this work before merging to `main`.