### PR TITLE
Work on Harold's `Maybe` `bind` example

### DIFF
--- a/src/Dijkstra/AST/Either.agda
+++ b/src/Dijkstra/AST/Either.agda
@@ -36,7 +36,7 @@ ASTOps.SubRet EitherOps  = EitherSubRet
 
 EitherAST = AST EitherOps
 
-module Syntax where
+module EitherSyntax where
   open import Dijkstra.AST.Syntax public
   open import Dijkstra.Syntax
 
@@ -56,7 +56,7 @@ private
       ASTreturn a
 
   module prog₁ where
-    open Syntax
+    open EitherSyntax
     prog₁' : ∀ {A} → Err → A → EitherAST A
     prog₁' {A} e a = do
       bail {Void} e

--- a/src/Dijkstra/AST/Examples/Maybe/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Bind.agda
@@ -47,6 +47,17 @@ module OneMaybeBindExample where
     mn1Post⇒Goal : _
     mn1Post⇒Goal nothing   mn1Postnothing .nothing   refl = tt
     mn1Post⇒Goal (just x₁) mn1Postjust    .(just x₁) refl = refl
+
+  -- Here is an alternative proof showing how maybePTLemma makes it easy for the user to provide the
+  -- needed cases for a proof about a bind
+  progPostWP2 : predTrans prog ProgPost unit
+  progPostWP2 = maybePTBindLemma prog refl nothingCase justCase
+    where
+    nothingCase : _
+    nothingCase _ = tt
+    justCase : _
+    justCase _ _  = refl
+
 module TwoMaybeBindsExample where
 
   prog : MaybeD (List Nat)

--- a/src/Dijkstra/AST/Examples/Maybe/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Bind.agda
@@ -1,0 +1,41 @@
+module Dijkstra.AST.Examples.Maybe.Bind where
+
+open import Data.Nat renaming (ℕ to Nat)
+open import Dijkstra.AST.Core
+open import Dijkstra.AST.Maybe
+open        Syntax
+open        ASTTypes     MaybeTypes
+open        ASTPredTrans MaybePT
+open        ASTOpSem     MaybeOpSem
+open import Haskell.Prelude
+open import Util.Prelude
+
+prog : (mn1 mn2 : MaybeD Nat) -> MaybeD (List Nat)
+prog mn1 mn2 = do
+  n1 <- mn1
+  n2 <- mn2
+  return (n1 ∷ n2 ∷ [])
+
+ProgPost : Unit -> Maybe (List Nat) -> Set
+ProgPost _  nothing = ⊤
+ProgPost _ (just l) = length l ≡ 2
+
+progPostWP : ∀ mn1 mn2
+          -> ASTPredTrans.predTrans MaybePT (prog mn1 mn2) (ProgPost unit) unit
+progPostWP mn1 mn2 =
+  ASTPredTransMono.predTransMono MaybePTMono
+    (prog mn1 mn2) (λ o → runMaybe (prog mn1 mn2) unit ≡ o) _ ⊆ₒProgPost unit PT
+ where
+  ⊆ₒProgPost : (λ o → runMaybe (prog mn1 mn2) unit ≡ o) ⊆ₒ ProgPost unit
+  ⊆ₒProgPost nothing _ = tt
+  ⊆ₒProgPost (just l) just_n1∷n2∷[]≡just_l with runMaybe mn1 unit
+  ... | just n1                           with runMaybe mn2 unit
+  ... | just n2 rewrite just-injective (sym just_n1∷n2∷[]≡just_l) = refl
+
+  PT : predTrans (prog mn1 mn2) (λ o → runMaybe (prog mn1 mn2) unit ≡ o) unit
+  PT = {!!}
+
+progPost : ∀ mn1 mn2  -> ProgPost unit (runMaybe (prog mn1 mn2) unit)
+progPost mn1 mn2 =
+  ASTSufficientPT.sufficient MaybeSuf (prog mn1 mn2) (ProgPost unit) unit (progPostWP mn1 mn2)
+

--- a/src/Dijkstra/AST/Examples/Maybe/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Bind.agda
@@ -95,15 +95,12 @@ module TwoMaybeBindsExample where
 
     open ASTSufficientPT MaybeSuf
 
-    cont : Nat → MaybeD (List Nat)
-    cont x = ((MonadAST Monad.>>= mn2)
-                      (λ n2 → Monad.return MonadAST (x ∷ n2 ∷ [])))
-
     justCase : _
