### PR TITLE
Add `AST` version of `insertQuorumCertE`, prove its contract

### DIFF
--- a/src/Dijkstra/AST/Either.agda
+++ b/src/Dijkstra/AST/Either.agda
@@ -34,20 +34,20 @@ ASTOps.Cmd    EitherOps  = EitherCmd
 ASTOps.SubArg EitherOps  = EitherSubArg
 ASTOps.SubRet EitherOps  = EitherSubRet
 
-EitherD = AST EitherOps
+EitherAST = AST EitherOps
 
 module Syntax where
   open import Dijkstra.AST.Syntax public
   open import Dijkstra.Syntax
 
-  bail : ∀ {A} → Err → EitherD A
+  bail : ∀ {A} → Err → EitherAST A
   bail a = ASTop (Either-bail a) λ ()
 
-  return : ∀ {A} → A → EitherD A
+  return : ∀ {A} → A → EitherAST A
   return a = ASTreturn a
 
 private
-  prog₁ : ∀ {A} → Err → A → EitherD A
+  prog₁ : ∀ {A} → Err → A → EitherAST A
   prog₁ e a =
     -- Either-bail always returns left, so Agda cannot infer the
     -- type that it would return if it were to return Right, so
@@ -57,7 +57,7 @@ private
 
   module prog₁ where
     open Syntax
-    prog₁' : ∀ {A} → Err → A → EitherD A
+    prog₁' : ∀ {A} → Err → A → EitherAST A
     prog₁' {A} e a = do
       bail {Void} e
       return a

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -15,14 +15,16 @@ open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Crypto
 open import LibraBFT.ImplShared.Util.Dijkstra.All
+open import Level
 open import Optics.All
 open import Util.ByteString
 open import Util.Hash
 import      Util.KVMap                                           as Map
 open import Util.PKCS
 open import Util.Prelude
+open import Dijkstra.AST.Branching
 open import Dijkstra.AST.Core
-open import Dijkstra.AST.Either renaming (EitherD to EitherAST)
+import      Dijkstra.AST.Either as EitherAST renaming (EitherD to EitherAST)
 open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; return; Unit; unit; Void)
 
 ------------------------------------------------------------------------------
@@ -49,7 +51,7 @@ module addChild (lb : LinkableBlock) (hv : HashValue) where
   E = toEither step₀
 
   postulate -- TODO: implement it
-    addChild-AST : EitherAST ErrLog LinkableBlock
+    addChild-AST : EitherAST.EitherAST ErrLog LinkableBlock
 
 abstract
   addChild   = addChild.step₀
@@ -126,12 +128,11 @@ insertBlockE-original block bt = do
         pure (  (bt' & btIdToBlock ∙~ Map.kvm-insert-Haskell blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
              , block))
 
--- An AST version
-module ASTVersion (block : ExecutedBlock) (bt : BlockTree) where
-  open import Dijkstra.AST.Either ErrLog
+-- An AST version of insertBlockE
+module insertBlockE-AST (block : ExecutedBlock) (bt : BlockTree) where
+  open EitherAST
   open import Dijkstra.AST.Core
-  import Dijkstra.AST.Either ErrLog as EitherAST
-  open EitherAST.Syntax renaming (bail to bail-AST; return to return-AST)
+  open EitherAST.Syntax ErrLog renaming (bail to bail-AST; return to return-AST)
   open addChild
 
   insertBlockE-AST : EitherAST ErrLog (BlockTree × ExecutedBlock)
@@ -261,6 +262,50 @@ abstract
 
   insertQuorumCertE-Either-≡ : insertQuorumCertE-Either ≡ insertQuorumCertE.E
   insertQuorumCertE-Either-≡ = refl
