### PR TITLE
An example demonstrating the use of branching extensions in `MaybeD`.

### DIFF
--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -95,7 +95,7 @@ private
   BailWorks o = o ≡ nothing
 
   bailWorks  : ∀ {A} (a : A) i → ASTPredTrans.predTrans MaybePT (prog₁ a) BailWorks i
-  bailWorks  a unit r         r≡nothing rewrite r≡nothing = refl
+  bailWorks  a unit r refl = refl
 
   -- "expanded" version for understanding
   bailWorks' : ∀ {A} (a : A) i → ASTPredTrans.predTrans MaybePT (prog₁ a) BailWorks i
@@ -149,6 +149,16 @@ maybeSuffBind{P = P}{Q}{i} m f wp n⊆ j⊆ =
   MaybebindPost⊆ (λ x → predTrans (f x)) P Q n⊆ j⊆
     (runMaybe m i) (maybeSufficient m _ i wp _ refl)
 
+private
+  -- an easy example using sufficient
+  bailWorksSuf  : ∀ {A : Set} (a : A) i → (runMaybe (prog₁ a) i ≡ nothing)
+  bailWorksSuf a i =
+    ASTSufficientPT.sufficient MaybeSuf (prog₁ a) BailWorks unit (bailWorks a unit)
+
+  -- alternate version, showing that it's trivial in this case
+  bailWorksSuf' : ∀ {A : Set} (a : A) i → (runMaybe (prog₁ a) i ≡ nothing)
+  bailWorksSuf' a i = refl
+
 -- This property says that predTrans really is the *weakest* precondition for a
 -- postcondition to hold after running a MaybeD.
 Post⇒wp : ∀ {A} → MaybeD A → Input → Set₁
@@ -167,228 +177,13 @@ predTrans-is-weakest {A} (ASTbind {mA} {fB} m f) P Pr
 ... | just x  = rec _ λ where r refl → predTrans-is-weakest (f x) _ Pr
 predTrans-is-weakest {A} (ASTop Maybe-bail f) P = id
 
-private
-  bailWorksSuf  : ∀ {A : Set} (a : A) i → (runMaybe (prog₁ a) i ≡ nothing)
-  bailWorksSuf a i =
-    ASTSufficientPT.sufficient MaybeSuf (prog₁ a) BailWorks unit (bailWorks a unit)
+maybePTApp
+    : ∀ {A} {P₁ P₂ : Post A} (m : MaybeD A) i
+      → predTrans m (λ o → P₁ o → P₂ o) i
+      → predTrans m P₁ i
+      → predTrans m P₂ i
+maybePTApp {P₁ = P₁} {P₂} m unit imp pt1 =
+  predTrans-is-weakest m P₂
+    (ASTSufficientPT.sufficient MaybeSuf m (λ o → P₁ o → P₂ o) unit imp
+      (ASTSufficientPT.sufficient MaybeSuf m P₁ unit pt1))
 