-    justCase x _ = sufficient (cont x)
-                              (ProgPost unit)
-                              unit
-                              (maybePTBindLemma (cont x) refl (const tt) (λ x2 rm≡j → refl))
+    justCase x _ = let f = bindCont prog refl x
+                    in sufficient f
+                         (ProgPost unit)
+                         unit
+                         (maybePTBindLemma f refl (const tt) (λ x2 rm≡j → refl))
 
   progPost : ProgPost unit (runMaybe prog unit)
   progPost =

--- a/src/Dijkstra/AST/Examples/Maybe/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Bind.agda
@@ -37,7 +37,9 @@ module OneMaybeBindExample where
     where
 
     Goal : Post Nat
-    Goal x = -- bindPT (λ x → predTrans (Monad.return MonadAST (x ∷ []))) unit ProgPost
+    Goal x = -- The following goal is determined by:
+             -- bindPT (λ x → predTrans (Monad.return MonadAST (x ∷ []))) unit ProgPost
+             -- because prog is an AST-bind at the top level
            ∀ r → r ≡ x → MaybebindPost (λ x → predTrans (Monad.return MonadAST (x ∷ []))) ProgPost r
 
     PT : _

--- a/src/Dijkstra/AST/Examples/Maybe/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Bind.agda
@@ -4,9 +4,10 @@ open import Data.Nat renaming (ℕ to Nat)
 open import Dijkstra.AST.Core
 open import Dijkstra.AST.Maybe
 open        Syntax
-open        ASTTypes     MaybeTypes
-open        ASTPredTrans MaybePT
-open        ASTOpSem     MaybeOpSem
+open        ASTTypes         MaybeTypes
+open        ASTPredTrans     MaybePT
+open        ASTPredTransMono MaybePTMono
+open        ASTOpSem         MaybeOpSem
 open import Haskell.Prelude
 open import Util.Prelude
 
@@ -22,9 +23,9 @@ module _ (mn1 mn2 : MaybeD Nat) where
   ProgPost _  nothing = ⊤
   ProgPost _ (just l) = length l ≡ 2
 
-  progPostWP : ASTPredTrans.predTrans MaybePT prog (ProgPost unit) unit
+  progPostWP : predTrans prog (ProgPost unit) unit
   progPostWP =
-    ASTPredTransMono.predTransMono MaybePTMono
+    predTransMono
       prog (λ o → runMaybe prog unit ≡ o) _ ⊆ₒProgPost unit PT
    where
     ⊆ₒProgPost : (λ o → runMaybe prog unit ≡ o) ⊆ₒ ProgPost unit

--- a/src/Dijkstra/AST/Examples/Maybe/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Bind.agda
@@ -1,7 +1,7 @@
 open import Data.Nat renaming (ℕ to Nat)
 open import Dijkstra.AST.Core
 open import Dijkstra.AST.Maybe
-open        Syntax
+open        MaybeSyntax
 open        ASTTypes         MaybeTypes
 open        ASTPredTrans     MaybePT
 open        ASTPredTransMono MaybePTMono

--- a/src/Dijkstra/AST/Examples/Maybe/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Bind.agda
@@ -10,32 +10,33 @@ open        ASTOpSem     MaybeOpSem
 open import Haskell.Prelude
 open import Util.Prelude
 
-prog : (mn1 mn2 : MaybeD Nat) -> MaybeD (List Nat)
-prog mn1 mn2 = do
-  n1 <- mn1
-  n2 <- mn2
-  return (n1 ∷ n2 ∷ [])
+module _ (mn1 mn2 : MaybeD Nat) where
 
-ProgPost : Unit -> Maybe (List Nat) -> Set
-ProgPost _  nothing = ⊤
-ProgPost _ (just l) = length l ≡ 2
+  prog : MaybeD (List Nat)
+  prog = do
+    n1 <- mn1
+    n2 <- mn2
+    return (n1 ∷ n2 ∷ [])
 
-progPostWP : ∀ mn1 mn2
-          -> ASTPredTrans.predTrans MaybePT (prog mn1 mn2) (ProgPost unit) unit
-progPostWP mn1 mn2 =
-  ASTPredTransMono.predTransMono MaybePTMono
-    (prog mn1 mn2) (λ o → runMaybe (prog mn1 mn2) unit ≡ o) _ ⊆ₒProgPost unit PT
- where
-  ⊆ₒProgPost : (λ o → runMaybe (prog mn1 mn2) unit ≡ o) ⊆ₒ ProgPost unit
-  ⊆ₒProgPost nothing _ = tt
-  ⊆ₒProgPost (just l) just_n1∷n2∷[]≡just_l with runMaybe mn1 unit
-  ... | just n1                           with runMaybe mn2 unit
-  ... | just n2 rewrite just-injective (sym just_n1∷n2∷[]≡just_l) = refl
+  ProgPost : Unit -> Maybe (List Nat) -> Set
+  ProgPost _  nothing = ⊤
+  ProgPost _ (just l) = length l ≡ 2
 