+
+module insertQuorumCertE-AST (qc : QuorumCert) (bt0 : BlockTree) where
+  open EitherAST ErrLog
+  open SyntaxExt renaming (bail to bail-AST; return to return-AST)
+  open BranchingSyntax EitherOps
+
+  here' : List String → List String
+  here' t = "BlockTree" ∷ "insertQuorumCert" ∷ t
+
+  blockId = qc ^∙ qcCertifiedBlock ∙ biId
+
+  safetyInvariant = forM_ (Map.elems (bt0 ^∙ btIdToQuorumCert)) $ \x →
+          lcheck (   (x  ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash
+                  ==  qc ^∙ qcLedgerInfo ∙ liwsLedgerInfo ∙ liConsensusDataHash)
+                  ∨  (x  ^∙ qcCertifiedBlock ∙ biRound
+                  /=  qc ^∙ qcCertifiedBlock ∙ biRound))
+                 (here' ("failed check" ∷ "existing qc == qc || existing qc.round /= qc.round" ∷ []))
+
+  continue1 : BlockTree → HashValue → ExecutedBlock → List InfoLog → (BlockTree × List InfoLog)
+  continue2 : BlockTree → List InfoLog → (BlockTree × List InfoLog)
+
+  insertQuorumCertE-AST : EitherDExt (BlockTree × List InfoLog)
+  insertQuorumCertE-AST =
+    case safetyInvariant of λ where
+      (Left  e)    → bail-AST e
+      (Right unit) → maybeSD (btGetBlock blockId bt0) (bail-AST fakeErr) λ block →
+                     maybeSD (bt0 ^∙ btHighestCertifiedBlock) (bail-AST fakeErr) λ hcb →
+                     ifAST ⌊ (block ^∙ ebRound) >? (hcb ^∙ ebRound) ⌋
+                     then
+                       (let bt   = bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId
+                                       & btHighestQuorumCert       ∙~ qc
+                            info = (fakeInfo ∷ [])
+                        in return-AST (continue1 bt  blockId block info))
+                     else
+                       (return-AST (continue1 bt0 blockId block []))
+
+  continue1 bt blockId block info =
+    continue2 ( bt & btIdToQuorumCert ∙~ lookupOrInsert blockId qc (bt ^∙ btIdToQuorumCert))
+              ( (fakeInfo ∷ info) ++ (if ExecutedBlock.isNilBlock block then fakeInfo ∷ [] else [] ))
+
+  continue2 bt info =
+    if-dec (bt ^∙ btHighestCommitCert ∙ qcCommitInfo ∙ biRound) <? (qc ^∙ qcCommitInfo ∙ biRound)
+    then ((bt & btHighestCommitCert ∙~ qc) , info)
+    else (bt , info)
 
 insertQuorumCertM : QuorumCert → LBFT Unit
 insertQuorumCertM qc = do

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -24,7 +24,7 @@ open import Util.PKCS
 open import Util.Prelude
 open import Dijkstra.AST.Branching
 open import Dijkstra.AST.Core
-import      Dijkstra.AST.Either as EitherAST renaming (EitherD to EitherAST)
+import      Dijkstra.AST.Either as EitherAST
 open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; return; Unit; unit; Void)
 
 ------------------------------------------------------------------------------
@@ -128,14 +128,13 @@ insertBlockE-original block bt = do
         pure (  (bt' & btIdToBlock ∙~ Map.kvm-insert-Haskell blockId (LinkableBlock∙new block) (bt' ^∙ btIdToBlock))
              , block))
 
--- An AST version of insertBlockE
 module insertBlockE-AST (block : ExecutedBlock) (bt : BlockTree) where
-  open EitherAST
+  open import Dijkstra.AST.Either ErrLog
   open import Dijkstra.AST.Core
   open EitherAST.Syntax ErrLog renaming (bail to bail-AST; return to return-AST)
   open addChild
 
-  insertBlockE-AST : EitherAST ErrLog (BlockTree × ExecutedBlock)
+  insertBlockE-AST : EitherAST (BlockTree × ExecutedBlock)
   insertBlockE-AST = do
     let blockId = block ^∙ ebId
     case btGetBlock blockId bt of λ where
@@ -296,7 +295,7 @@ module insertQuorumCertE-AST (qc : QuorumCert) (bt0 : BlockTree) where
                             info = (fakeInfo ∷ [])
                         in return-AST (continue1 bt  blockId block info))
                      else
-                       (return-AST (continue1 bt0 blockId block []))
+                          (return-AST (continue1 bt0 blockId block []))
 
   continue1 bt blockId block info =
     continue2 ( bt & btIdToQuorumCert ∙~ lookupOrInsert blockId qc (bt ^∙ btIdToQuorumCert))

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -103,7 +103,7 @@ module insertBlockESpec
   contract-E : Contract (insertBlockE.E eb0 bt)
   contract-E = EitherD-contract (step₀ eb0 bt) Contract contract'
 
-  open ASTVersion eb0 bt
+  open insertBlockE-AST eb0 bt
   open addChild
 
   contract'-AST : ASTPredTrans.predTrans EitherPT insertBlockE-AST Contract unit
@@ -184,13 +184,6 @@ module insertBlockESpec
 module insertQuorumCertESpec
   (qc : QuorumCert) (bt0  : BlockTree) where
   open insertQuorumCertE qc bt0
