### PR TITLE
proving soundness of partiality : still has hole

### DIFF
--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -251,11 +251,11 @@ module Partiality where
 
   sound : ∀ (e : Expr) i → Dom ⟦_⟧ e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
   sound (Val _)        _                 _   = ⇓Base
-  sound (Div e₁ e₂) unit (sdd , (sd₁ , sd₂)) =
+  sound (Div e₁ e₂) unit (ddiv , (de₁ , de₂)) =
     ASTPredTransMono.predTransMono MaybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
    where
-    ih₁ = sound e₁ unit sd₁
-    ih₂ = sound e₂ unit sd₂
+    ih₁ = sound e₁ unit de₁
+    ih₂ = sound e₂ unit de₂
 
     PN⊆₂ : ∀ n → e₁ ⇓ n → PN e₂ ⊆ₒ _
     PN⊆₂ _ e₁⇓n (just (Succ _)) e₂⇓Succ .(just (Succ _)) refl = ⇓Step e₁⇓n e₂⇓Succ
@@ -263,9 +263,9 @@ module Partiality where
       with   runMaybe ⟦ e₁ ⟧ unit | inspect (runMaybe ⟦ e₁ ⟧) unit
            | runMaybe ⟦ e₂ ⟧ unit | inspect (runMaybe ⟦ e₂ ⟧) unit
            | ASTSufficientPT.sufficient MaybeSuf ⟦ e₂ ⟧ _ unit ih₂
-    ... | just _ | _ | nothing       | [ eq₂ ] | _ rewrite eq₂ = ⊥-elim sdd
-    ... | just _ | _ | just 0        | [ eq₂ ] | _ rewrite eq₂ = ⊥-elim sdd
-    ... | just l | _ | just (Succ _) | [ eq₂ ] | e₂⇓Succ =
+    ... | just _ | _ | nothing       | [ eq₂ ] |       _ rewrite eq₂ = ⊥-elim ddiv
+    ... | just _ | _ | just 0        | [ eq₂ ] |       _ rewrite eq₂ = ⊥-elim ddiv
+    ... | just l | _ | just (Succ _) | [ eq₂ ] | e₂⇓Succ             =
       absurd (Succ _ ≡ 0) case (deterministic e₂⇓Succ e₂⇓0) of λ ()
 
     PN⊆₁ : PN e₁ ⊆ₒ _

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -8,6 +8,7 @@ module Dijkstra.AST.Maybe where
 
 open import Dijkstra.AST.Core
 open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; return; Unit; unit; Void)
+open import Data.Product using (Σ)
 import      Level
 open import Relation.Binary.PropositionalEquality
 open import Util.Prelude using (contradiction)
@@ -68,6 +69,14 @@ MaybebindPost : ∀ {A B} → (A → PredTrans B) → Post B → Post A
 MaybebindPost _ P nothing  = P nothing
 MaybebindPost f P (just y) = f y P unit
 
+MaybebindPost⊆
+  : ∀ {A B} (f : A → PredTrans B) (P₁ : Post B) (P₂ : Post A)
+    → (P₁ nothing → P₂ nothing)
+    → (∀ x → f x P₁ unit → P₂ (just x))
+    → MaybebindPost f P₁ ⊆ₒ P₂
+MaybebindPost⊆ f P₁ P₂ n⊆ j⊆ nothing wp = n⊆ wp
+MaybebindPost⊆ f P₁ P₂ n⊆ j⊆ (just x) wp = j⊆ x wp
+
 MaybePT : ASTPredTrans MaybeOps MaybeTypes
 ASTPredTrans.returnPT MaybePT x P i               = P (just x)
 -- Note that it is important *not* to pattern match the input as 'unit'.  Even though this is the
@@ -112,14 +121,29 @@ ASTPredTransMono.opPTMono₁    MaybePTMono Maybe-bail f monoF P₁ P₂ P₁⊆
 ASTPredTransMono.opPTMono₂    MaybePTMono Maybe-bail f₁ f₂ f₁⊑f₂ P i wp =
   wp
 