-  PT : predTrans (prog mn1 mn2) (λ o → runMaybe (prog mn1 mn2) unit ≡ o) unit
-  PT = {!!}
+  progPostWP : ASTPredTrans.predTrans MaybePT prog (ProgPost unit) unit
+  progPostWP =
+    ASTPredTransMono.predTransMono MaybePTMono
+      prog (λ o → runMaybe prog unit ≡ o) _ ⊆ₒProgPost unit PT
+   where
+    ⊆ₒProgPost : (λ o → runMaybe prog unit ≡ o) ⊆ₒ ProgPost unit
+    ⊆ₒProgPost nothing _ = tt
+    ⊆ₒProgPost (just l) just_n1∷n2∷[]≡just_l with runMaybe mn1 unit
+    ... | just n1                           with runMaybe mn2 unit
+    ... | just n2 rewrite just-injective (sym just_n1∷n2∷[]≡just_l) = refl
 
-progPost : ∀ mn1 mn2  -> ProgPost unit (runMaybe (prog mn1 mn2) unit)
-progPost mn1 mn2 =
-  ASTSufficientPT.sufficient MaybeSuf (prog mn1 mn2) (ProgPost unit) unit (progPostWP mn1 mn2)
+    PT : predTrans prog (λ o → runMaybe prog unit ≡ o) unit
+    PT = {!!}
+
+  progPost : ProgPost unit (runMaybe prog unit)
+  progPost =
+    ASTSufficientPT.sufficient MaybeSuf prog (ProgPost unit) unit progPostWP
 

--- a/src/Dijkstra/AST/Examples/Maybe/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Bind.agda
@@ -2,10 +2,11 @@ open import Data.Nat renaming (ℕ to Nat)
 open import Dijkstra.AST.Core
 open import Dijkstra.AST.Maybe
 open        MaybeSyntax
-open        ASTTypes         MaybeTypes
+open        ASTOpSem         MaybeOpSem
 open        ASTPredTrans     MaybePT
 open        ASTPredTransMono MaybePTMono
-open        ASTOpSem         MaybeOpSem
+open        ASTSufficientPT  MaybeSuf
+open        ASTTypes         MaybeTypes
 open import Haskell.Prelude
 open import Util.Prelude
 
@@ -84,16 +85,13 @@ module TwoMaybeBindsExample where
     PT : predTrans prog (λ o → runMaybe prog unit ≡ o) unit
     PT = predTrans-is-weakest prog _ refl
 
-  -- A nicer proof using maybePTBindLemma (twice), but requires explicitly stating the continuation,
-  -- which is not nice.  Why doesn't Agda figure it out?
+  -- A nicer proof using maybePTBindLemma (twice)
   progPostWP2 : predTrans prog (ProgPost unit) unit
   progPostWP2 = maybePTBindLemma prog refl nothingCase justCase
     where
 
     nothingCase : _
     nothingCase _ = tt
-
-    open ASTSufficientPT MaybeSuf
 
     justCase : _
     justCase x _ = let f = bindCont prog refl x
@@ -104,5 +102,5 @@ module TwoMaybeBindsExample where
 
   progPost : ProgPost unit (runMaybe prog unit)
   progPost =
-    ASTSufficientPT.sufficient MaybeSuf prog (ProgPost unit) unit progPostWP
+    sufficient prog (ProgPost unit) unit progPostWP
 

--- a/src/Dijkstra/AST/Examples/Maybe/Partiality.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Partiality.agda
@@ -24,9 +24,11 @@ module Dijkstra.AST.Examples.Maybe.Partiality where
    https://zenodo.org/record/3257707#.Yec-nxPMJqt
 -}
 
-open ASTTypes MaybeTypes
-open ASTPredTrans MaybePT
-open Syntax
+open ASTPredTrans     MaybePT
+open ASTPredTransMono MaybePTMono
+open ASTSufficientPT  MaybeSuf
+open ASTTypes         MaybeTypes
+open MaybeSyntax
 
 Partial : {A : Set} → (P : A → Set) → Maybe A → Set
 Partial _ nothing  = ⊥
@@ -101,10 +103,10 @@ PN e = Partial (e ⇓_)
 --           because Agda figures it out from the goal.
 -- TODO-1: show steps needed in order to get Agda to infer types indicated by '_'
 --         in the type signatures of PN⊆₁ and PN⊆₂