-
-  Ok : Set
-  Ok = ∃₂ λ bt1 il → insertQuorumCertE-Either qc bt0 ≡ Right (bt1 , il)
-
-  private
-    Ok' : BlockTree → List InfoLog → Either ErrLog (BlockTree × List InfoLog) → Set
-    Ok' bt il m = m ≡ Right (bt , il)
 
   record ContractOk (btPre btPost : BlockTree) (ilPre ilPost : List InfoLog) : Set where
     constructor mkContractOk

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -26,7 +26,7 @@ open import Util.Lemmas
 open import Util.PKCS
 open import Util.Prelude
 
-open import Dijkstra.AST.Either ErrLog renaming (EitherD to EitherAST)
+open import Dijkstra.AST.Either ErrLog
 
 open QCProps
 open Invariants
@@ -293,10 +293,14 @@ module insertQuorumCertE-ASTSpec
       -- proofs, one for the nothing case and one for the just case; each receives evidence that mb
       -- is the relevant case (nothing or just something), and determines the relevant proof
       -- obligation.
+
       const tt , λ block _ →
+
       -- Similarly, another use of maybeSD in the code results in automatically introducing two
       -- proof obligations using C-c C-r
+
       const tt ,
+
       -- The "Right" goal in this case is determined by the use of ifAST in the code, which
       -- translates to ASTop (Right (BCif b)) ... (see BranchingSyntax).  Therefore, in this case,
       -- the proof obligation is determined in PredTransExtension to have two proof obligations, one
@@ -306,9 +310,10 @@ module insertQuorumCertE-ASTSpec
       -- The proofs for each case here are more or less copied from the insertQuorumcertESpec proof,
       -- but because the framework guided us to the goals, we did not need to state their types
       -- explicitly, which in turn means that we did not need to break the code into explicit steps.
+
       λ _ _ →