+maybePTMono      = ASTPredTransMono.predTransMono MaybePTMono
+maybePTMonoBind₂ = ASTPredTransMono.bindPTMono₂   MaybePTMono
+
 MaybeSuf : ASTSufficientPT MaybeOpSem MaybePT
 ASTSufficientPT.returnSuf MaybeSuf x P i wp = wp
 ASTSufficientPT.bindSuf   MaybeSuf {A} {B} m f mSuf fSuf P unit wp
   with runMaybe m unit | inspect (runMaybe m) unit
-... | nothing | [ eq ] = mSuf _ unit wp nothing (sym eq)
-... | just y  | [ eq ] = let wp' = mSuf _ unit wp (just y) (sym eq)
-                          in fSuf y P unit wp'
+... |  nothing         | [ eq ] = mSuf _ unit wp nothing (sym eq)
+... |  just y          | [ eq ] = let wp' = mSuf _ unit wp (just y) (sym eq)
+                                   in fSuf y P unit wp'
 ASTSufficientPT.opSuf     MaybeSuf Maybe-bail f fSuf P i wp = wp
+
+maybeSufficient = ASTSufficientPT.sufficient MaybeSuf
+
+maybeSuffBind
+  : ∀ {A B P} {Q : Post A} {i} (m : MaybeD A) (f : A → MaybeD B)
+    → predTrans (m >>= f) P i
+    → (P nothing → Q nothing)
+    → (∀ x → predTrans (f x) P unit → Q (just x))
+    → Q (runMaybe m i)
+maybeSuffBind{P = P}{Q}{i} m f wp n⊆ j⊆ =
+  MaybebindPost⊆ (λ x → predTrans (f x)) P Q n⊆ j⊆
+    (runMaybe m i) (maybeSufficient m _ i wp _ refl)
 
 private
   bailWorksSuf : ∀ {A : Set} (a : A) i → (runMaybe (prog₁ a) i ≡ nothing)
@@ -128,6 +152,16 @@ private
   bailWorksSuf a i
     with runMaybe (prog₁ a) i
   ... | x≡x = refl
+
+  postulate
+    maybeNeccessary
+      : ∀ {A} (m : MaybeD A) P i → P (runMaybe m i) → predTrans m P i
+
+    maybePTApp
+      : ∀ {A} {P₁ P₂ : Post A} (m : MaybeD A) i
+        → predTrans m (λ o → P₁ o → P₂ o) i
+        → predTrans m P₁ i
+        → predTrans m P₂ i
 
 ------------------------------------------------------------------------------
 
@@ -141,12 +175,16 @@ module Partiality where
 
   open Syntax
   open import Agda.Builtin.Unit using (⊤; tt)
-  open import Data.Empty using (⊥; ⊥-elim)
-  open import Data.Nat public using () renaming (ℕ to Nat; zero to Zero; suc to Succ)
+  open import Data.Empty        using (⊥; ⊥-elim)
+  open import Data.Nat          public renaming (ℕ to Nat; zero to Zero; suc to Succ)
   open import Data.Nat.DivMod
-  open import Data.Product using (∃ ; ∃-syntax ; _×_)
-  open import Function.Base using (case_of_)
-  open import Util.Prelude  using (absurd_case_of_)
+  open import Data.Product      using (∃ ; ∃-syntax ; _×_)
+  open import Function.Base     using (case_of_)
+  open import Util.Prelude      using (absurd_case_of_)
+
+  Partial : {A : Set} → (P : A → Set) → Maybe A → Set
+  Partial _ nothing  = ⊥
+  Partial P (just x) = P x
 
   data Expr : Set where
     Val : Nat  -> Expr
@@ -159,13 +197,6 @@ module Partiality where
          ->     el    ⇓  n1
          ->        er ⇓         (Succ n2) -- divisor is non-zero
          -> Div el er ⇓ (n1 div (Succ n2))
