### PR TITLE
Create `AST` version of `insertBlockE`, prove its contract (after refining it)

### DIFF
--- a/src/Dijkstra/AST/Core.agda
+++ b/src/Dijkstra/AST/Core.agda
@@ -47,17 +47,17 @@ record ASTTypes : Set₁ where
   PredTrans : (A : Set) → Set₁
   PredTrans A = (P : Post A) → Pre
 
-  _⊆ᵢ_ : (P₁ P₂ : Pre) → Set
-  P₁ ⊆ᵢ P₂ = ∀ i → P₁ i → P₂ i
+  _⊆ᵢ_ : (Pre₁ Pre₂ : Pre) → Set
+  Pre₁ ⊆ᵢ Pre₂ = ∀ i → Pre₁ i → Pre₂ i
 
-  _⊆ₒ_ : ∀ {A} → (P₁ P₂ : Post A) → Set
-  P₁ ⊆ₒ P₂ = ∀ o → P₁ o → P₂ o
+  _⊆ₒ_ : ∀ {A} → (Post₁ Post₂ : Post A) → Set
+  Post₁ ⊆ₒ Post₂ = ∀ o → Post₁ o → Post₂ o
 
   _⊑_ : {A : Set} → (pt₁ pt₂ : PredTrans A) → Set₁
-  pt₁ ⊑ pt₂ = ∀ P → pt₁ P ⊆ᵢ pt₂ P
+  pt₁ ⊑ pt₂ = ∀ Pre → pt₁ Pre ⊆ᵢ pt₂ Pre
 
   MonoPredTrans : ∀ {A} → PredTrans A → Set₁
-  MonoPredTrans pt = ∀ P₁ P₂ → (P₁⊆ₒP₂ : P₁ ⊆ₒ P₂) → pt P₁ ⊆ᵢ pt P₂
+  MonoPredTrans pt = ∀ Post₁ Post₂ → Post₁ ⊆ₒ Post₂ → pt Post₁ ⊆ᵢ pt Post₂
 
 record ASTOpSem (OP : ASTOps) (Ty : ASTTypes) : Set₁ where
   constructor mkASTOpSem

--- a/src/Dijkstra/AST/Either.agda
+++ b/src/Dijkstra/AST/Either.agda
@@ -12,11 +12,10 @@ open import Data.Empty
 open import Data.Product using (_×_) -- ; _,_ ; proj₁ ; proj₂)
 open import Data.Unit
 open import Dijkstra.AST.Core
-open import Haskell.Prelude
+open import Haskell.Prelude hiding (return)
 import      Level
 import      Level.Literals as Level using (#_)
 open import Relation.Binary.PropositionalEquality
-
 data EitherCmd (A : Set) : Set₁ where
   Either-bail : Err → EitherCmd A
 
@@ -39,6 +38,9 @@ module Syntax where
   bail : ∀ {A} → Err → EitherD A
   bail a = ASTop (Either-bail a) λ ()
 
+  return : ∀ {A} → A → EitherD A
+  return a = ASTreturn a
+
 private
   prog₁ : ∀ {A} → Err → A → EitherD A
   prog₁ e a =
@@ -60,7 +62,6 @@ ASTTypes.Input  EitherTypes   = Unit -- We can always run an Either program.  In
                                      -- RWS program, we need environment and prestate (Ev and St,
                                      -- respectively)
 ASTTypes.Output EitherTypes A = Either Err A
-
 open ASTTypes EitherTypes
 
 EitherOpSem : ASTOpSem EitherOps EitherTypes

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -200,7 +200,8 @@ module Partiality where
   -- TUTORIAL: This example provides a good demonstration of how predTransMono can be used to
   -- construct proofs for ASTs that include ASTbind, and shows how Agda can figure out the required
   -- post condition from context, saving us from writing out ugly expressions for the continuation
-  -- of a bind.
+  -- of a bind.  For example, we do not need to write out the second post condition in the type
+  -- signature of PN⊆₁ below, because Agda figures it out from the goal.
   divWorks : ∀ (e : Expr) i → SafeDiv e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
   divWorks (Val x₁) i x = ⇓Base
   divWorks (Div e₁ e₂) unit (¬e₂⇓0 , (sd₁ , sd₂)) =

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -21,6 +21,10 @@ open import Util.Hash
 import      Util.KVMap                                           as Map
 open import Util.PKCS
 open import Util.Prelude
+open import Dijkstra.AST.Core
+open import Dijkstra.AST.Either renaming (EitherD to EitherAST; return to return-AST)
+open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; return; Unit; unit; Void)
+
 ------------------------------------------------------------------------------
 open import Data.String                                          using (String)
 