-correct : ∀ (e : Expr) i → SafeDiv e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
+correct : ∀ (e : Expr) i → SafeDiv e → predTrans (⟦ e ⟧) (PN e) i
 correct (Val _)        _                   _   = ⇓Base
 correct (Div e₁ e₂) unit (¬e₂⇓0 , (sd₁ , sd₂)) =
-  ASTPredTransMono.predTransMono MaybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
+  predTransMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
  where
   ih₁ = correct e₁ unit sd₁
   ih₂ = correct e₂ unit sd₂
@@ -117,7 +119,7 @@ correct (Div e₁ e₂) unit (¬e₂⇓0 , (sd₁ , sd₂)) =
   PN⊆₁ : PN e₁ ⊆ₒ _
   PN⊆₁       _    ()   nothing refl
   PN⊆₁ (just n) e₁⇓n .(just n) refl =
-    ASTPredTransMono.predTransMono MaybePTMono ⟦ e₂ ⟧ (PN e₂) _ (PN⊆₂ n e₁⇓n) unit ih₂
+    predTransMono ⟦ e₂ ⟧ (PN e₂) _ (PN⊆₂ n e₁⇓n) unit ih₂
 
 Dom : {A : Set} {B : A → Set}
       → ((x : A) → MaybeD (B x)) → A → Set
@@ -191,10 +193,10 @@ Dom' : (Expr -> MaybeD Nat) -> Expr -> Set
 Dom' f a@(Val _)     =  dom' f a
 Dom' f a@(Div el er) = (dom' f a) ∧ Dom' f el ∧ Dom' f er
 
-sound' : ∀ (e : Expr) i → Dom' ⟦_⟧ e → ASTPredTrans.predTrans MaybePT (⟦ e ⟧) (PN e) i
+sound' : ∀ (e : Expr) i → Dom' ⟦_⟧ e → predTrans (⟦ e ⟧) (PN e) i
 sound' (Val _)        _                  _   = ⇓Base
 sound' (Div e₁ e₂) unit (ddiv , (de₁ , de₂)) =
-  ASTPredTransMono.predTransMono MaybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
+  predTransMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
  where
   ih₁ = sound' e₁ unit de₁
   ih₂ = sound' e₂ unit de₂
@@ -204,7 +206,7 @@ sound' (Div e₁ e₂) unit (ddiv , (de₁ , de₂)) =
   PN⊆₂ _ e₁⇓n (just       0)  e₂⇓0     (just       0)  refl
     with   runMaybe ⟦ e₁ ⟧ unit
          | runMaybe ⟦ e₂ ⟧ unit | inspect (runMaybe ⟦ e₂ ⟧) unit
-         | ASTSufficientPT.sufficient MaybeSuf ⟦ e₂ ⟧ _ unit ih₂
+         | sufficient ⟦ e₂ ⟧ _ unit ih₂
   ... | just _ | nothing       | [ eq₂ ] |       _ rewrite eq₂ = ⊥-elim ddiv
   ... | just _ | just 0        | [ eq₂ ] |       _ rewrite eq₂ = ⊥-elim ddiv
   ... | just l | just (Succ _) | [ eq₂ ] | e₂⇓Succ             =
@@ -212,4 +214,5 @@ sound' (Div e₁ e₂) unit (ddiv , (de₁ , de₂)) =
 
   PN⊆₁ : PN e₁ ⊆ₒ _
   PN⊆₁ (just n) e₁⇓n .(just n) refl =
-    ASTPredTransMono.predTransMono MaybePTMono ⟦ e₂ ⟧ (PN e₂) _ (PN⊆₂ n e₁⇓n) unit ih₂
+    predTransMono  ⟦ e₂ ⟧ (PN e₂) _ (PN⊆₂ n e₁⇓n) unit ih₂
+

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -19,9 +19,6 @@ open import Relation.Binary.PropositionalEquality
 open import Util.Prelude using (contradiction; id; Left)
 open        ASTExtension
 
-
-
-
 data MaybeCmd (C : Set) : Set₁ where
   Maybe-bail : MaybeCmd C
 
