### PR TITLE
Add some syntax support for branching operations for `AST MaybeExtOps`, and some examples

### DIFF
--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -55,6 +55,17 @@ module BranchingSyntax (O : ASTOps) where
                           λ { (Level.lift true)  → t
                             ; (Level.lift false) → e
                             }
+
+  eitherAST : ∀ {A B C : Set} → (A → AST BranchOps C) → (B → AST BranchOps C) → Either A B → AST BranchOps C
+  eitherAST fA fB eAB = ASTop (Right (BCeither eAB))
+                              λ { (Level.lift (Left  a)) → fA a
+                                ; (Level.lift (Right b)) → fB b
+                                }
+
+  -- Same but with arguments in more "natural" order
+  eitherSAST : ∀ {A B C : Set} → Either A B → (A → AST BranchOps C) → (B → AST BranchOps C) → AST BranchOps C
+  eitherSAST eAB fA fB = eitherAST fA fB eAB
+
 module OpSemExtension {O : ASTOps} {T : ASTTypes} (OpSem : ASTOpSem O T) where
   open ASTExtension O
 

--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -52,9 +52,9 @@ module BranchingSyntax (O : ASTOps) where
 
   ifAST_then_else : ∀ {A} → Bool → (t e : AST BranchOps A) → AST BranchOps A
   ifAST b then t else e = ASTop (Right (BCif b))
-                          λ { (Level.lift true)  → t
-                            ; (Level.lift false) → e
-                            }
+                                λ { (Level.lift true)  → t
+                                  ; (Level.lift false) → e
+                                  }
 
   eitherAST : ∀ {A B C : Set} → (A → AST BranchOps C) → (B → AST BranchOps C) → Either A B → AST BranchOps C
   eitherAST fA fB eAB = ASTop (Right (BCeither eAB))

--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -47,6 +47,14 @@ module ASTExtension (O : ASTOps) where
   unextend (ASTop (Right (BCeither (Left x))) f) = unextend (f (Level.lift (Left x)))
   unextend (ASTop (Right (BCeither (Right y))) f) = unextend (f (Level.lift (Right y)))
 
+module BranchingSyntax (O : ASTOps) where
+  open ASTExtension O
+
+  ifAST_then_else : ∀ {A} → Bool → (t e : AST BranchOps A) → AST BranchOps A
+  ifAST b then t else e = ASTop (Right (BCif b))
+                          λ { (Level.lift true)  → t
+                            ; (Level.lift false) → e
+                            }
 module OpSemExtension {O : ASTOps} {T : ASTTypes} (OpSem : ASTOpSem O T) where
   open ASTExtension O
 

--- a/src/Dijkstra/AST/Examples/Maybe/Branching.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Branching.agda
@@ -35,6 +35,66 @@ module Example-if (n : ℕ) where
     -- The weakest precondition for bpPost holds
     branchingProgWorks : (i : Input)
                          → ASTPredTrans.predTrans MaybePTExt branchingProg bpPost i
+
+    {- TUTORIAL: A simple proof using the branching support for AST MaybeExtOps, specifically BCif.
+
+    TODO-1: elaborate on the example to highlight how the framework guides the proof
+
+    If we start with
+
+    branchingProgWorks i = ?
+
+    and do C-c C-, in the hole, we see that the goal is of type:
+
+    ASTPredTrans.predTrans MaybePTExt branchingProg bpPost i
+
+    which may not be very enlightening at first.  However, if we do C-u C-u C-c C-, in the hole, now
+    we have:
+
+    Σ
+      (isYes
+       (map′ (≡ᵇ⇒≡ n 0) (≡⇒≡ᵇ n 0) (Data.Bool.Properties.T? (n ≡ᵇ 0)))
+       ≡ true →
+       n ≡ 0)
+      (λ x →
+         isYes
+         (map′ (≡ᵇ⇒≡ n 0) (≡⇒≡ᵇ n 0) (Data.Bool.Properties.T? (n ≡ᵇ 0)))
+         ≡ false →
+         Σ (1 ≤ n) (λ x₁ → n + (n + 0) ≡ n + (n + 0)))
+
+    Now, if we squint, we can see that this is a product.  The second conjunct
+    does not depend on the first, so we can separate into two goals:
+
+    proj₁ (branchingProgWorks _) = ?
+    proj₂ (branchingProgWorks _) = ?
+
+    C-c C-, in the first hole gives us this goal:
+
+    ToBool.toBool ToBool-Dec (n ≟ℕ 0) ≡ true →
+    ASTPredTrans.predTrans (PredTransExtension.BranchPT MaybePT)
+    ((λ { (lift false) → ASTreturn (2 * n)
+        ; (lift true) → ASTop (Left Maybe-bail) (λ ())
+        })
+     (lift true))
+    bpPost i
+
+    It looks like we get some evidence that n ≟ℕ 0 is true, and we need to prove ... something.
+    Again, C-u C-u C-c C-, reveals something more understandable:
+
+    isYes
+      (map′ (≡ᵇ⇒≡ n 0) (≡⇒≡ᵇ n 0) (Data.Bool.Properties.T? (n ≡ᵇ 0)))
+      ≡ true →
+      n ≡ 0
+
+     The "something" is simply that n ≡ 0.  Let's give the evidence that n ≟ℕ 0 is true a name, then
+     use it to prove that n≡0.
+
+     proj₁ (branchingProgWorks _) isTrue  =           toWitnessT isTrue
+
+     The second conjunct is similar.
+
+    -}
+
     proj₁ (branchingProgWorks _) isTrue  =           toWitnessT isTrue
     proj₂ (branchingProgWorks _) isFalse = (n≢0⇒n>0 (toWitnessF isFalse)) , refl
 

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -8,11 +8,11 @@ module Dijkstra.AST.Maybe where
 
 open import Dijkstra.AST.Branching
 open import Dijkstra.AST.Core
-open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; return; Unit; unit; Void)
+open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; return; Unit; unit; Monad; Void)
 open import Data.Product using (Σ)
 import      Level
 open import Relation.Binary.PropositionalEquality
-open import Util.Prelude using (contradiction; id)
+open import Util.Prelude using (contradiction; id; Left)
 open        ASTExtension
 
 data MaybeCmd (C : Set) : Set₁ where
@@ -185,6 +185,16 @@ MaybePTExt     = PredTransExtension.BranchPT MaybePT
 runMaybeExt    = ASTOpSem.runAST (OpSemExtension.BranchOpSem MaybeOpSem)
 MaybePTMonoExt = PredTransExtensionMono.BranchPTMono MaybePTMono
 MaybeSufExt    = SufficientExtension.BranchSuf MaybePTMono MaybeSuf
+
+module MaybeBranchingSyntax where
+
+  bail : ∀ {A} → AST MaybeExtOps A
+  bail =  ASTop (Left Maybe-bail) λ ()
+
+  instance
+    Monad-Maybe-AST : Monad (AST MaybeExtOps)
+    Monad.return Monad-Maybe-AST = ASTreturn
+    Monad._>>=_ Monad-Maybe-AST  = ASTbind
 
 private
   -- an easy example using sufficient


### PR DESCRIPTION
This PR:
- adds some syntax support for branching operations for `AST MaybeExtOps`
  - `ifAST_then_else_` and `eitherAST` and a variant `eitherSAST` with different argument order
-  simplifies and cleans up the `BCif` example and adds an `ifAST` version
-  adds an example for `BCeither` / `either[S]AST`