-  -- alternate version
-  bailWorksSuf' : ∀ {A : Set} (a : A) i → (runMaybe (prog₁ a) i ≡ nothing)
-  bailWorksSuf' a i
-    with runMaybe (prog₁ a) i
-  ... | x≡x = refl
-
-  maybePTApp
-      : ∀ {A} {P₁ P₂ : Post A} (m : MaybeD A) i
-        → predTrans m (λ o → P₁ o → P₂ o) i
-        → predTrans m P₁ i
-        → predTrans m P₂ i
-  maybePTApp {P₁ = P₁} {P₂} m unit imp pt1 =
-    predTrans-is-weakest m P₂
-      (ASTSufficientPT.sufficient MaybeSuf m (λ o → P₁ o → P₂ o) unit imp
-        (ASTSufficientPT.sufficient MaybeSuf m P₁ unit pt1))
-
-------------------------------------------------------------------------------
-
-module Partiality where
-
-  {- Examples corresponding to
-     "A predicate transformer semantics for effects"
-     https://webspace.science.uu.nl/~swier004/publications/2019-icfp-submission-a.pdf
-     https://zenodo.org/record/3257707#.Yec-nxPMJqt
-  -}
-
-  open Syntax
-  open import Agda.Builtin.Unit using (⊤; tt)
-  open import Data.Empty        using (⊥; ⊥-elim)
-  open import Data.Nat          public renaming (ℕ to Nat; zero to Zero; suc to Succ)
-  open import Data.Nat.DivMod
-  open import Data.Product      using (∃ ; ∃-syntax ; _×_)
-  open import Function.Base     using (case_of_)
-  open import Util.Prelude      using (absurd_case_of_)
-
-  Partial : {A : Set} → (P : A → Set) → Maybe A → Set
-  Partial _ nothing  = ⊥
-  Partial P (just x) = P x
-
-  data Expr : Set where
-    Val : Nat  -> Expr
-    Div : Expr -> Expr -> Expr
-
-  data _⇓_ : Expr -> Nat -> Set where
-    ⇓Base : forall {n}
-         -> Val n ⇓ n
-    ⇓Step : forall {el er n1 n2}
-         ->     el    ⇓  n1
-         ->        er ⇓         (Succ n2) -- divisor is non-zero
-         -> Div el er ⇓ (n1 div (Succ n2))
-
-  _÷_ : Nat -> Nat -> MaybeD Nat
-  n ÷ Zero     = bail
-  n ÷ (Succ k) = ASTreturn (n div (Succ k))
-
-  -- ⟦_⟧ : Expr -> MaybeD Nat
-  -- ⟦ Val x ⟧     = return x
-  -- ⟦ Div e1 e2 ⟧ = ⟦ e1 ⟧ >>= \v1 ->
-  --                 ⟦ e2 ⟧ >>= \v2 ->
-  --                 v1 ÷ v2
-
-  ⟦_⟧ : Expr -> MaybeD Nat
-  ⟦ Val x ⟧     = ASTreturn x
-  ⟦ Div e1 e2 ⟧ = ASTbind (⟦ e1 ⟧) (\v1 ->
-                  ASTbind (⟦ e2 ⟧) (\v2 ->
-                   (v1 ÷ v2)))
-
-  wpPartial
-    : {A : Set} {B : A → Set} (f : (x : A) → MaybeD (B x))
-      (P : (x : A) → B x → Set) → A → Set
-  wpPartial f P x =
-    predTrans (f x) (Partial (P x)) unit
-
-  record Pair {l l'} (a : Set l) (b : Set l') : Set (l Level.⊔ l') where
-    constructor _,_
-    field
-      fst : a
-      snd : b
-
-  _∧_ : ∀ {l l'} -> Set l -> Set l' -> Set (l Level.⊔ l')
-  _∧_ A B = Pair A B
-  infixr 1 _∧_
-
-  SafeDiv : Expr -> Set
-  SafeDiv (Val x)     = ⊤
-  SafeDiv (Div el er) = (er ⇓ Zero -> ⊥) ∧ SafeDiv el ∧ SafeDiv er
-
-  ------------------------------------------------------------------------------
-  -- everything above from Wouter paper (modified with our AST)
-  -- everything below our attempts to prove sufficient, sound, complete, ...
-
-  -- The proof of 'correct' in the Wouter paper uses wpPartial.
-  -- wpPartial is like wp, but it is for a Partial (Maybe) computation
-  -- - it requires the computation to succeed (i.e., returns a just)
-  --   by making the post condition not hold when the computation returns nothing.
-  -- PN is the functional equivalent, where PN plays the role of mustPT in the paper.
-  PN : Expr → Post Nat
-  PN e = Partial (e ⇓_)
-
-  -- TUTORIAL:
-  -- Demonstrates how predTransMono can be used
-  -- - to construct proofs for ASTs that include ASTbind, and
-  -- - shows how Agda can figure out the required post condition from context,
-  --   saving the need to write (ugly) expressions for the continuation of a bind.
-  --   - e.g., The underscore in the type signature of PN⊆₁ below (the second post condition)
-  --           because Agda figures it out from the goal.
-  -- TODO-1: show steps needed in order to get Agda to infer types indicated by '_'
-  --         in the type signatures of PN⊆₁ and PN⊆₂
-  correct : ∀ (e : Expr) i → SafeDiv e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
-  correct (Val _)        _                   _   = ⇓Base
-  correct (Div e₁ e₂) unit (¬e₂⇓0 , (sd₁ , sd₂)) =
-    ASTPredTransMono.predTransMono MaybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
-   where
-    ih₁ = correct e₁ unit sd₁
-    ih₂ = correct e₂ unit sd₂
-
-    PN⊆₂ : ∀ n → e₁ ⇓ n → PN e₂ ⊆ₒ _
-    PN⊆₂ _    _              _        ()  nothing        refl
-    PN⊆₂ _    _ .(just       _)  e₂⇓Zero (just Zero)     refl = ¬e₂⇓0 e₂⇓Zero
-    PN⊆₂ _ e₁⇓n .(just (Succ _)) e₂⇓Succ (just (Succ _)) refl = ⇓Step e₁⇓n e₂⇓Succ
-
-    PN⊆₁ : PN e₁ ⊆ₒ _
-    PN⊆₁       _    ()   nothing refl
-    PN⊆₁ (just n) e₁⇓n .(just n) refl =
-      ASTPredTransMono.predTransMono MaybePTMono ⟦ e₂ ⟧ (PN e₂) _ (PN⊆₂ n e₁⇓n) unit ih₂
-
-  Dom : {A : Set} {B : A → Set}
-        → ((x : A) → MaybeD (B x)) → A → Set
-  Dom f = wpPartial f λ _ _ → ⊤
-
-  DomDiv : ∀ {e₁ e₂}
-           → Dom ⟦_⟧ (Div e₁ e₂)
-           → Dom ⟦_⟧ e₁
-             ∧ wpPartial ⟦_⟧ (λ _ → _> 0) e₂
-  Pair.fst (DomDiv{e₁}{e₂} dom) =
-    maybePTMono ⟦ e₁ ⟧ _ _ ⊆Partial unit dom
-    where
-    ⊆Partial : _ ⊆ₒ Partial (λ _ → ⊤)
-    ⊆Partial nothing wp = wp _ refl
-    ⊆Partial (just m) wp = tt
-  Pair.snd (DomDiv{e₁}{e₂} dom) =
-    maybeSuffBind {Q = λ _ → _} ⟦ e₁ ⟧
-      (λ m → ⟦ e₂ ⟧ >>= λ n → m ÷ n) dom (λ ())
-      λ m wp →
-        maybePTMono ⟦ e₂ ⟧ _ _ (⊆Partial m) unit wp
-      where
-      ⊆Partial : ∀ m → _ ⊆ₒ Partial (_> 0)
-      ⊆Partial m nothing wp = wp _ refl
-      ⊆Partial m (just Zero) wp = ⊥-elim (wp _ refl)
-      ⊆Partial m (just (Succ n)) wp = s≤s z≤n
-
-  sound : ∀ (e : Expr) i → Dom ⟦_⟧ e → predTrans ⟦ e ⟧ (PN e) i
-  sound (Val x) unit dom = ⇓Base
-  sound (Div e₁ e₂) unit dom =
-    maybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
-    where
-    ih₁ = sound e₁ unit (Pair.fst (DomDiv{e₁}{e₂} dom))
-    ih₂ =
-      sound e₂ unit
-        (maybePTMono ⟦ e₂ ⟧ _ _ (λ { nothing () ; (just x) _ → tt}) unit
-          (Pair.snd (DomDiv{e₁}{e₂} dom)))
-
-    PN⊆₂ : ∀ n → e₁ ⇓ n → Partial (λ n → e₂ ⇓ n ∧ (n > 0)) ⊆ₒ _
-    PN⊆₂ n e₁⇓n (just (Succ x)) wp .(just (Succ x)) refl =
-      ⇓Step e₁⇓n (Pair.fst wp)
-
-    PN⊆₁ : PN e₁ ⊆ₒ _
-    PN⊆₁ (just m) e₁⇓m ._ refl =
-      maybePTMono ⟦ e₂ ⟧ _ _ (PN⊆₂ m e₁⇓m) unit
-        (maybePTApp ⟦ e₂ ⟧ unit
-          (maybePTMono ⟦ e₂ ⟧ _ _
-            (λ where
-              (just x) wp₁ wp₂ → wp₂ , wp₁)
-            unit ((Pair.snd (DomDiv{e₁}{e₂} dom))))
-          ih₂)
-
-  -------------------------
-  -- alternate proof of sound
-
-  deterministic : ∀ {e n₁ n₂} → e ⇓ n₁ → e ⇓ n₂ → n₁ ≡ n₂
-  deterministic ⇓Base ⇓Base = refl
-  deterministic (⇓Step e⇓n₁ e⇓n₂) (⇓Step e⇓n₃ e⇓n₄)
-    with deterministic e⇓n₁ e⇓n₃
-    |    deterministic e⇓n₂ e⇓n₄
-  ... | refl | refl = refl
-
-  dom' : (Expr -> MaybeD Nat)
-      -> Expr
-      -> Set
-  dom' f e =
-    case runMaybe (f e) unit of λ where
-      nothing  -> ⊥
-      (just _) -> ⊤
-
-  Dom' : (Expr -> MaybeD Nat) -> Expr -> Set
-  Dom' f a@(Val _)     =  dom' f a
-  Dom' f a@(Div el er) = (dom' f a) ∧ Dom' f el ∧ Dom' f er
-
-  sound' : ∀ (e : Expr) i → Dom' ⟦_⟧ e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
-  sound' (Val _)        _                  _   = ⇓Base
-  sound' (Div e₁ e₂) unit (ddiv , (de₁ , de₂)) =
-    ASTPredTransMono.predTransMono MaybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
-   where
-    ih₁ = sound' e₁ unit de₁
-    ih₂ = sound' e₂ unit de₂
-
-    PN⊆₂ : ∀ n → e₁ ⇓ n → PN e₂ ⊆ₒ _
-    PN⊆₂ _ e₁⇓n (just (Succ _)) e₂⇓Succ .(just (Succ _)) refl = ⇓Step e₁⇓n e₂⇓Succ
-    PN⊆₂ _ e₁⇓n (just       0)  e₂⇓0     (just       0)  refl
-      with   runMaybe ⟦ e₁ ⟧ unit
-           | runMaybe ⟦ e₂ ⟧ unit | inspect (runMaybe ⟦ e₂ ⟧) unit
-           | ASTSufficientPT.sufficient MaybeSuf ⟦ e₂ ⟧ _ unit ih₂
-    ... | just _ | nothing       | [ eq₂ ] |       _ rewrite eq₂ = ⊥-elim ddiv
-    ... | just _ | just 0        | [ eq₂ ] |       _ rewrite eq₂ = ⊥-elim ddiv
-    ... | just l | just (Succ _) | [ eq₂ ] | e₂⇓Succ             =
-      absurd (Succ _ ≡ 0) case (deterministic e₂⇓Succ e₂⇓0) of λ ()
-
-    PN⊆₁ : PN e₁ ⊆ₒ _
-    PN⊆₁ (just n) e₁⇓n .(just n) refl =
-      ASTPredTransMono.predTransMono MaybePTMono ⟦ e₂ ⟧ (PN e₂) _ (PN⊆₂ n e₁⇓n) unit ih₂

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -6,12 +6,15 @@
 
 module Dijkstra.AST.Maybe where
 
+open import Dijkstra.AST.Branching
 open import Dijkstra.AST.Core
 open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; return; Unit; unit; Void)
 open import Data.Product using (Σ)
 import      Level
 open import Relation.Binary.PropositionalEquality
 open import Util.Prelude using (contradiction; id)
+
+open ASTExtension
 
 data MaybeCmd (C : Set) : Set₁ where
   Maybe-bail : MaybeCmd C
@@ -187,3 +190,9 @@ maybePTApp {P₁ = P₁} {P₂} m unit imp pt1 =
     (ASTSufficientPT.sufficient MaybeSuf m (λ o → P₁ o → P₂ o) unit imp
       (ASTSufficientPT.sufficient MaybeSuf m P₁ unit pt1))
 
+MaybeExtOps    = BranchOps MaybeOps
+MaybeDExt      = AST MaybeExtOps
+MaybePTExt     = PredTransExtension.BranchPT MaybePT
+runMaybeExt    = ASTOpSem.runAST (OpSemExtension.BranchOpSem MaybeOpSem)
+MaybePTMonoExt = PredTransExtensionMono.BranchPTMono MaybePTMono
+MaybeSufExt    = SufficientExtension.BranchSuf MaybePTMono MaybeSuf

--- a/src/Dijkstra/AST/Maybe/Examples/Branching.agda
+++ b/src/Dijkstra/AST/Maybe/Examples/Branching.agda
@@ -1,0 +1,47 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import Data.Nat
+import      Level
+open import Util.Prelude
+open import Dijkstra.AST.Branching
+open import Dijkstra.AST.Core
+open import Dijkstra.AST.Maybe
+
+module  Dijkstra.AST.Maybe.Examples.Branching where
+
+  open ASTTypes MaybeTypes
+  open ASTPredTrans MaybePT
+  open ASTExtension 
+  open Syntax
+
+  dblNonZero : ℕ → ∀ {ℓ} → Level.Lift ℓ Bool → MaybeDExt ℕ
+  dblNonZero _ (lift true)  = ASTop (Left Maybe-bail) λ ()
+  dblNonZero n (lift false) = ASTreturn (2 * n)
+
+  -- A program that includes branching in MaybeD
+  branchingProg : ℕ → MaybeDExt ℕ
+  branchingProg n = ASTop (Right (BCif (toBool (n ≟ℕ 0) ))) (dblNonZero n)
+
+  -- A postcondition requiring that it can fail only if n is zero, and if it succeeds, the result is
+  -- greater than the argument
+  bpPost : ℕ → Post ℕ
+  bpPost n (just n') = n' > n
+  bpPost n nothing   = n ≡ 0
+
+  dblNZ> : ∀ {n} → n ≢ 0 → n < n + (n + 0)
+  dblNZ> {0} nz     = ⊥-elim (nz refl)
+  dblNZ> {suc n} nz rewrite +-identityʳ (suc n) = m<m+n _ 0<1+n
+
+  -- The weakest precondition for bpPost holds
+  branchingProgWorks : (n : ℕ) → (i : Input)
+                       → ASTPredTrans.predTrans MaybePTExt (branchingProg n) (bpPost n) i
+  proj₁ (branchingProgWorks n i) isTrue  = toWitnessT isTrue
+  proj₂ (branchingProgWorks n i) isFalse = dblNZ> (toWitnessF isFalse)
+
+  -- And therefore, the result of running the program satisfies the postcondition
+  prop : (n : ℕ) → (i : Input) → (bpPost n) (runMaybeExt (branchingProg n) i)
+  prop n i = ASTSufficientPT.sufficient MaybeSufExt (branchingProg n) (bpPost n) i (branchingProgWorks n i)

--- a/src/Dijkstra/AST/Maybe/Examples/Partiality.agda
+++ b/src/Dijkstra/AST/Maybe/Examples/Partiality.agda
@@ -1,0 +1,215 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
+open import Agda.Builtin.Unit using (⊤; tt)
+open import Data.Empty        using (⊥; ⊥-elim)
+open import Data.Nat          renaming (ℕ to Nat; zero to Zero; suc to Succ)
+open import Data.Nat.DivMod
+open import Data.Product      using (∃ ; ∃-syntax ; _×_)
+open import Function.Base     using (case_of_)
+import      Level
+open import Util.Prelude      using (Maybe ; just ; nothing ; unit ; _>>=_ ; absurd_case_of_)
+open import Dijkstra.AST.Core
+open import Dijkstra.AST.Maybe
+open import Relation.Binary.PropositionalEquality
+
+module  Dijkstra.AST.Maybe.Examples.Partiality where
+
+  {- Examples corresponding to
+     "A predicate transformer semantics for effects"
+     https://webspace.science.uu.nl/~swier004/publications/2019-icfp-submission-a.pdf
+     https://zenodo.org/record/3257707#.Yec-nxPMJqt
+  -}
+
+  open ASTTypes MaybeTypes
+  open ASTPredTrans MaybePT
+  open Syntax
+
+  Partial : {A : Set} → (P : A → Set) → Maybe A → Set
+  Partial _ nothing  = ⊥
+  Partial P (just x) = P x
+
+  data Expr : Set where
+    Val : Nat  -> Expr
+    Div : Expr -> Expr -> Expr
+
+  data _⇓_ : Expr -> Nat -> Set where
+    ⇓Base : forall {n}
+         -> Val n ⇓ n
+    ⇓Step : forall {el er n1 n2}
+         ->     el    ⇓  n1
+         ->        er ⇓         (Succ n2) -- divisor is non-zero
+         -> Div el er ⇓ _div_ n1 (Succ n2)
+
+  _÷_ : Nat -> Nat -> MaybeD Nat
+  n ÷ Zero     = bail
+  n ÷ (Succ k) = ASTreturn (n div (Succ k))
+
+  -- ⟦_⟧ : Expr -> MaybeD Nat
+  -- ⟦ Val x ⟧     = return x
+  -- ⟦ Div e1 e2 ⟧ = ⟦ e1 ⟧ >>= \v1 ->
+  --                 ⟦ e2 ⟧ >>= \v2 ->
+  --                 v1 ÷ v2
+
+  ⟦_⟧ : Expr -> MaybeD Nat
+  ⟦ Val x ⟧     = ASTreturn x
+  ⟦ Div e1 e2 ⟧ = ASTbind (⟦ e1 ⟧) (\v1 ->
+                  ASTbind (⟦ e2 ⟧) (\v2 ->
+                   (v1 ÷ v2)))
+
+  wpPartial
+    : {A : Set} {B : A → Set} (f : (x : A) → MaybeD (B x))
+      (P : (x : A) → B x → Set) → A → Set
+  wpPartial f P x =
+    predTrans (f x) (Partial (P x)) unit
+
+  record Pair {l l'} (a : Set l) (b : Set l') : Set (l Level.⊔ l') where
+    constructor _,_
+    field
+      fst : a
+      snd : b
+
+  _∧_ : ∀ {l l'} -> Set l -> Set l' -> Set (l Level.⊔ l')
+  _∧_ A B = Pair A B
+  infixr 1 _∧_
+
+  SafeDiv : Expr -> Set
+  SafeDiv (Val x)     = ⊤
+  SafeDiv (Div el er) = (er ⇓ Zero -> ⊥) ∧ SafeDiv el ∧ SafeDiv er
+
+  ------------------------------------------------------------------------------
+  -- everything above from Wouter paper (modified with our AST)
+  -- everything below our attempts to prove sufficient, sound, complete, ...
+
+  -- The proof of 'correct' in the Wouter paper uses wpPartial.
+  -- wpPartial is like wp, but it is for a Partial (Maybe) computation
+  -- - it requires the computation to succeed (i.e., returns a just)
+  --   by making the post condition not hold when the computation returns nothing.
+  -- PN is the functional equivalent, where PN plays the role of mustPT in the paper.
+  PN : Expr → Post Nat
+  PN e = Partial (e ⇓_)
+
+  -- TUTORIAL:
+  -- Demonstrates how predTransMono can be used
+  -- - to construct proofs for ASTs that include ASTbind, and
+  -- - shows how Agda can figure out the required post condition from context,
+  --   saving the need to write (ugly) expressions for the continuation of a bind.
+  --   - e.g., The underscore in the type signature of PN⊆₁ below (the second post condition)
+  --           because Agda figures it out from the goal.
+  -- TODO-1: show steps needed in order to get Agda to infer types indicated by '_'
+  --         in the type signatures of PN⊆₁ and PN⊆₂
+  correct : ∀ (e : Expr) i → SafeDiv e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
+  correct (Val _)        _                   _   = ⇓Base
+  correct (Div e₁ e₂) unit (¬e₂⇓0 , (sd₁ , sd₂)) =
+    ASTPredTransMono.predTransMono MaybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
+   where
+    ih₁ = correct e₁ unit sd₁
+    ih₂ = correct e₂ unit sd₂
+
+    PN⊆₂ : ∀ n → e₁ ⇓ n → PN e₂ ⊆ₒ _
+    PN⊆₂ _    _              _        ()  nothing        refl
+    PN⊆₂ _    _ .(just       _)  e₂⇓Zero (just Zero)     refl = ¬e₂⇓0 e₂⇓Zero
+    PN⊆₂ _ e₁⇓n .(just (Succ _)) e₂⇓Succ (just (Succ _)) refl = ⇓Step e₁⇓n e₂⇓Succ
+
+    PN⊆₁ : PN e₁ ⊆ₒ _
+    PN⊆₁       _    ()   nothing refl
+    PN⊆₁ (just n) e₁⇓n .(just n) refl =
+      ASTPredTransMono.predTransMono MaybePTMono ⟦ e₂ ⟧ (PN e₂) _ (PN⊆₂ n e₁⇓n) unit ih₂
+
+  Dom : {A : Set} {B : A → Set}
+        → ((x : A) → MaybeD (B x)) → A → Set
+  Dom f = wpPartial f λ _ _ → ⊤
+
+  DomDiv : ∀ {e₁ e₂}
+           → Dom ⟦_⟧ (Div e₁ e₂)
+           → Dom ⟦_⟧ e₁
+             ∧ wpPartial ⟦_⟧ (λ _ → _> 0) e₂
+  Pair.fst (DomDiv{e₁}{e₂} dom) =
+    maybePTMono ⟦ e₁ ⟧ _ _ ⊆Partial unit dom
+    where
+    ⊆Partial : _ ⊆ₒ Partial (λ _ → ⊤)
+    ⊆Partial nothing wp = wp _ refl
+    ⊆Partial (just m) wp = tt
+  Pair.snd (DomDiv{e₁}{e₂} dom) =
+    maybeSuffBind {Q = λ _ → _} ⟦ e₁ ⟧
+      (λ m → ⟦ e₂ ⟧ >>= λ n → m ÷ n) dom (λ ())
+      λ m wp →
+        maybePTMono ⟦ e₂ ⟧ _ _ (⊆Partial m) unit wp
+      where
+      ⊆Partial : ∀ m → _ ⊆ₒ Partial (_> 0)
+      ⊆Partial m nothing wp = wp _ refl
+      ⊆Partial m (just Zero) wp = ⊥-elim (wp _ refl)
+      ⊆Partial m (just (Succ n)) wp = s≤s z≤n
+
+  sound : ∀ (e : Expr) i → Dom ⟦_⟧ e → predTrans ⟦ e ⟧ (PN e) i
+  sound (Val x) unit dom = ⇓Base
+  sound (Div e₁ e₂) unit dom =
+    maybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
+    where
+    ih₁ = sound e₁ unit (Pair.fst (DomDiv{e₁}{e₂} dom))
+    ih₂ =
+      sound e₂ unit
+        (maybePTMono ⟦ e₂ ⟧ _ _ (λ { nothing () ; (just x) _ → tt}) unit
+          (Pair.snd (DomDiv{e₁}{e₂} dom)))
+
+    PN⊆₂ : ∀ n → e₁ ⇓ n → Partial (λ n → e₂ ⇓ n ∧ (n > 0)) ⊆ₒ _
+    PN⊆₂ n e₁⇓n (just (Succ x)) wp .(just (Succ x)) refl =
+      ⇓Step e₁⇓n (Pair.fst wp)
+
+    PN⊆₁ : PN e₁ ⊆ₒ _
+    PN⊆₁ (just m) e₁⇓m ._ refl =
+      maybePTMono ⟦ e₂ ⟧ _ _ (PN⊆₂ m e₁⇓m) unit
+        (maybePTApp ⟦ e₂ ⟧ unit
+          (maybePTMono ⟦ e₂ ⟧ _ _
+            (λ where
+              (just x) wp₁ wp₂ → wp₂ , wp₁)
+            unit ((Pair.snd (DomDiv{e₁}{e₂} dom))))
+          ih₂)
+
+  -------------------------
+  -- alternate proof of sound
+
+  deterministic : ∀ {e n₁ n₂} → e ⇓ n₁ → e ⇓ n₂ → n₁ ≡ n₂
+  deterministic ⇓Base ⇓Base = refl
+  deterministic (⇓Step e⇓n₁ e⇓n₂) (⇓Step e⇓n₃ e⇓n₄)
+    with deterministic e⇓n₁ e⇓n₃
+    |    deterministic e⇓n₂ e⇓n₄
+  ... | refl | refl = refl
+
+  dom' : (Expr -> MaybeD Nat)
+      -> Expr
+      -> Set
+  dom' f e =
+    case runMaybe (f e) unit of λ where
+      nothing  -> ⊥
+      (just _) -> ⊤
+
+  Dom' : (Expr -> MaybeD Nat) -> Expr -> Set
+  Dom' f a@(Val _)     =  dom' f a
+  Dom' f a@(Div el er) = (dom' f a) ∧ Dom' f el ∧ Dom' f er
+
+  sound' : ∀ (e : Expr) i → Dom' ⟦_⟧ e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
+  sound' (Val _)        _                  _   = ⇓Base
+  sound' (Div e₁ e₂) unit (ddiv , (de₁ , de₂)) =
+    ASTPredTransMono.predTransMono MaybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
+   where
+    ih₁ = sound' e₁ unit de₁
+    ih₂ = sound' e₂ unit de₂
+
+    PN⊆₂ : ∀ n → e₁ ⇓ n → PN e₂ ⊆ₒ _
+    PN⊆₂ _ e₁⇓n (just (Succ _)) e₂⇓Succ .(just (Succ _)) refl = ⇓Step e₁⇓n e₂⇓Succ
+    PN⊆₂ _ e₁⇓n (just       0)  e₂⇓0     (just       0)  refl
+      with   runMaybe ⟦ e₁ ⟧ unit
+           | runMaybe ⟦ e₂ ⟧ unit | inspect (runMaybe ⟦ e₂ ⟧) unit
+           | ASTSufficientPT.sufficient MaybeSuf ⟦ e₂ ⟧ _ unit ih₂
+    ... | just _ | nothing       | [ eq₂ ] |       _ rewrite eq₂ = ⊥-elim ddiv
+    ... | just _ | just 0        | [ eq₂ ] |       _ rewrite eq₂ = ⊥-elim ddiv
+    ... | just l | just (Succ _) | [ eq₂ ] | e₂⇓Succ             =
+      absurd (Succ _ ≡ 0) case (deterministic e₂⇓Succ e₂⇓0) of λ ()
+
+    PN⊆₁ : PN e₁ ⊆ₒ _
+    PN⊆₁ (just n) e₁⇓n .(just n) refl =
+      ASTPredTransMono.predTransMono MaybePTMono ⟦ e₂ ⟧ (PN e₂) _ (PN⊆₂ n e₁⇓n) unit ih₂


### PR DESCRIPTION
The main purpose of this PR is to add an example illustrating the use of a branching extension using our framework.  Details:

* use framework to extend `MaybeD` with branching operations
* add an example program that uses them
* prove a property about the program
* factor `Partiality` out into a separate file under new `Examples` directory
* various minor simplifications and comments