@@ -184,8 +181,10 @@ maybePTBindLemma : ∀ {A B : Set} {m : MaybeD A} {f : A → MaybeD B} {P : Post
                    → predTrans prog P i
 maybePTBindLemma {A} {m = m} {f} {P} {unit} prog refl nothingCase justCase
    with runMaybe m unit | inspect (runMaybe m) unit
-... | nothing | [ R ] = predTrans-is-weakest m _
-      λ where r refl → subst (MaybebindPost _ _) (sym R) (nothingCase refl)
+... | nothing | [ R ] = predTrans-is-weakest m _ bindPost
+      where
+      bindPost : _
+      bindPost r refl rewrite R = nothingCase refl
 ... | just x  | [ R ]
    with runMaybe (f x) unit | inspect (runMaybe (f x)) unit
 ... | nothing | [ R2 ] = obm-dangerous-magic! "TODO: contradiction between R and R2"

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -4,8 +4,6 @@
    Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
 -}
 
-open import LibraBFT.Base.Util
-
 module Dijkstra.AST.Maybe where
 
 open import Dijkstra.AST.Branching

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -35,6 +35,12 @@ ASTOps.SubRet MaybeOps = MaybeSubRet
 
 MaybeD = AST MaybeOps
 
+bindCont : ∀ {A}{B}{m : MaybeD A}{f : A → MaybeD B}
+           (prog : MaybeD B)
+           → prog ≡ AST.ASTbind m f
+           → (A → MaybeD B)
+bindCont {f = f} _ refl = f
+
 module Syntax where
   open import Dijkstra.AST.Syntax public
 

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -39,7 +39,7 @@ bindCont : ∀ {A}{B}{m : MaybeD A}{f : A → MaybeD B}
            → (A → MaybeD B)
 bindCont {f = f} _ refl = f
 
-module Syntax where
+module MaybeSyntax where
   open import Dijkstra.AST.Syntax public
 
   bail : ∀ {A} → MaybeD A
@@ -53,7 +53,7 @@ private
             (λ _ → ASTreturn  a)
 
   module prog₁ where
-    open Syntax
+    open MaybeSyntax
     prog₁' : ∀ {A} → A → MaybeD A
     prog₁' a = do
       bail {Void}

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -92,6 +92,14 @@ ASTPredTrans.opPT     MaybePT Maybe-bail f Post i = Post nothing
 -- MaybebindPost goal, for example.
 open ASTPredTrans MaybePT
 
+postulate
+  maybePTBindLemma : ∀ {A B : Set} {m : MaybeD A} {f : A → MaybeD B} {P : Post B}{i : Input}
+                     → (prog : MaybeD B)
+                     → prog ≡ ASTbind m f
+                     → (      runMaybe m i ≡ nothing → P nothing)
+                     → (∀ x → runMaybe m i ≡ just x  → P (runMaybe (f x) i))
+                     → predTrans prog P i
+
 private
   BailWorks : ∀ {A} -> Post A
   BailWorks o = o ≡ nothing

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -53,7 +53,7 @@ ASTOps.SubRet RWSOps  = RWSSubRet
 
 RWS = AST RWSOps
 
-module Syntax where
+module RWSSyntax where
   open import Dijkstra.AST.Syntax public
 
   gets : ∀ {A} → (St → A) → RWS A
@@ -86,7 +86,7 @@ private
       ASTreturn (unit , λ o → o ++ o)
 
   module prog₁ where
-    open Syntax
+    open RWSSyntax
     prog₁' : (St → Wr) → RWS Unit
     prog₁' f =
       pass $ do

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -131,7 +131,7 @@ insertBlockE-original block bt = do
 module insertBlockE-AST (block : ExecutedBlock) (bt : BlockTree) where
   open import Dijkstra.AST.Either ErrLog
   open import Dijkstra.AST.Core
-  open EitherAST.Syntax ErrLog renaming (bail to bail-AST; return to return-AST)
+  open EitherAST.EitherSyntax ErrLog renaming (bail to bail-AST; return to return-AST)
   open addChild
 
   insertBlockE-AST : EitherAST (BlockTree × ExecutedBlock)


### PR DESCRIPTION
This PR starts with an example created by @haroldcarr, with a simple `MaybeD` (should be renamed `MaybeAST`) program that includes two `bind`s using (unknown) `MaybeD` programs.  It then finishes the proof that came with the initial example, and along the way establishes a simpler example with only a single bind and proves it in a roundabout way, with documentation to help us  understand it.  It then postulates a lemma to make it easier to provide the proof obligations for `bind`s in `MaybeD`, and uses that lemma to also prove the two-bind example.  Finally, it begins the proof of this lemma, which is not quite finished as I am out of time.  The above-mentioned lemma is not quite satisfying because it requires explicitly specifying the "continuation" after the bind, which is cumbersome and takes us back to the "breaking into steps" days we want to leave behind in order to avoid unsolved constraints warnings, so this requires some more work too.