-      (const $ let bt' = bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId
-                             & btHighestQuorumCert       ∙~ qc
+        (const $ let bt' = bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId
+                               & btHighestQuorumCert       ∙~ qc
                 in ContractOk-trans
                      (mkContractOk (∈BlockTree-upd-hqc refl refl))
                      (contract-cont1' block bt' (fakeInfo ∷ [])))

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -4,6 +4,7 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
+open import Dijkstra.AST.Branching
 open import Dijkstra.AST.Core
 open import LibraBFT.Base.Types
 open import LibraBFT.Concrete.Records using (BlockId-correct)
@@ -252,3 +253,94 @@ module insertQuorumCertESpec
         proj₂ contract-step₃' _ = ContractOk-trans
                                     (mkContractOk (∈Post⇒∈PreOr'-refl _∈BlockTree_ _))
                                     (contract-cont1' bt0 [])
+
+module insertQuorumCertE-ASTSpec
+  (qc : QuorumCert) (bt0  : BlockTree) where
+  open insertQuorumCertE-AST qc bt0
+
+  -- The following definitions are the same as for the EitherD version above
+  record ContractOk (btPre btPost : BlockTree) (ilPre ilPost : List InfoLog) : Set where
+    constructor mkContractOk
+    field
+      noNewQCs : ∈Post⇒∈PreOrBT (_≡ qc) btPre btPost
+
+  ContractOk-trans : ∀ {btPre btInt btPost ilPre ilInt ilPost}
+                   → ContractOk btPre btInt  ilPre ilInt
+                   → ContractOk btInt btPost ilInt ilPost
+                   → ContractOk btPre btPost ilPre ilPost
+  ContractOk-trans (mkContractOk noNewQCs) (mkContractOk noNewQCs₁) =
+                    mkContractOk (∈Post⇒∈PreOr'-trans _∈BlockTree_ (_≡ qc) noNewQCs noNewQCs₁)
+
+  Contract : Either ErrLog (BlockTree × List InfoLog) → Set
+  Contract (Left x) = ⊤
+  Contract (Right (bt1 , il)) = ContractOk bt0 bt1 [] il
+
+  -- Here we prove the weakest precondition for insertQuorumCertE-AST to ensure Contract The proof
+  -- is similar to the corresponding one for insertQuorumCertE above, but the AST framework makes it
+  -- easier to discover the proof obligations.  Note that the code for insertQuorumCertE-AST is not
+  -- broken explicitly into steps because we don't need to write the types of the individual proofs
+  -- because the framework presents them to us.
+  contract-AST : ASTPredTrans.predTrans EitherPTExt insertQuorumCertE-AST Contract unit
+  contract-AST with safetyInvariant
+  --  The Left/bail cases are easy, as Contract simply requires ⊤ in this case.
+  ... | Left _ = tt
+  ... | Right unit =
+      -- Two proof obligations are introduced due to the use of maybeSD; the AST framework with the
+      -- branching extensions ensures that the two goals are created by typing C-c C-r in a hole
+      -- here.  To understand why, see the definition of maybeSD, which is in terms of the maybeD
+      -- field of the relevant MonadMaybeD instance (EitherDASTExt-MonadMaybeD), which translates to
+      -- ASTop (Right (BCmaybe mb)).  The opPT field of BranchPT establishes that we require two
+      -- proofs, one for the nothing case and one for the just case; each receives evidence that mb
+      -- is the relevant case (nothing or just something), and determines the relevant proof
+      -- obligation.
+      const tt , λ block _ →
+      -- Similarly, another use of maybeSD in the code results in automatically introducing two
+      -- proof obligations using C-c C-r
+      const tt ,
+      -- The "Right" goal in this case is determined by the use of ifAST in the code, which
+      -- translates to ASTop (Right (BCif b)) ... (see BranchingSyntax).  Therefore, in this case,
+      -- the proof obligation is determined in PredTransExtension to have two proof obligations, one
+      -- for the case in which b is true and one for b is false.  Each gets evidence of the value of
+      -- b (not used in this example) and the predicate transformer resulting from passing the value
+      -- of b to the function in the definition of ASTPredTrans.opPT yields the proof obligation.
+      -- The proofs for each case here are more or less copied from the insertQuorumcertESpec proof,
+      -- but because the framework guided us to the goals, we did not need to state their types
+      -- explicitly, which in turn means that we did not need to break the code into explicit steps.
+      λ _ _ →
+      (const $ let bt' = bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId
+                             & btHighestQuorumCert       ∙~ qc
+                in ContractOk-trans
+                     (mkContractOk (∈BlockTree-upd-hqc refl refl))
+                     (contract-cont1' block bt' (fakeInfo ∷ [])))
+      , (const $ ContractOk-trans
+                   (mkContractOk (∈Post⇒∈PreOr'-refl _∈BlockTree_ _))
+                   (contract-cont1' block bt0 []))
+      where
+      -- The following proofs are just about pure code, and are copied verbatim from
+      -- insertQuorumCertESpec above
+      contract-cont2' : ∀ (bt : BlockTree) (info : List InfoLog)
+                       → let (bt' , info') = continue2 bt info
+                         in ContractOk bt bt' info info'
+      contract-cont2' bt info
+         with (bt ^∙ btHighestCommitCert ∙ qcCommitInfo ∙ biRound) <? (qc ^∙ qcCommitInfo ∙ biRound)
+      ...| yes hqcR<qcR = mkContractOk (∈BlockTree-upd-hcc refl refl)
+      ...| no  hqcR≥qcR = mkContractOk (λ _ x → inj₁ x)
+
+      cont1-update-bt : BlockTree → BlockTree
+      cont1-update-bt bt = bt & btIdToQuorumCert ∙~ Map.insert blockId qc (bt ^∙ btIdToQuorumCert)
+
+      info' : List InfoLog → Bool → List InfoLog
+      info' il b = (fakeInfo ∷ il) ++ (if b then (fakeInfo ∷ []) else [])
+
+      contract-cont1' : ∀ (block : ExecutedBlock) (btPre : BlockTree) (infoPre : List InfoLog)
+                      → let (btPost , infoPost) = continue1 btPre blockId block infoPre
+                        in  ContractOk btPre btPost infoPre infoPost
+      contract-cont1' block btPre infoPre
+         with Map.kvm-member blockId (btPre ^∙ btIdToQuorumCert)
+      ...| true  = mkContractOk (ContractOk.noNewQCs (contract-cont2' btPre (info' infoPre $ ExecutedBlock.isNilBlock block )))
+      ...| false = ContractOk-trans {btInt = cont1-update-bt btPre} {ilInt = info' infoPre $ ExecutedBlock.isNilBlock block }
+                             (mkContractOk (∈Post⇒∈PreOrBT-QCs≡ _ refl refl))
+                             (mkContractOk (ContractOk.noNewQCs (contract-cont2'
+                                                                   (cont1-update-bt btPre)
+                                                                 (info' infoPre $ ExecutedBlock.isNilBlock block))))
+


### PR DESCRIPTION
This PR:

* adds an `AST` version of `insertQuorumCertE`
* proves the contract for `insertQuorumCertE-AST`

The  `AST` version of `insertQuorumCertE` does *not* split into explicit steps, and I could do the proof nonetheless.  I think this indicates that the framework is having its desired effect of guiding the prover.  That said, this is hardly a rigorous user experience study, given that I was able to reuse parts of the previous proof, and had the experience of having proved it before.