-
-  deterministic : ∀ {e n₁ n₂} → e ⇓ n₁ → e ⇓ n₂ → n₁ ≡ n₂
-  deterministic ⇓Base ⇓Base = refl
-  deterministic (⇓Step e⇓n₁ e⇓n₂) (⇓Step e⇓n₃ e⇓n₄)
-    with deterministic e⇓n₁ e⇓n₃
-    |    deterministic e⇓n₂ e⇓n₄
-  ... | refl | refl = refl
 
   _÷_ : Nat -> Nat -> MaybeD Nat
   n ÷ Zero     = bail
@@ -182,6 +213,12 @@ module Partiality where
   ⟦ Div e1 e2 ⟧ = ASTbind (⟦ e1 ⟧) (\v1 ->
                   ASTbind (⟦ e2 ⟧) (\v2 ->
                    (v1 ÷ v2)))
+
+  wpPartial
+    : {A : Set} {B : A → Set} (f : (x : A) → MaybeD (B x))
+      (P : (x : A) → B x → Set) → A → Set
+  wpPartial f P x =
+    predTrans (f x) (Partial (P x)) unit
 
   record Pair {l l'} (a : Set l) (b : Set l') : Set (l Level.⊔ l') where
     constructor _,_
@@ -207,8 +244,7 @@ module Partiality where
   --   by making the post condition not hold when the computation returns nothing.
   -- PN is the functional equivalent, where PN plays the role of mustPT in the paper.
   PN : Expr → Post Nat
-  PN e nothing  = ⊥
-  PN e (just n) = e ⇓ n
+  PN e = Partial (e ⇓_)
 
   -- TUTORIAL:
   -- Demonstrates how predTransMono can be used
@@ -217,8 +253,6 @@ module Partiality where
   --   saving the need to write (ugly) expressions for the continuation of a bind.
   --   - e.g., The underscore in the type signature of PN⊆₁ below (the second post condition)
   --           because Agda figures it out from the goal.
-  --
-  -- This corresponds to 'correct' in the Wouter/Tim paper.
   correct : ∀ (e : Expr) i → SafeDiv e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
   correct (Val _)        _                   _   = ⇓Base
   correct (Div e₁ e₂) unit (¬e₂⇓0 , (sd₁ , sd₂)) =
@@ -237,25 +271,85 @@ module Partiality where
     PN⊆₁ (just n) e₁⇓n .(just n) refl =
       ASTPredTransMono.predTransMono MaybePTMono ⟦ e₂ ⟧ (PN e₂) _ (PN⊆₂ n e₁⇓n) unit ih₂
 
-  dom : (Expr -> MaybeD Nat)
-     -> Expr
-     -> Set
-  dom f e =
+  Dom : {A : Set} {B : A → Set}
+        → ((x : A) → MaybeD (B x)) → A → Set
+  Dom f = wpPartial f λ _ _ → ⊤
+
+  DomDiv : ∀ {e₁ e₂}
+           → Dom ⟦_⟧ (Div e₁ e₂)
+           → Dom ⟦_⟧ e₁
+             ∧ wpPartial ⟦_⟧ (λ _ → _> 0) e₂
+  Pair.fst (DomDiv{e₁}{e₂} dom) =
+    maybePTMono ⟦ e₁ ⟧ _ _ ⊆Partial unit dom
+    where
+    ⊆Partial : _ ⊆ₒ Partial (λ _ → ⊤)
+    ⊆Partial nothing wp = wp _ refl
+    ⊆Partial (just m) wp = tt
+  Pair.snd (DomDiv{e₁}{e₂} dom) =
+    maybeSuffBind {Q = λ _ → _} ⟦ e₁ ⟧
+      (λ m → ⟦ e₂ ⟧ >>= λ n → m ÷ n) dom (λ ())
+      λ m wp →
+        maybePTMono ⟦ e₂ ⟧ _ _ (⊆Partial m) unit wp
+      where
+      ⊆Partial : ∀ m → _ ⊆ₒ Partial (_> 0)
+      ⊆Partial m nothing wp = wp _ refl
+      ⊆Partial m (just Zero) wp = ⊥-elim (wp _ refl)
+      ⊆Partial m (just (Succ n)) wp = s≤s z≤n
+ 
+  sound : ∀ (e : Expr) i → Dom ⟦_⟧ e → predTrans ⟦ e ⟧ (PN e) i
+  sound (Val x) unit dom = ⇓Base
+  sound (Div e₁ e₂) unit dom =
+    maybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
+    where
+    ih₁ = sound e₁ unit (Pair.fst (DomDiv{e₁}{e₂} dom))
+    ih₂ =
+      sound e₂ unit
+        (maybePTMono ⟦ e₂ ⟧ _ _ (λ { nothing () ; (just x) _ → tt}) unit
+          (Pair.snd (DomDiv{e₁}{e₂} dom)))
+
+    PN⊆₂ : ∀ n → e₁ ⇓ n → Partial (λ n → e₂ ⇓ n ∧ (n > 0)) ⊆ₒ _
+    PN⊆₂ n e₁⇓n (just (Succ x)) wp .(just (Succ x)) refl =
+      ⇓Step e₁⇓n (Pair.fst wp)
+
+    PN⊆₁ : PN e₁ ⊆ₒ _
+    PN⊆₁ (just m) e₁⇓m ._ refl =
+      maybePTMono ⟦ e₂ ⟧ _ _ (PN⊆₂ m e₁⇓m) unit
+        (maybePTApp ⟦ e₂ ⟧ unit
+          (maybePTMono ⟦ e₂ ⟧ _ _
+            (λ where
+              (just x) wp₁ wp₂ → wp₂ , wp₁)
+            unit ((Pair.snd (DomDiv{e₁}{e₂} dom))))
+          ih₂)
+
+  -------------------------
+  -- alternate proof of sound
+
+  deterministic : ∀ {e n₁ n₂} → e ⇓ n₁ → e ⇓ n₂ → n₁ ≡ n₂
+  deterministic ⇓Base ⇓Base = refl
+  deterministic (⇓Step e⇓n₁ e⇓n₂) (⇓Step e⇓n₃ e⇓n₄)
+    with deterministic e⇓n₁ e⇓n₃
+    |    deterministic e⇓n₂ e⇓n₄
+  ... | refl | refl = refl
+
+  dom' : (Expr -> MaybeD Nat)
+      -> Expr
+      -> Set
+  dom' f e =
     case runMaybe (f e) unit of λ where
       nothing  -> ⊥
       (just _) -> ⊤
 
-  Dom : (Expr -> MaybeD Nat) -> Expr -> Set
-  Dom f a@(Val _)     =  dom f a
-  Dom f a@(Div el er) = (dom f a) ∧ Dom f el ∧ Dom f er
+  Dom' : (Expr -> MaybeD Nat) -> Expr -> Set
+  Dom' f a@(Val _)     =  dom' f a
+  Dom' f a@(Div el er) = (dom' f a) ∧ Dom' f el ∧ Dom' f er
 