@@ -56,6 +60,9 @@ abstract
 
   addChild-≡-E1 : ∀ (lb : LinkableBlock) (hv : HashValue) → addChild-E lb hv ≡ EitherD-run (addChild lb hv)
   addChild-≡-E1 lb hv = refl
+
+  postulate -- TODO: implement it
+    addChild-AST : LinkableBlock → HashValue → EitherAST ErrLog LinkableBlock
 
 new : ExecutedBlock → QuorumCert → QuorumCert → Usize → Maybe TimeoutCertificate
     → Either ErrLog BlockTree
@@ -118,6 +125,27 @@ insertBlockE-original block bt = do
         let bt' = bt & btIdToBlock ∙~ Map.kvm-insert-Haskell (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
         pure (  (bt' & btIdToBlock ∙~ Map.kvm-insert-Haskell blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
              , block))
+
+-- An AST version
+module _ where
+  open import Dijkstra.AST.Either ErrLog
+  open import Dijkstra.AST.Core
+  import Dijkstra.AST.Either ErrLog as EitherAST
+  open EitherAST.Syntax renaming (bail to bail-AST; return to return-AST)
+
+  insertBlockE-AST : ExecutedBlock → BlockTree → EitherAST ErrLog (BlockTree × ExecutedBlock)
+  insertBlockE-AST block bt = do
+    let blockId = block ^∙ ebId
+    case btGetBlock blockId bt of λ where
+      (just existingBlock) → return-AST (bt , existingBlock)
+      nothing → case btGetLinkableBlock (block ^∙ ebParentId) bt of λ where
+        nothing → bail-AST fakeErr
+        (just parentBlock) → (do
+          parentBlock' ← addChild-AST parentBlock blockId
+          let bt' = bt & btIdToBlock ∙~ Map.kvm-insert-Haskell (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
+          pure (  (bt' & btIdToBlock ∙~ Map.kvm-insert-Haskell blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
+               , block))
+
 
 -- An EitherD variant, broken into steps
 module insertBlockE (block : ExecutedBlock)(bt : BlockTree) where

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -120,7 +120,8 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (vblock : ValidBlock) where
     -- in the else branch, we call step₂ bsr
     proj₂ (proj₂ contract₁ bsr bsr≡) btr<br = contract₂
       where
-      contract₃ : ∀ eb → block ≡ (eb ^∙ ebBlock) → BlockIsValid (eb ^∙ ebBlock) (eb ^∙ ebId)
+      contract₃ : ∀ eb → block ≡ (eb ^∙ ebBlock)
+                  → BlockIsValid (eb ^∙ ebBlock) (eb ^∙ ebId)
                   → EitherD-weakestPre (step₃ eb) Contract
 
       module EB = executeBlockESpec bs0 vblock

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockStore.agda
@@ -87,7 +87,7 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (vblock : ValidBlock) where
   record ContractOk (bs' : BlockStore) (eb : ExecutedBlock) : Set where
     constructor mkContractOk
     field
-      ebBlock≈ : NoHC1 → BlockIsValid (eb ^∙ ebBlock) (eb ^∙ ebId) → eb ^∙ ebBlock ≈Block block
+      ebBlock≈ : NoHC1 → eb ^∙ ebBlock ≈Block block
       bsInv    : ∀ {eci}
                  → Preserves BlockStoreInv (bs0 , eci) (bs' , eci)
       -- executeAndInsertBlockE does not modify BlockTree fields other than btIDToBlock
@@ -106,7 +106,7 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (vblock : ValidBlock) where
   -- this translates to EitherD-maybe.  We first deal with the easy case, applying the NoHC1
   -- function provided to ebBlock≈ to evidence eb≡ that eb is in btIdToBlock.
   proj₂ contract' eb eb≡ =
-    mkContractOk (λ nohc _ → nohc eb≡ block-c) id refl
+    mkContractOk (λ nohc → nohc eb≡ block-c) id refl
   proj₁ contract' getBlock≡nothing = contract₁
     where
     -- step₁ is again a maybeSD; if bs0 ^∙ bsRoot ≡ nothing, the Contract is trivial
@@ -161,7 +161,7 @@ module executeAndInsertBlockESpec (bs0 : BlockStore) (vblock : ValidBlock) where
              con⇒bindPost : ∀ r → insertBlockESpec.Contract eb (bs0 ^∙ bsInner) r → EitherD-weakestPre-bindPost _ Contract r
              con⇒bindPost (Left _) _                       = tt
              con⇒bindPost (Right (bt' , eb')) con' ._ refl =
-               mkContractOk (λ nohc biv → IBE.blocks≈ nohc block-c)
+               mkContractOk (λ nohc → IBE.blocks≈ nohc block-c)
                             btP bss≡x
                where
                  module IBE = insertBlockESpec.ContractOk con'

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -4,7 +4,9 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import Dijkstra.AST.Core
 open import LibraBFT.Base.Types
+open import LibraBFT.Concrete.Records using (BlockId-correct)
 open import LibraBFT.Impl.Consensus.BlockStorage.BlockStore
 open import LibraBFT.Impl.Consensus.BlockStorage.BlockTree
 open import LibraBFT.Impl.Consensus.ConsensusTypes.ExecutedBlock as ExecutedBlock
@@ -19,13 +21,36 @@ open import Optics.All
 open import Util.ByteString
 open import Util.Hash
 open import Util.KVMap                                           as Map
+open import Util.Lemmas
 open import Util.PKCS
 open import Util.Prelude
+
+open import Dijkstra.AST.Either ErrLog renaming (EitherD to EitherAST)
 
 open QCProps
 open Invariants
 
 module LibraBFT.Impl.Consensus.BlockStorage.Properties.BlockTree where
+
+module addChildSpec (lb : LinkableBlock) (hv : HashValue) where
+
+  open addChild lb hv
+
+  record ContractOk (lb' : LinkableBlock) : Set where
+    field
+      presLB : lb ≡L lb' at lbExecutedBlock
+  open ContractOk
+
+  Contract : Either ErrLog LinkableBlock → Set
+  Contract (Left _) = ⊤
+  Contract (Right lb') = ContractOk lb'
+
+  postulate -- TODO: prove after implementing addChild
+    contract'-AST : ASTPredTrans.predTrans EitherPT addChild-AST Contract unit
+
+  contract-AST : Contract (runEither addChild-AST unit)
+  contract-AST = ASTSufficientPT.sufficient EitherSuf addChild-AST Contract unit contract'-AST
+
 
 module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
   eb0Id = eb0 ^∙ ebId
@@ -50,22 +75,12 @@ module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
 
   open Reqs (eb0 ^∙ ebBlock) bt
 
-  -- This is not quite right.  It does not yet account for the updating of the parent Block
-  -- Is it needed (see below)?
-  record Updated (hv : HashValue) (pre post : BlockTree) (eb : ExecutedBlock) : Set where
-    field
-      ≢hv¬Upd : ∀ {hv'} → hv' ≢ hv → btGetBlock hv' post ≡ btGetBlock hv' pre
-
   record ContractOk (bt“ : BlockTree) (eb : ExecutedBlock) : Set where
     constructor mkContractOk
     field
       bt≡x    : bt ≡ (bt“ & btIdToBlock ∙~ (bt ^∙ btIdToBlock))
-      -- The following two fields are not used, but something like this will be useful in proving
-      -- btiPres and may provide value in their own right
-      ¬upd    : ∀ {eb'} → btGetBlock eb0Id bt ≡ just eb' → bt ≡ bt“
-      upd     :           btGetBlock eb0Id bt ≡ nothing  →  Updated eb0Id bt bt“ eb
-      blocks≈ : NoHC1 → eb [ _≈Block_ ]L eb0 at ebBlock
-      btiPres : ∀ {eci} → Preserves BlockTreeInv (bt , eci) (bt“ , eci)
+      blocks≈ : NoHC1 → BlockId-correct (eb0 ^∙ ebBlock) → eb [ _≈Block_ ]L eb0 at ebBlock
+      btiPres : BlockIsValid (eb0 ^∙ ebBlock) eb0Id → ∀ {eci} → Preserves BlockTreeInv (bt , eci) (bt“ , eci)
 
   Contract : Either ErrLog (BlockTree × ExecutedBlock) → Set
   Contract (Left _) = ⊤
@@ -83,6 +98,84 @@ module insertBlockESpec (eb0 : ExecutedBlock) (bt : BlockTree) where
   -- A contract (not used yet) for the Either version
   contract-E : Contract (insertBlockE.E eb0 bt)
   contract-E = EitherD-contract (step₀ eb0 bt) Contract contract'
+
+  open ASTVersion eb0 bt
+  open addChild
+
+  contract'-AST : ASTPredTrans.predTrans EitherPT insertBlockE-AST Contract unit
+  contract'-AST
+     with  btGetBlock (eb0 ^∙ ebId)  bt | inspect
+          (btGetBlock (eb0 ^∙ ebId)) bt
+  ... | just existingBlock | [ R ] =
+          mkContractOk refl
+                       (λ nohc eb0IdCorr → nohc {existingBlock} R eb0IdCorr)
+                       λ _ → id
+  ... | nothing | [ R ]
+    with  btGetLinkableBlock (eb0 ^∙ ebParentId)  bt | inspect
+         (btGetLinkableBlock (eb0 ^∙ ebParentId)) bt
+  ... | nothing | _ = tt
+  ... | just parentBlock | [ R' ] =
+          ASTPredTransMono.predTransMono EitherPTMono
+            (addChild-AST parentBlock (eb0 ^∙ ebId))
+            (addChildSpec.Contract parentBlock (eb0 ^∙ ebId))
+            _
+            Contract⊆
+            unit
+            (addChildSpec.contract'-AST  parentBlock (eb0 ^∙ ebId))
+
+         where
+           btInsert : BlockTree → HashValue → LinkableBlock → BlockTree
+           btInsert bt bid lb = bt & btIdToBlock ∙~ Map.kvm-insert-Haskell bid lb (bt ^∙ btIdToBlock)
+
+           pres-AVB : ∀ {bt : BlockTree} → AllValidBlocks bt
+                      → {bid : HashValue} {lb : LinkableBlock}
+                      → BlockIsValid ((lb ^∙ lbExecutedBlock) ^∙ ebBlock) bid
+                      → AllValidBlocks (btInsert bt bid lb)
+           pres-AVB {bt} hyp {bid} {lb} biv {bid'} {eb} ij
+             with bid' ≟Hash bid
+           ...| no  neq  rewrite sym (insert-target-≢-Haskell {v = lb} {kvm = bt ^∙ btIdToBlock} neq) = hyp ij
+           ...| yes refl rewrite lookup-correct-haskell {k = bid} {v = lb} {kvm = bt ^∙ btIdToBlock}
+                               | just-injective ij = biv
+
+           module _ (parentBlock' : LinkableBlock)
+                    (parentValid  : BlockIsValid ((parentBlock' ^∙ lbExecutedBlock) ^∙ ebBlock) (eb0 ^∙ ebParentId))
+                    (ebValid      : BlockIsValid (eb0 ^∙ ebBlock) (eb0 ^∙ ebId)) where
+             bt' : BlockTree
+             bt' = btInsert bt (eb0 ^∙ ebParentId) parentBlock'
+
+             bt'' : BlockTree
+             bt'' = btInsert bt' (eb0 ^∙ ebId) (LinkableBlock∙new eb0)
+
+             finalAllValidBlocks : AllValidBlocks bt → AllValidBlocks bt''
+             finalAllValidBlocks avb = pres-AVB {bt'} (pres-AVB {bt} avb parentValid) ebValid
+
+           Contract⊆ : _
+           Contract⊆ (Left _)    _                    .(Left _)             refl = tt
+           Contract⊆ (Right parentBlock') addChildCon .(Right parentBlock') refl = con
+             where
+             con : _
+             con = mkContractOk
+                          refl
+                          (λ _ _ → refl)
+                          λ eb0Valid bti → mkBlockTreeInv
+                                             (BlockTreeInv.allValidQCs bti)
+                                             (finalAllValidBlocks parentBlock'
+                                                                  (biv1 $ BlockTreeInv.allValidBlocks bti)
+                                                                  eb0Valid
+                                                                  (BlockTreeInv.allValidBlocks bti))
+                    where
+
+                      -- Because rewrite directly in biv1 did not work for some reason
+                      biv' : AllValidBlocks bt → _ → _
+                      biv' avb refl
+                         with avb (btGetBlock≡ {bt = bt} R')
+                      ...| bv = mkBlockIsValid (BlockIsValid.bidCorr {bid = eb0 ^∙ ebParentId} bv)
+                                               (BlockIsValid.bhashCorr bv)
+                      biv1 : AllValidBlocks bt → _
+                      biv1 avb = biv' avb (sym (cong (_^∙ ebBlock) (addChildSpec.ContractOk.presLB addChildCon)))
+
+  contract-AST : Contract (runEither insertBlockE-AST unit)
+  contract-AST = ASTSufficientPT.sufficient EitherSuf insertBlockE-AST Contract unit contract'-AST
 
 module insertQuorumCertESpec
   (qc : QuorumCert) (bt0  : BlockTree) where

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -52,7 +52,11 @@ module addChildSpec (lb : LinkableBlock) (hv : HashValue) where
   contract-AST = ASTSufficientPT.sufficient EitherSuf addChild-AST Contract unit contract'-AST
 
 
-module insertBlockESpec (eb0 : ExecutedBlock) (eb0Valid : BlockIsValid (eb0 ^∙ ebBlock) (eb0 ^∙ ebId)) (bt : BlockTree) where
+module insertBlockESpec
+         (eb0 : ExecutedBlock)
+         (eb0Valid : BlockIsValid (eb0 ^∙ ebBlock) (eb0 ^∙ ebId))
+         (bt : BlockTree)
+  where
   eb0Id = eb0 ^∙ ebId
 
   -- A straightforward proof that the EitherD variant of insertBlockE has the same behaviour as the
@@ -160,7 +164,7 @@ module insertBlockESpec (eb0 : ExecutedBlock) (eb0Valid : BlockIsValid (eb0 ^∙
                           λ bti → mkBlockTreeInv
                                     (BlockTreeInv.allValidQCs bti)
                                     (finalAllValidBlocks parentBlock'
-                                                         (biv1 $ BlockTreeInv.allValidBlocks bti)
+                                                         (biv (BlockTreeInv.allValidBlocks bti))
                                                          eb0Valid
                                                          (BlockTreeInv.allValidBlocks bti))
                     where
@@ -171,8 +175,8 @@ module insertBlockESpec (eb0 : ExecutedBlock) (eb0Valid : BlockIsValid (eb0 ^∙
                          with avb (btGetBlock≡ {bt = bt} R')
                       ...| bv = mkBlockIsValid (BlockIsValid.bidCorr {bid = eb0 ^∙ ebParentId} bv)
                                                (BlockIsValid.bhashCorr bv)
-                      biv1 : AllValidBlocks bt → _
-                      biv1 avb = biv' avb (sym (cong (_^∙ ebBlock) (addChildSpec.ContractOk.presLB addChildCon)))
+                      biv : AllValidBlocks bt → _
+                      biv avb = biv' avb (sym (cong (_^∙ ebBlock) (addChildSpec.ContractOk.presLB addChildCon)))
 
   contract-AST : Contract (runEither insertBlockE-AST unit)
   contract-AST = ASTSufficientPT.sufficient EitherSuf insertBlockE-AST Contract unit contract'-AST

--- a/src/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/src/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -191,7 +191,7 @@ module executeAndVoteMSpec (vb : ValidBlock) where
                   Voting.glue-VoteNotGenerated-VoteGeneratedCorrect
                     (mkVoteNotGenerated refl refl)
                     (Voting.substVoteGeneratedCorrect proposedBlock b
-                      (EAIBECon.ebBlock≈ nohc)
+                      (EAIBECon.ebBlock≈ nohc {- Now requires another argument, see isOk, vbValid vb -})
                       vrc)
 
                 noMsgOutsBail₃ : ∀ outs → NoMsgs outs → NoMsgs (CASVouts ++ outs)

--- a/src/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
+++ b/src/LibraBFT/Impl/Consensus/RoundManager/Properties.agda
@@ -191,7 +191,7 @@ module executeAndVoteMSpec (vb : ValidBlock) where
                   Voting.glue-VoteNotGenerated-VoteGeneratedCorrect
                     (mkVoteNotGenerated refl refl)
                     (Voting.substVoteGeneratedCorrect proposedBlock b
-                      (EAIBECon.ebBlock≈ nohc {- Now requires another argument, see isOk, vbValid vb -})
+                      (EAIBECon.ebBlock≈ nohc)
                       vrc)
 
                 noMsgOutsBail₃ : ∀ outs → NoMsgs outs → NoMsgs (CASVouts ++ outs)

--- a/src/LibraBFT/Impl/Properties/Util.agda
+++ b/src/LibraBFT/Impl/Properties/Util.agda
@@ -259,7 +259,7 @@ module Invariants where
 
   -- This is not currently used, but illustrates that BlockIsValid is a bit weird and possibly
   -- should be stated in a more intuitive way.
-  validHash⇒validBlock : ∀ {b : Block} → BlockHash≡ b (b ^∙ bId) → BlockIsValid b (b ^∙ bId)
+  validHash⇒validBlock : ∀ {b : Block} → BlockId-correct b → BlockIsValid b (b ^∙ bId)
   validHash⇒validBlock b≡ = mkBlockIsValid b≡ b≡
 
   AllValidBlocks : BlockTree → Set

--- a/src/LibraBFT/Impl/Properties/Util.agda
+++ b/src/LibraBFT/Impl/Properties/Util.agda
@@ -257,7 +257,7 @@ module Invariants where
       bidCorr   : BlockId-correct b
       bhashCorr : BlockHash≡ b bid
 
-  -- This is not currently used, but illustrates that BlockIsValid is a bit weird and possibly
+  -- This illustrates that BlockIsValid is a bit weird and possibly
   -- should be stated in a more intuitive way.
   validHash⇒validBlock : ∀ {b : Block} → BlockId-correct b → BlockIsValid b (b ^∙ bId)
   validHash⇒validBlock b≡ = mkBlockIsValid b≡ b≡

--- a/src/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
+++ b/src/LibraBFT/ImplShared/Consensus/Types/EpochIndep.agda
@@ -802,6 +802,11 @@ module LibraBFT.ImplShared.Consensus.Types.EpochIndep where
   btGetBlock : HashValue → BlockTree → Maybe ExecutedBlock
   btGetBlock hv bt = (_^∙ lbExecutedBlock) <$> btGetLinkableBlock hv bt
 
+  btGetBlock≡ : ∀ {hv : HashValue} {bt : BlockTree} {lb : LinkableBlock}
+                → btGetLinkableBlock hv bt ≡ just lb
+                → btGetBlock hv bt ≡ just (lb ^∙ lbExecutedBlock)
+  btGetBlock≡ jlb rewrite jlb = refl
+
   -- getter only in Haskell
   btRoot : Lens BlockTree (Maybe ExecutedBlock)
   btRoot = mkLens' g s

--- a/src/Util/KVMap.agda
+++ b/src/Util/KVMap.agda
@@ -124,6 +124,11 @@ module Util.KVMap  where
                    → k' ≢ k
                    → lookup k' kvm ≡ lookup k' (kvm-insert k v kvm prf)
 
+   insert-target-≢-Haskell :
+                     {kvm : KVMap Key Val}{k k' : Key}
+                   → k' ≢ k
+                   → lookup k' kvm ≡ lookup k' (kvm-insert-Haskell k v kvm)
+
    update-target-≢  : {kvm : KVMap Key Val}
                   → ∀ {k1 k2 x}
                   → k2 ≢ k1


### PR DESCRIPTION
This PR provides the first experience with using the new framework to prove something about LBFT.  Specifically, it adds an `AST` version of `insertBlockE`, and proves its contract (after refining it).  The refinement required more assumptions for some proof obligations.  This required changes to the proofs "up the stack"~~, which have not all been done.  There is a comment where it still breaks, providing some rough hints about how to proceed when I am less tired~~.  After reverting some overzealous requirement propagation, all proofs are working now.