-  sound : ∀ (e : Expr) i → Dom ⟦_⟧ e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
-  sound (Val _)        _                 _   = ⇓Base
-  sound (Div e₁ e₂) unit (ddiv , (de₁ , de₂)) =
+  sound' : ∀ (e : Expr) i → Dom' ⟦_⟧ e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
+  sound' (Val _)        _                  _   = ⇓Base
+  sound' (Div e₁ e₂) unit (ddiv , (de₁ , de₂)) =
     ASTPredTransMono.predTransMono MaybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
    where
-    ih₁ = sound e₁ unit de₁
-    ih₂ = sound e₂ unit de₂
+    ih₁ = sound' e₁ unit de₁
+    ih₂ = sound' e₂ unit de₂
 
     PN⊆₂ : ∀ n → e₁ ⇓ n → PN e₂ ⊆ₒ _
     PN⊆₂ _ e₁⇓n (just (Succ _)) e₂⇓Succ .(just (Succ _)) refl = ⇓Step e₁⇓n e₂⇓Succ


### PR DESCRIPTION
The hole that is left clearly has a contradiction:

- `e₂⇓0` says it evaluates to 0
- but `dom` for the `Div` returns `⊤`
- and `runMaybe  ⟦ e₂ ⟧` is claiming `just (Succ _)`

Can anyone provide hints on how to proceed?

