### PR TITLE
Make extended `AST` versions default, streamline their use, update examples and proofs

### DIFF
--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -251,4 +251,3 @@ module ConditionalExtensions
   open ASTPredTransMono PTMono    public
   open BranchingSyntax BaseOps    public
   open import Dijkstra.AST.Syntax public
-

--- a/src/Dijkstra/AST/Either.agda
+++ b/src/Dijkstra/AST/Either.agda
@@ -51,7 +51,7 @@ module EitherBase where
   ...| Right x = ASTOpSem.runAST EitherOpSem (f x) i
   ASTOpSem.runAST EitherOpSem (ASTop (Either-bail a) f) i = Left a
 
-  runEither = ASTOpSem.runAST EitherOpSem
+  runEitherBase = ASTOpSem.runAST EitherOpSem
 
   EitherbindPost : ∀ {A B} → (A → PredTrans B) → Post B → Post A
   EitherbindPost _ P (Left x)  = P (Left x)
@@ -87,8 +87,8 @@ module EitherBase where
   EitherSuf : ASTSufficientPT EitherOpSem EitherPT
   ASTSufficientPT.returnSuf EitherSuf x P i wp = wp
   ASTSufficientPT.bindSuf EitherSuf {A} {B} m f mSuf fSuf P unit wp
-     with  ASTOpSem.runAST EitherOpSem m  unit  | inspect
-          (ASTOpSem.runAST EitherOpSem m) unit
+     with  runEitherBase m  unit  | inspect
+          (runEitherBase m) unit
   ... | Left  x | [ R ] = mSuf _ unit wp (Left x) (sym R)
   ... | Right y | [ R ] = let wp' = mSuf _ unit wp (Right y) (sym R)
                            in fSuf y P unit wp'
@@ -124,13 +124,13 @@ module EitherAST where
   -- TODO: this is identical to the same for Maybe -- generalise?
   predTrans-is-weakest (ASTop (Right (BCif b)) f) Pr
      with predTrans-is-weakest (f (Level.lift b))
-  ...| rec = λ x → (λ where refl → rec Pr x) , (λ where refl → rec Pr x)
+  ...| rec = λ x → (λ where   refl → rec Pr x) , (λ where   refl → rec Pr x)
   predTrans-is-weakest (ASTop (Right (BCeither b)) f) Pr
      with predTrans-is-weakest (f (Level.lift b))
   ...| rec = λ x → (λ where r refl → rec Pr x) , (λ where r refl → rec Pr x)
   predTrans-is-weakest (ASTop (Right (BCmaybe mb)) f) Pr
      with predTrans-is-weakest (f (Level.lift mb))
-  ...| rec = λ x → (λ where refl → rec Pr x) , λ where j refl → rec Pr x
+  ...| rec = λ x → (λ where   refl → rec Pr x) , (λ where j refl → rec Pr x)
 
 
   module EitherSyntax where

--- a/src/Dijkstra/AST/Either.agda
+++ b/src/Dijkstra/AST/Either.agda
@@ -9,176 +9,175 @@
 module Dijkstra.AST.Either (Err : Set) where
 
 open import Data.Empty
-open import Data.Product using (_×_) -- ; _,_ ; proj₁ ; proj₂)
+open import Data.Product using (_×_ ; _,_)
 open import Data.Unit
-open import Dijkstra.AST.Core
-open import Dijkstra.AST.Branching
-open import Dijkstra.Syntax
 open import Haskell.Prelude hiding (return)
 import      Level
 import      Level.Literals as Level using (#_)
 open import Relation.Binary.PropositionalEquality
-open        ASTExtension
+open import Dijkstra.AST.Core
+open import Dijkstra.Syntax
 
-data EitherCmd (A : Set) : Set₁ where
-  Either-bail : Err → EitherCmd A
+module EitherBase where
 
-EitherSubArg : {A : Set} (a : EitherCmd A) → Set₁
-EitherSubArg (Either-bail _) = Level.Lift _ Void
+  data EitherCmd (A : Set) : Set₁ where
+    Either-bail : Err → EitherCmd A
 
-EitherSubRet : {A : Set} {c : EitherCmd A} (r : EitherSubArg c) → Set
-EitherSubRet {c = Either-bail _} _ = Void
+  EitherSubArg : {A : Set} (a : EitherCmd A) → Set₁
+  EitherSubArg (Either-bail _) = Level.Lift _ Void
 
-EitherOps : ASTOps
-ASTOps.Cmd    EitherOps  = EitherCmd
-ASTOps.SubArg EitherOps  = EitherSubArg
-ASTOps.SubRet EitherOps  = EitherSubRet
+  EitherSubRet : {A : Set} {c : EitherCmd A} (r : EitherSubArg c) → Set
+  EitherSubRet {c = Either-bail _} _ = Void
 
-EitherAST = AST EitherOps
+  EitherOps : ASTOps
+  ASTOps.Cmd    EitherOps  = EitherCmd
+  ASTOps.SubArg EitherOps  = EitherSubArg
+  ASTOps.SubRet EitherOps  = EitherSubRet
 
-module EitherSyntax where
-  open import Dijkstra.AST.Syntax public
-  open import Dijkstra.Syntax
+  EitherBaseAST = AST EitherOps
 
-  bail : ∀ {A} → Err → EitherAST A
-  bail a = ASTop (Either-bail a) λ ()
+  EitherTypes : ASTTypes
+  ASTTypes.Input  EitherTypes   = Unit -- We can always run an Either program.  In contrast, for an
+                                       -- RWS program, we need environment and prestate (Ev and St,
+                                       -- respectively)
+  ASTTypes.Output EitherTypes A = Either Err A
+  open ASTTypes EitherTypes
 
-  return : ∀ {A} → A → EitherAST A
-  return a = ASTreturn a
+  EitherOpSem : ASTOpSem EitherOps EitherTypes
+  ASTOpSem.runAST EitherOpSem (ASTreturn x) _ = Right x
+  ASTOpSem.runAST EitherOpSem (ASTbind m f) i
+    with ASTOpSem.runAST EitherOpSem m i
+  ...| Left a = Left a
+  ...| Right x = ASTOpSem.runAST EitherOpSem (f x) i
+  ASTOpSem.runAST EitherOpSem (ASTop (Either-bail a) f) i = Left a
 
-private
+  runEither = ASTOpSem.runAST EitherOpSem
+
+  EitherbindPost : ∀ {A B} → (A → PredTrans B) → Post B → Post A
+  EitherbindPost _ P (Left x)  = P (Left x)
+  EitherbindPost f P (Right y) = f y P unit
+
+  EitherPT : ASTPredTrans EitherOps EitherTypes
+  ASTPredTrans.returnPT EitherPT x P i = P (Right x)
+  ASTPredTrans.bindPT EitherPT {A} {B} f i Post x =
+    ∀ r → r ≡ x → EitherbindPost f Post r
+  ASTPredTrans.opPT EitherPT (Either-bail a) f Post i = Post (Left a)
+  open ASTPredTrans EitherPT
+
+  EitherPTMono : ASTPredTransMono EitherPT
+  ASTPredTransMono.returnPTMono EitherPTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
+     P₁⊆ₒP₂ _ wp
+
+  ASTPredTransMono.bindPTMono₁ EitherPTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ (Left x ) wp .(Left x ) refl =
+    P₁⊆ₒP₂ (Left x) (wp (Left x) refl)
+  ASTPredTransMono.bindPTMono₁ EitherPTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ (Right y) wp .(Right y) refl =
+    monoF y P₁ P₂ P₁⊆ₒP₂ unit (wp (Right y) refl)
+
+  ASTPredTransMono.bindPTMono₂ EitherPTMono {B1} {B2} f₁ f₂ f₁⊑f₂ unit P (Left x)  wp .(Left x) refl =
+    wp (Left x) refl
+  ASTPredTransMono.bindPTMono₂ EitherPTMono f₁ f₂ f₁⊑f₂ unit P (Right y) wp .(Right y) refl =
+    f₁⊑f₂ y _ unit (wp (Right y) refl)
+
+  ASTPredTransMono.opPTMono₁ EitherPTMono (Either-bail x) f monoF P₁ P₂ P₁⊆ₒP₂ unit wp =
+    P₁⊆ₒP₂ (Left x) wp
+
+  ASTPredTransMono.opPTMono₂ EitherPTMono (Either-bail x) f₁ f₂ f₁⊑f₂ P i wp =
+    wp
+
+  EitherSuf : ASTSufficientPT EitherOpSem EitherPT
+  ASTSufficientPT.returnSuf EitherSuf x P i wp = wp
+  ASTSufficientPT.bindSuf EitherSuf {A} {B} m f mSuf fSuf P unit wp
+     with  ASTOpSem.runAST EitherOpSem m  unit  | inspect
+          (ASTOpSem.runAST EitherOpSem m) unit
+  ... | Left  x | [ R ] = mSuf _ unit wp (Left x) (sym R)
+  ... | Right y | [ R ] = let wp' = mSuf _ unit wp (Right y) (sym R)
+                           in fSuf y P unit wp'
+  ASTSufficientPT.opSuf EitherSuf (Either-bail x) f fSuf P i wp = wp
+
+module EitherAST where
+  open EitherBase
+  open EitherBase using (EitherbindPost)                                 public
+  open import Dijkstra.AST.Branching
+  open ConditionalExtensions EitherPT EitherOpSem EitherPTMono EitherSuf public
+
+  EitherAST    = ExtAST
+
+  runEitherAST = runAST
+
+  -- This property says that predTrans really is the *weakest* precondition for a
+  -- postcondition to hold after running a MaybeD.
+  Post⇒wp : ∀ {A} → EitherAST A → Input → Set₁
+  Post⇒wp {A} e i =
+    (P : Post A)
+    → P (runEitherAST e i)
+    → predTrans e P i
+
+  predTrans-is-weakest : ∀ {A} → (e : EitherAST A) → Post⇒wp {A} e unit
+  predTrans-is-weakest (ASTreturn _) _ = id
+  predTrans-is-weakest (ASTbind e f) _ Pr
+     with predTrans-is-weakest e
+  ...| rec
+    with runEitherAST e unit
+  ... | Left  _ = rec _ λ where _ refl →                              Pr
+  ... | Right r = rec _ λ where _ refl → predTrans-is-weakest (f r) _ Pr
+  predTrans-is-weakest (ASTop (Left (Either-bail _)) _) _ = id
+  -- TODO: this is identical to the same for Maybe -- generalise?
+  predTrans-is-weakest (ASTop (Right (BCif b)) f) Pr
+     with predTrans-is-weakest (f (Level.lift b))
+  ...| rec = λ x → (λ where refl → rec Pr x) , (λ where refl → rec Pr x)
+  predTrans-is-weakest (ASTop (Right (BCeither b)) f) Pr
+     with predTrans-is-weakest (f (Level.lift b))
+  ...| rec = λ x → (λ where r refl → rec Pr x) , (λ where r refl → rec Pr x)
+  predTrans-is-weakest (ASTop (Right (BCmaybe mb)) f) Pr
+     with predTrans-is-weakest (f (Level.lift mb))
+  ...| rec = λ x → (λ where refl → rec Pr x) , λ where j refl → rec Pr x
+
+
+  module EitherSyntax where
+    EitherD-maybe : ∀ {A B : Set} → ExtAST B → (A → ExtAST B) → Maybe A → ExtAST B
+    EitherD-maybe m f mb = ASTop (Right (BCmaybe mb))
+                                 λ { (Level.lift nothing)  → m
+                                   ; (Level.lift (just j)) → f j
+                                   }
+    instance
+      MonadMaybeD-EitherAST : MonadMaybeD ExtAST
+      MonadMaybeD.monad  MonadMaybeD-EitherAST = MonadAST
+      MonadMaybeD.maybeD MonadMaybeD-EitherAST = EitherD-maybe
+
+    bail : ∀ {A} → Err → ExtAST A
+    bail a = ASTop (Left (Either-bail a)) λ ()
+
+    return : ∀ {A} → A → ExtAST A
+    return a = ASTreturn a
+
+open EitherAST    public
+open EitherSyntax public
+
+module EitherExample where
+  open EitherBase
+  open EitherSyntax
+  open EitherAST
+
   prog₁ : ∀ {A} → Err → A → EitherAST A
   prog₁ e a =
     -- Either-bail always returns left, so Agda cannot infer the
     -- type that it would return if it were to return Right, so
     -- we provide a type explicitly (Unit, in this case)
-    ASTbind (ASTop (Either-bail {Unit} e) λ ()) λ _ →
+    ASTbind (ASTop (Left (Either-bail {Unit} e)) λ ()) λ _ →
       ASTreturn a
 
-  module prog₁ where
-    open EitherSyntax
-    prog₁' : ∀ {A} → Err → A → EitherAST A
-    prog₁' {A} e a = do
-      bail {Void} e
-      return a
+  prog₁' : ∀ {A} → Err → A → EitherAST A
+  prog₁' {A} e a = do
+    bail {Void} e
+    return a
 
-EitherTypes : ASTTypes
-ASTTypes.Input  EitherTypes   = Unit -- We can always run an Either program.  In contrast, for an
-                                     -- RWS program, we need environment and prestate (Ev and St,
-                                     -- respectively)
-ASTTypes.Output EitherTypes A = Either Err A
-open ASTTypes EitherTypes
-
-EitherOpSem : ASTOpSem EitherOps EitherTypes
-ASTOpSem.runAST EitherOpSem (ASTreturn x) _ = Right x
-ASTOpSem.runAST EitherOpSem (ASTbind m f) i
-  with ASTOpSem.runAST EitherOpSem m i
-...| Left a = Left a
-...| Right x = ASTOpSem.runAST EitherOpSem (f x) i
-ASTOpSem.runAST EitherOpSem (ASTop (Either-bail a) f) i = Left a
-
-runEither = ASTOpSem.runAST EitherOpSem
-
-EitherbindPost : ∀ {A B} → (A → PredTrans B) → Post B → Post A
-EitherbindPost _ P (Left x)  = P (Left x)
-EitherbindPost f P (Right y) = f y P unit
-
-EitherPT : ASTPredTrans EitherOps EitherTypes
-ASTPredTrans.returnPT EitherPT x P i = P (Right x)
-ASTPredTrans.bindPT EitherPT {A} {B} f i Post x =
-  ∀ r → r ≡ x → EitherbindPost f Post r
-ASTPredTrans.opPT EitherPT (Either-bail a) f Post i = Post (Left a)
-open ASTPredTrans EitherPT
-
-private
   -- If Either-bail did not work (e.g., if it were a noop), prog₁ would return Right a and the proof
   -- would fail
   BailWorks : ∀ {A : Set} → Err → Post A
   BailWorks e = _≡ Left e
 
-  bailWorks : ∀ e i {A : Set} → (a : A) → ASTPredTrans.predTrans EitherPT (prog₁ e a) (BailWorks e) i
+  bailWorks : ∀ e i {A : Set} → (a : A) → predTrans (prog₁ e a) (BailWorks e) i
   bailWorks e unit _ _ refl = refl
 
-EitherPTMono : ASTPredTransMono EitherPT
-ASTPredTransMono.returnPTMono EitherPTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
-   P₁⊆ₒP₂ _ wp
-
-ASTPredTransMono.bindPTMono₁ EitherPTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ (Left x ) wp .(Left x ) refl =
-  P₁⊆ₒP₂ (Left x) (wp (Left x) refl)
-ASTPredTransMono.bindPTMono₁ EitherPTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ (Right y) wp .(Right y) refl =
-  monoF y P₁ P₂ P₁⊆ₒP₂ unit (wp (Right y) refl)
-
-ASTPredTransMono.bindPTMono₂ EitherPTMono {B1} {B2} f₁ f₂ f₁⊑f₂ unit P (Left x)  wp .(Left x) refl =
-  wp (Left x) refl
-ASTPredTransMono.bindPTMono₂ EitherPTMono f₁ f₂ f₁⊑f₂ unit P (Right y) wp .(Right y) refl =
-  f₁⊑f₂ y _ unit (wp (Right y) refl)
-
-ASTPredTransMono.opPTMono₁ EitherPTMono (Either-bail x) f monoF P₁ P₂ P₁⊆ₒP₂ unit wp =
-  P₁⊆ₒP₂ (Left x) wp
-
-ASTPredTransMono.opPTMono₂ EitherPTMono (Either-bail x) f₁ f₂ f₁⊑f₂ P i wp =
-  wp
-
-EitherSuf : ASTSufficientPT EitherOpSem EitherPT
-ASTSufficientPT.returnSuf EitherSuf x P i wp = wp
-ASTSufficientPT.bindSuf EitherSuf {A} {B} m f mSuf fSuf P unit wp
-   with  ASTOpSem.runAST EitherOpSem m  unit  | inspect
-        (ASTOpSem.runAST EitherOpSem m) unit
-... | Left  x | [ R ] = mSuf _ unit wp (Left x) (sym R)
-... | Right y | [ R ] = let wp' = mSuf _ unit wp (Right y) (sym R)
-                         in fSuf y P unit wp'
-ASTSufficientPT.opSuf EitherSuf (Either-bail x) f fSuf P i wp = wp
-
--- This property says that predTrans really is the *weakest* precondition for a
--- postcondition to hold after running a MaybeD.
-Post⇒wp : ∀ {A} → EitherAST A → Input → Set₁
-Post⇒wp {A} e i =
-  (P : Post A)
-  → P (runEither e i)
-  → predTrans e P i
-
-predTrans-is-weakest : ∀ {A} → (e : EitherAST A) → Post⇒wp {A} e unit
-predTrans-is-weakest (ASTreturn _) _ = id
-predTrans-is-weakest (ASTbind e f) _ Pr
-   with predTrans-is-weakest e
-...| rec
-  with runEither e unit
-... | Left  _ = rec _ λ where _ refl →                              Pr
-... | Right r = rec _ λ where _ refl → predTrans-is-weakest (f r) _ Pr
-predTrans-is-weakest (ASTop (Either-bail _) _) _ = id
-
-private
-  bailWorksSuf : ∀ e {A : Set} (a : A) i → (runEither (prog₁ e a) i ≡ Left e)
-  bailWorksSuf e a i = ASTSufficientPT.sufficient EitherSuf (prog₁ e a) (BailWorks e) unit (bailWorks e unit a )
-
-EitherExtOps    = BranchOps EitherOps
-EitherDExt      = AST EitherExtOps
-EitherPTExt     = PredTransExtension.BranchPT EitherPT
-runEitherExt    = ASTOpSem.runAST (OpSemExtension.BranchOpSem EitherOpSem)
-EitherPTMonoExt = PredTransExtensionMono.BranchPTMono EitherPTMono
-EitherSufExt    = SufficientExtension.BranchSuf EitherPTMono EitherSuf
-
-module SyntaxExt where
-  open import Dijkstra.AST.Syntax public
-  open import Dijkstra.Syntax
-
-  EitherD-maybe : ∀ {A B : Set} → EitherDExt B → (A → EitherDExt B) → Maybe A → EitherDExt B
-  EitherD-maybe m f mb = ASTop (Right (BCmaybe mb))
-                               λ { (Level.lift nothing)  → m
-                                 ; (Level.lift (just j)) → f j
-                                 }
-  instance
-    Monad-EitherDAST : Monad EitherDExt
-    Monad.return Monad-EitherDAST = ASTreturn
-    Monad._>>=_  Monad-EitherDAST = ASTbind
-
-    EitherDASTExt-MonadMaybeD : MonadMaybeD EitherDExt
-    MonadMaybeD.monad  EitherDASTExt-MonadMaybeD = Monad-EitherDAST
-    MonadMaybeD.maybeD EitherDASTExt-MonadMaybeD = EitherD-maybe
-
-  bail : ∀ {A} → Err → EitherDExt A
-  bail a = ASTop (Left (Either-bail a)) λ ()
-
-  return : ∀ {A} → A → EitherDExt A
-  return a = ASTreturn a
-
+  bailWorksSuf : ∀ e {A : Set} (a : A) i → (runEitherAST (prog₁ e a) i ≡ Left e)
+  bailWorksSuf e a i = sufficient (prog₁ e a) (BailWorks e) unit (bailWorks e unit a )

--- a/src/Dijkstra/AST/Examples/Either/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Either/Bind.agda
@@ -4,9 +4,7 @@ open import Data.Nat
 open import Dijkstra.AST.Core
 open import Util.Prelude
 open import Dijkstra.AST.Either ⊤
-open        ASTTypes         EitherTypes
-open        ASTPredTrans     EitherPT
-open        ASTPredTransMono EitherPTMono
+open EitherBase
 
 module TwoEitherBindsExample
   (en1 en2 : EitherAST ℕ)
@@ -23,16 +21,16 @@ module TwoEitherBindsExample
   ProgPost _ (Right r) = length r ≡ 2
 
   progPostWP : predTrans prog (ProgPost unit) unit
-  progPostWP = predTransMono prog runPost _ ⊆ₒProgPost unit PT
+  progPostWP = predTransMono prog runPost _ ⊆ₒProgPost unit PT1
    where
     runPost : Post (List ℕ)
-    runPost = runEither prog unit ≡_
+    runPost = runEitherAST prog unit ≡_
 
     ⊆ₒProgPost : runPost ⊆ₒ ProgPost unit
     ⊆ₒProgPost (Left  _) _                                               = refl
-    ⊆ₒProgPost (Right r) Right_n1∷n2∷[]≡Right_r with runEither en1 unit
-    ... | (Right n1)                            with runEither en2 unit
+    ⊆ₒProgPost (Right r) Right_n1∷n2∷[]≡Right_r with runEitherAST en1 unit
+    ... | (Right n1)                            with runEitherAST en2 unit
     ... | (Right n2) rewrite inj₂-injective (sym Right_n1∷n2∷[]≡Right_r) = refl
 
-    PT : predTrans prog runPost unit
-    PT = predTrans-is-weakest prog _ refl
+    PT1 : predTrans prog runPost unit
+    PT1 = predTrans-is-weakest prog _ refl

--- a/src/Dijkstra/AST/Examples/Either/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Either/Bind.agda
@@ -1,36 +1,35 @@
 module Dijkstra.AST.Examples.Either.Bind where
 
 open import Data.Nat
-open import Dijkstra.AST.Core
 open import Util.Prelude
-open import Dijkstra.AST.Either ⊤
-open EitherBase
 
-module TwoEitherBindsExample
-  (en1 en2 : EitherAST ℕ)
-  where
+module TwoEitherBindsExample where
+  open import Dijkstra.AST.Either ⊤
+  open        EitherBase
 
-  prog : EitherAST (List ℕ)
-  prog = do
-    n1 ← en1
-    n2 ← en2
-    ASTreturn (n1 ∷ n2 ∷ [])
+  module _ (en1 en2 : EitherAST ℕ) where
 
-  ProgPost : Unit → Either ⊤ (List ℕ) → Set
-  ProgPost _ (Left  l) =        l ≡ tt
-  ProgPost _ (Right r) = length r ≡ 2
+    prog : EitherAST (List ℕ)
+    prog = do
+      n1 ← en1
+      n2 ← en2
+      return (n1 ∷ n2 ∷ [])
 
-  progPostWP : predTrans prog (ProgPost unit) unit
-  progPostWP = predTransMono prog runPost _ ⊆ₒProgPost unit PT1
-   where
-    runPost : Post (List ℕ)
-    runPost = runEitherAST prog unit ≡_
+    ProgPost : Unit → Either ⊤ (List ℕ) → Set
+    ProgPost _ (Left  l) =        l ≡ tt
+    ProgPost _ (Right r) = length r ≡ 2
 
-    ⊆ₒProgPost : runPost ⊆ₒ ProgPost unit
-    ⊆ₒProgPost (Left  _) _                                               = refl
-    ⊆ₒProgPost (Right r) Right_n1∷n2∷[]≡Right_r with runEitherAST en1 unit
-    ... | (Right n1)                            with runEitherAST en2 unit
-    ... | (Right n2) rewrite inj₂-injective (sym Right_n1∷n2∷[]≡Right_r) = refl
+    progPostWP : predTrans prog (ProgPost unit) unit
+    progPostWP = predTransMono prog runPost _ ⊆ₒProgPost unit PT1
+     where
+      runPost : Post (List ℕ)
+      runPost = runEitherAST prog unit ≡_
 
-    PT1 : predTrans prog runPost unit
-    PT1 = predTrans-is-weakest prog _ refl
+      ⊆ₒProgPost : runPost ⊆ₒ ProgPost unit
+      ⊆ₒProgPost (Left  _) _                                               = refl
+      ⊆ₒProgPost (Right r) Right_n1∷n2∷[]≡Right_r with runEitherAST en1 unit
+      ... | (Right n1)                            with runEitherAST en2 unit
+      ... | (Right n2) rewrite inj₂-injective (sym Right_n1∷n2∷[]≡Right_r) = refl
+
+      PT1 : predTrans prog runPost unit
+      PT1 = predTrans-is-weakest prog _ refl

--- a/src/Dijkstra/AST/Examples/Maybe/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Bind.agda
@@ -1,101 +1,110 @@
+{- Byzantine Fault Tolerant Consensus Verification in Agda, version 0.9.
+
+   Copyright (c) 2022, Oracle and/or its affiliates.
+   Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.oracle.com/licenses/upl
+-}
+
 open import Data.Nat renaming (ℕ to Nat)
-open import Dijkstra.AST.Maybe
 open import Haskell.Prelude
 open import Util.Prelude
 
-module Dijkstra.AST.Examples.Maybe.Bind (mn1 mn2 : MaybeAST Nat) where
+module Dijkstra.AST.Examples.Maybe.Bind where
 
 module OneMaybeBindExample where
-  prog : MaybeAST (List Nat)
-  prog = do
-    n1 <- mn1
-    return (n1 ∷ [])
+  open import Dijkstra.AST.Maybe
+  module _ (mn1 mn2 : MaybeAST Nat) where
+    prog : MaybeAST (List Nat)
+    prog = do
+      n1 <- mn1
+      return (n1 ∷ [])
 
-  ProgPost : Maybe (List Nat) -> Set
-  ProgPost nothing = ⊤
-  ProgPost (just l) = length l ≡ 1
+    ProgPost : Maybe (List Nat) -> Set
+    ProgPost nothing = ⊤
+    ProgPost (just l) = length l ≡ 1
 
-  mn1Post : Post Nat
-  mn1Post nothing = ⊤
-  mn1Post (just n) = runMaybeAST mn1 unit ≡ just n
+    mn1Post : Post Nat
+    mn1Post nothing = ⊤
+    mn1Post (just n) = runMaybeAST mn1 unit ≡ just n
 
-  -- Here is the property we want to prove
-  progPostWP : predTrans prog ProgPost unit
-  -- This long-winded proof was helpful in understanding how to make the proof work
-  -- Agda knows the Goal postcondition because it knows that prog is a bind, and knows the rest of
-  -- the program.  To help us understand what it is that Agda figures out to enable putting _ for
-  -- the goal argument below, we define Goal below, and we can replace _ by Goal and see that it's
-  -- right.
-  progPostWP = predTransMono mn1 mn1Post _ {- Goal -} mn1Post⇒Goal unit PT1
-    where
+    -- Here is the property we want to prove
+    progPostWP : predTrans prog ProgPost unit
+    -- This long-winded proof was helpful in understanding how to make the proof work
+    -- Agda knows the Goal postcondition because it knows that prog is a bind, and knows the rest of
+    -- the program.  To help us understand what it is that Agda figures out to enable putting _ for
+    -- the goal argument below, we define Goal below, and we can replace _ by Goal and see that it's
+    -- right.
+    progPostWP = predTransMono mn1 mn1Post _ {- Goal -} mn1Post⇒Goal unit PT1
+      where
 
-    Goal : Post Nat
-    Goal x = -- The following goal is determined by:
-             -- bindPT (λ x → predTrans (Monad.return MonadAST (x ∷ []))) unit ProgPost
-             -- because prog is an AST-bind at the top level
-           ∀ r → r ≡ x → MaybebindPost (λ x → predTrans (Monad.return MonadAST (x ∷ []))) ProgPost r
+      Goal : Post Nat
+      Goal x = -- The following goal is determined by:
+               -- bindPT (λ x → predTrans (Monad.return MonadAST (x ∷ []))) unit ProgPost
+               -- because prog is an AST-bind at the top level
+             ∀ r → r ≡ x → MaybebindPost (λ x → predTrans (Monad.return MonadAST (x ∷ []))) ProgPost r
 
-    PT1 : _
-    PT1 with runAST mn1 unit | inspect (runAST mn1) unit
-    ... | nothing | [ R ] = predTrans-is-weakest mn1 mn1Post (subst mn1Post (sym R) tt)
-    ... | just x  | [ R ] = predTrans-is-weakest mn1 _       (subst mn1Post (sym R) R)
+      PT1 : _
+      PT1 with runAST mn1 unit | inspect (runAST mn1) unit
+      ... | nothing | [ R ] = predTrans-is-weakest mn1 mn1Post (subst mn1Post (sym R) tt)
+      ... | just x  | [ R ] = predTrans-is-weakest mn1 _       (subst mn1Post (sym R) R)
 
-    mn1Post⇒Goal : _
-    mn1Post⇒Goal nothing   mn1Postnothing .nothing   refl = tt
-    mn1Post⇒Goal (just x₁) mn1Postjust    .(just x₁) refl = refl
+      mn1Post⇒Goal : _
+      mn1Post⇒Goal nothing   mn1Postnothing .nothing   refl = tt
+      mn1Post⇒Goal (just x₁) mn1Postjust    .(just x₁) refl = refl
 
-  -- Here is an alternative proof showing how maybePTLemma makes it easy for the user to provide the
-  -- needed cases for a proof about a bind
-  progPostWP2 : predTrans prog ProgPost unit
-  progPostWP2 = maybePTBindLemma prog refl nothingCase justCase
-    where
-    nothingCase : _
-    nothingCase _ = tt
-    justCase : _
-    justCase _ _  = refl
+    -- Here is an alternative proof showing how maybePTLemma makes it easy for the user to provide the
+    -- needed cases for a proof about a bind
+    progPostWP2 : predTrans prog ProgPost unit
+    progPostWP2 = maybePTBindLemma prog refl nothingCase justCase
+      where
+      nothingCase : _
+      nothingCase _ = tt
+      justCase : _
+      justCase _ _  = refl
 
 module TwoMaybeBindsExample where
+  open import Dijkstra.AST.Maybe
 
-  prog : MaybeAST (List Nat)
-  prog = do
-    n1 <- mn1
-    n2 <- mn2
-    return (n1 ∷ n2 ∷ [])
+  module _ (mn1 mn2 : MaybeAST Nat) where
+    prog : MaybeAST (List Nat)
+    prog = do
+      n1 <- mn1
+      n2 <- mn2
+      return (n1 ∷ n2 ∷ [])
 
-  ProgPost : Unit -> Maybe (List Nat) -> Set
-  ProgPost _  nothing = ⊤
-  ProgPost _ (just l) = length l ≡ 2
+    ProgPost : Unit -> Maybe (List Nat) -> Set
+    ProgPost _  nothing = ⊤
+    ProgPost _ (just l) = length l ≡ 2
 
-  progPostWP : predTrans prog (ProgPost unit) unit
-  progPostWP =
-    predTransMono
-      prog (λ o → runMaybeAST prog unit ≡ o) _ ⊆ₒProgPost unit PT1
-   where
-    ⊆ₒProgPost : (λ o → runMaybeAST prog unit ≡ o) ⊆ₒ ProgPost unit
-    ⊆ₒProgPost nothing _ = tt
-    ⊆ₒProgPost (just l) just_n1∷n2∷[]≡just_l with runMaybeAST mn1 unit
-    ... | just n1                           with runMaybeAST mn2 unit
-    ... | just n2 rewrite just-injective (sym just_n1∷n2∷[]≡just_l) = refl
+    progPostWP : predTrans prog (ProgPost unit) unit
+    progPostWP =
+      predTransMono
+        prog (λ o → runMaybeAST prog unit ≡ o) _ ⊆ₒProgPost unit PT1
+     where
+      ⊆ₒProgPost : (λ o → runMaybeAST prog unit ≡ o) ⊆ₒ ProgPost unit
+      ⊆ₒProgPost nothing _ = tt
+      ⊆ₒProgPost (just l) just_n1∷n2∷[]≡just_l with runMaybeAST mn1 unit
+      ... | just n1                           with runMaybeAST mn2 unit
+      ... | just n2 rewrite just-injective (sym just_n1∷n2∷[]≡just_l) = refl
 
-    PT1 : predTrans prog (λ o → runMaybeAST prog unit ≡ o) unit
-    PT1 = predTrans-is-weakest prog _ refl
+      PT1 : predTrans prog (λ o → runMaybeAST prog unit ≡ o) unit
+      PT1 = predTrans-is-weakest prog _ refl
 
-  -- A nicer proof using maybePTBindLemma (twice)
-  progPostWP2 : predTrans prog (ProgPost unit) unit
-  progPostWP2 = maybePTBindLemma prog refl nothingCase justCase
-    where
+    -- A nicer proof using maybePTBindLemma (twice)
+    progPostWP2 : predTrans prog (ProgPost unit) unit
+    progPostWP2 = maybePTBindLemma prog refl nothingCase justCase
+      where
 
-    nothingCase : _
-    nothingCase _ = tt
+      nothingCase : _
+      nothingCase _ = tt
 
-    justCase : _
-    justCase x _ = let f = bindCont prog refl x
-                    in sufficient f
-                         (ProgPost unit)
-                         unit
-                         (maybePTBindLemma f refl (const tt) (λ x2 rm≡j → refl))
+      justCase : _
+      justCase x _ = let f = bindCont prog refl x
+                      in sufficient f
+                           (ProgPost unit)
+                           unit
+                           (maybePTBindLemma f refl (const tt) (λ x2 rm≡j → refl))
 
-  progPost : ProgPost unit (runMaybeAST prog unit)
-  progPost =
-    sufficient prog (ProgPost unit) unit progPostWP
+    progPost : ProgPost unit (runMaybeAST prog unit)
+    progPost =
+      sufficient prog (ProgPost unit) unit progPostWP
 

--- a/src/Dijkstra/AST/Examples/Maybe/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Bind.agda
@@ -1,12 +1,5 @@
 open import Data.Nat renaming (ℕ to Nat)
-open import Dijkstra.AST.Core
 open import Dijkstra.AST.Maybe
-open        MaybeSyntax
-open        ASTOpSem         MaybeOpSem
-open        ASTPredTrans     MaybePT
-open        ASTPredTransMono MaybePTMono
-open        ASTSufficientPT  MaybeSuf
-open        ASTTypes         MaybeTypes
 open import Haskell.Prelude
 open import Util.Prelude
 
@@ -33,7 +26,7 @@ module OneMaybeBindExample where
   -- the program.  To help us understand what it is that Agda figures out to enable putting _ for
   -- the goal argument below, we define Goal below, and we can replace _ by Goal and see that it's
   -- right.
-  progPostWP = predTransMono mn1 mn1Post _ {- Goal -} mn1Post⇒Goal unit PT
+  progPostWP = predTransMono mn1 mn1Post _ {- Goal -} mn1Post⇒Goal unit PT1
     where
 
     Goal : Post Nat
@@ -42,8 +35,8 @@ module OneMaybeBindExample where
              -- because prog is an AST-bind at the top level
            ∀ r → r ≡ x → MaybebindPost (λ x → predTrans (Monad.return MonadAST (x ∷ []))) ProgPost r
 
-    PT : _
-    PT with runAST mn1 unit | inspect (runAST mn1) unit
+    PT1 : _
+    PT1 with runAST mn1 unit | inspect (runAST mn1) unit
     ... | nothing | [ R ] = predTrans-is-weakest mn1 mn1Post (subst mn1Post (sym R) tt)
     ... | just x  | [ R ] = predTrans-is-weakest mn1 _       (subst mn1Post (sym R) R)
 
@@ -76,7 +69,7 @@ module TwoMaybeBindsExample where
   progPostWP : predTrans prog (ProgPost unit) unit
   progPostWP =
     predTransMono
-      prog (λ o → runMaybeAST prog unit ≡ o) _ ⊆ₒProgPost unit PT
+      prog (λ o → runMaybeAST prog unit ≡ o) _ ⊆ₒProgPost unit PT1
    where
     ⊆ₒProgPost : (λ o → runMaybeAST prog unit ≡ o) ⊆ₒ ProgPost unit
     ⊆ₒProgPost nothing _ = tt
@@ -84,8 +77,8 @@ module TwoMaybeBindsExample where
     ... | just n1                           with runMaybeAST mn2 unit
     ... | just n2 rewrite just-injective (sym just_n1∷n2∷[]≡just_l) = refl
 
-    PT : predTrans prog (λ o → runMaybeAST prog unit ≡ o) unit
-    PT = predTrans-is-weakest prog _ refl
+    PT1 : predTrans prog (λ o → runMaybeAST prog unit ≡ o) unit
+    PT1 = predTrans-is-weakest prog _ refl
 
   -- A nicer proof using maybePTBindLemma (twice)
   progPostWP2 : predTrans prog (ProgPost unit) unit

--- a/src/Dijkstra/AST/Examples/Maybe/Branching.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Branching.agda
@@ -7,11 +7,12 @@
 open import Data.Nat
 import      Level
 open import Util.Prelude hiding (bail)
-open import Dijkstra.AST.Maybe
 
 module Dijkstra.AST.Examples.Maybe.Branching where
 
 module Example-if (n : ℕ) where
+  open import Dijkstra.AST.Maybe
+
   -- First we specify the behaviour we want via a postcondition requiring that the program can fail
   -- only if n is zero, and if it succeeds, the n is non-zero and the result is 2 * n
   bpPost : Post ℕ
@@ -24,9 +25,10 @@ module Example-if (n : ℕ) where
 
     -- Because this is a "raw" example that does not use the nice syntax, we have to explicitly
     -- import and open modules to access the underlying definitions
+    open import Dijkstra.AST.Core
     open import Dijkstra.AST.Branching using (BranchCmd)
     open BranchCmd using (BCif)
-    open MaybeBase using (Maybe-bail)
+    open MaybeBase
 
     branchingProg : MaybeAST ℕ
     branchingProg = ASTop (Right (BCif (toBool (n ≟ℕ 0) )))
@@ -160,6 +162,7 @@ module Example-if (n : ℕ) where
 module Example-either (n : ℕ) where
 
   module Common where
+    open import Dijkstra.AST.Maybe public
 
     _monus1 : ℕ → Either Unit ℕ
     _monus1 0        = Left unit
@@ -180,18 +183,19 @@ module Example-either (n : ℕ) where
     bpPost (just x) = n ≡ suc x
 
   module Raw where
-    open Common
+    open        Common
     -- Because this is a "raw" example that does not use the nice syntax, we have to explicitly
     -- import and open modules to access the underlying definitions
+    open import Dijkstra.AST.Core
     open import Dijkstra.AST.Branching using (BranchCmd)
-    open BranchCmd using (BCif ; BCeither)
-    open MaybeBase using (Maybe-bail)
+    open        BranchCmd using (BCif ; BCeither)
+    open        MaybeBase using (Maybe-bail)
 
     -- A branching program that bails if n monus1 is Left _
     -- and returns b if n monus1 is Right b
     branchingProg : MaybeAST ℕ
     branchingProg = ASTop (Right (BCeither (n monus1)))
-                          λ { (lift (Left  a)) → ASTop (Left Maybe-bail) λ () 
+                          λ { (lift (Left  a)) → ASTop (Left Maybe-bail) λ ()
                             ; (lift (Right b)) → return b
                             }
 
@@ -204,7 +208,7 @@ module Example-either (n : ℕ) where
     prop i = sufficient branchingProg bpPost i (branchingProgWP i)
 
   module Prettier where
-    open Common
+    open        Common
     -- Same program with nicer syntax using eitherSAST, bail and return
     branchingProg : MaybeAST ℕ
     branchingProg = eitherSAST (n monus1) (const bail) return

--- a/src/Dijkstra/AST/Examples/Maybe/Partiality.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Partiality.agda
@@ -12,7 +12,6 @@ open import Data.Product      using (∃ ; ∃-syntax ; _×_)
 open import Function.Base     using (case_of_)
 import      Level
 open import Util.Prelude      using (Maybe ; just ; nothing ; unit ; _>>=_ ; absurd_case_of_)
-open import Dijkstra.AST.Core
 open import Dijkstra.AST.Maybe
 open import Relation.Binary.PropositionalEquality
 
@@ -23,12 +22,6 @@ module Dijkstra.AST.Examples.Maybe.Partiality where
    https://webspace.science.uu.nl/~swier004/publications/2019-icfp-submission-a.pdf
    https://zenodo.org/record/3257707#.Yec-nxPMJqt
 -}
-
-open ASTPredTrans     MaybePT
-open ASTPredTransMono MaybePTMono
-open ASTSufficientPT  MaybeSuf
-open ASTTypes         MaybeTypes
-open MaybeSyntax
 
 Partial : {A : Set} → (P : A → Set) → Maybe A → Set
 Partial _ nothing  = ⊥
@@ -130,7 +123,7 @@ DomDiv : ∀ {e₁ e₂}
          → Dom ⟦_⟧ e₁
            ∧ wpPartial ⟦_⟧ (λ _ → _> 0) e₂
 Pair.fst (DomDiv {e₁} dom) =
-  maybePTMono ⟦ e₁ ⟧ _ _ ⊆Partial unit dom
+  predTransMono ⟦ e₁ ⟧ _ _ ⊆Partial unit dom
  where
   ⊆Partial : _ ⊆ₒ Partial (λ _ → ⊤)
   ⊆Partial nothing  wp = wp _ refl
@@ -138,7 +131,7 @@ Pair.fst (DomDiv {e₁} dom) =
 Pair.snd (DomDiv {e₁} {e₂} dom) =
   maybeSuffBind {Q = λ _ → _} ⟦ e₁ ⟧
     (λ m → ⟦ e₂ ⟧ >>= λ n → m ÷ n) dom (λ ())
-    λ m wp → maybePTMono ⟦ e₂ ⟧ _ _ (⊆Partial m) unit wp
+    λ m wp → predTransMono ⟦ e₂ ⟧ _ _ (⊆Partial m) unit wp
    where
     ⊆Partial : ∀ m → _ ⊆ₒ Partial (_> 0)
     ⊆Partial _  nothing        wp = wp _ refl
@@ -148,11 +141,11 @@ Pair.snd (DomDiv {e₁} {e₂} dom) =
 sound : ∀ (e : Expr) i → Dom ⟦_⟧ e → predTrans ⟦ e ⟧ (PN e) i
 sound (Val x) unit dom = ⇓Base
 sound (Div e₁ e₂) unit dom =
-  maybePTMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
+  predTransMono ⟦ e₁ ⟧ (PN e₁) _ PN⊆₁ unit ih₁
  where
   ih₁ = sound e₁ unit (Pair.fst (DomDiv {e₁} {e₂} dom))
   ih₂ = sound e₂ unit
-          (maybePTMono ⟦ e₂ ⟧ _ _ (λ { nothing () ; (just _) _ → tt}) unit
+          (predTransMono ⟦ e₂ ⟧ _ _ (λ { nothing () ; (just _) _ → tt}) unit
             (Pair.snd (DomDiv {e₁} {e₂} dom)))
 
   PN⊆₂ : ∀ n → e₁ ⇓ n → Partial (λ n → e₂ ⇓ n ∧ (n > 0)) ⊆ₒ _
@@ -161,9 +154,9 @@ sound (Div e₁ e₂) unit dom =
 
   PN⊆₁ : PN e₁ ⊆ₒ _
   PN⊆₁ (just m) e₁⇓m ._ refl =
-    maybePTMono ⟦ e₂ ⟧ _ _ (PN⊆₂ m e₁⇓m) unit
+    predTransMono ⟦ e₂ ⟧ _ _ (PN⊆₂ m e₁⇓m) unit
       (maybePTApp ⟦ e₂ ⟧ unit
-        (maybePTMono ⟦ e₂ ⟧ _ _
+        (predTransMono ⟦ e₂ ⟧ _ _
           (λ where
             (just x) wp₁ wp₂ → wp₂ , wp₁)
           unit ((Pair.snd (DomDiv {e₁} {e₂} dom))))

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -6,107 +6,230 @@
 
 module Dijkstra.AST.Maybe where
 
-open import Dijkstra.AST.Branching
 open import Dijkstra.AST.Core
-open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; return; Unit; unit; Monad; Void)
-open import Data.Product using (Σ)
+open import Haskell.Prelude using (_>>_; _>>=_; const; just; Maybe; nothing; return; Unit; unit; Monad; Void; false; true)
+open import Data.Product using (Σ; _,_)
 import      Level
 open import Relation.Binary.PropositionalEquality
-open import Util.Prelude using (contradiction; id; Left)
-open        ASTExtension
+open import Util.Prelude using (contradiction; id; Left; Right)
 
-data MaybeCmd (C : Set) : Set₁ where
-  Maybe-bail : MaybeCmd C
+module MaybeBase where
 
-MaybeSubArg : {C : Set} (c : MaybeCmd C) → Set₁
-MaybeSubArg Maybe-bail = Level.Lift _ Void
+  data MaybeCmd (C : Set) : Set₁ where
+    Maybe-bail : MaybeCmd C
 
-MaybeSubRet : {A : Set} {c : MaybeCmd A} (r : MaybeSubArg c) → Set
-MaybeSubRet {c = Maybe-bail} ()
+  MaybeSubArg : {C : Set} (c : MaybeCmd C) → Set₁
+  MaybeSubArg Maybe-bail = Level.Lift _ Void
 
-MaybeOps : ASTOps
-ASTOps.Cmd    MaybeOps = MaybeCmd
-ASTOps.SubArg MaybeOps = MaybeSubArg
-ASTOps.SubRet MaybeOps = MaybeSubRet
+  MaybeSubRet : {A : Set} {c : MaybeCmd A} (r : MaybeSubArg c) → Set
+  MaybeSubRet {c = Maybe-bail} ()
 
-MaybeAST = AST MaybeOps
+  MaybeOps : ASTOps
+  ASTOps.Cmd    MaybeOps = MaybeCmd
+  ASTOps.SubArg MaybeOps = MaybeSubArg
+  ASTOps.SubRet MaybeOps = MaybeSubRet
 
-bindCont : ∀ {A}{B}{m : MaybeAST A}{f : A → MaybeAST B}
-           (prog : MaybeAST B)
+  MaybeBaseAST = AST MaybeOps
+
+  MaybeTypes : ASTTypes
+  ASTTypes.Input  MaybeTypes   = Unit
+  ASTTypes.Output MaybeTypes A = Maybe A
+
+  open ASTTypes MaybeTypes
+
+  MaybeOpSem : ASTOpSem MaybeOps MaybeTypes
+  ASTOpSem.runAST MaybeOpSem (ASTreturn x) _ = just x
+  ASTOpSem.runAST MaybeOpSem (ASTbind m f) i
+    with ASTOpSem.runAST MaybeOpSem m i
+  ...| nothing = nothing
+  ...| just x  = ASTOpSem.runAST MaybeOpSem (f x) i
+  ASTOpSem.runAST MaybeOpSem (ASTop Maybe-bail f) i = nothing
+
+  runMaybe = ASTOpSem.runAST MaybeOpSem
+
+  MaybebindPost : ∀ {A B} → (A → PredTrans B) → Post B → Post A
+  MaybebindPost _ P nothing  = P nothing
+  MaybebindPost f P (just y) = f y P unit
+
+  MaybebindPost⊆
+    : ∀ {A B} (f : A → PredTrans B) (P₁ : Post B) (P₂ : Post A)
+      → (P₁ nothing → P₂ nothing)
+      → (∀ x → f x P₁ unit → P₂ (just x))
+      → MaybebindPost f P₁ ⊆ₒ P₂
+  MaybebindPost⊆ f P₁ P₂ n⊆ j⊆ nothing wp = n⊆ wp
+  MaybebindPost⊆ f P₁ P₂ n⊆ j⊆ (just x) wp = j⊆ x wp
+
+  MaybePT : ASTPredTrans MaybeOps MaybeTypes
+  ASTPredTrans.returnPT MaybePT x P i               = P (just x)
+  -- Note that it is important *not* to pattern match the input as 'unit'.  Even though this is the
+  -- only constructor for Unit, Agda does not figure out that this case applies to a general Input
+  -- (because Input is of type Unit), and therefore does not expand this case when encountering
+  -- bindPT.
+  ASTPredTrans.bindPT   MaybePT f i Post x          = ∀ r → r ≡ x → MaybebindPost f Post r
+  ASTPredTrans.opPT     MaybePT Maybe-bail f Post i = Post nothing
+  -- This open is important because, without it, Agda does not know how to interpret bindPT and
+  -- therefore does not refine the goal sufficiently to enable the old λ ._ refl trick to get to the
+  -- MaybebindPost goal, for example.
+  open ASTPredTrans MaybePT
+
+  MaybePTMono : ASTPredTransMono MaybePT
+  ASTPredTransMono.returnPTMono MaybePTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
+    P₁⊆ₒP₂ _ wp
+
+  ASTPredTransMono.bindPTMono₁  MaybePTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ nothing  wp .nothing  refl =
+    P₁⊆ₒP₂ nothing (wp nothing refl)
+  ASTPredTransMono.bindPTMono₁  MaybePTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ (just y) wp .(just y) refl =
+    monoF y P₁ P₂ P₁⊆ₒP₂ unit (wp (just y) refl)
+
+  ASTPredTransMono.bindPTMono₂  MaybePTMono {B1} {B2} f₁ f₂ f₁⊑f₂ unit P nothing wp .nothing refl =
+    wp nothing refl
+  ASTPredTransMono.bindPTMono₂  MaybePTMono f₁ f₂ f₁⊑f₂ unit P (just y) wp .(just y) refl =
+    f₁⊑f₂ y _ unit (wp (just y) refl)
+
+  ASTPredTransMono.opPTMono₁    MaybePTMono Maybe-bail f monoF P₁ P₂ P₁⊆ₒP₂ unit wp =
+    P₁⊆ₒP₂ nothing wp
+  ASTPredTransMono.opPTMono₂    MaybePTMono Maybe-bail f₁ f₂ f₁⊑f₂ P i wp =
+    wp
+
+  maybePTMono      = ASTPredTransMono.predTransMono MaybePTMono
+  maybePTMonoBind₂ = ASTPredTransMono.bindPTMono₂   MaybePTMono
+
+  MaybeSuf : ASTSufficientPT MaybeOpSem MaybePT
+  ASTSufficientPT.returnSuf MaybeSuf x P i wp = wp
+  ASTSufficientPT.bindSuf   MaybeSuf {A} {B} m f mSuf fSuf P unit wp
+    with runMaybe m unit | inspect (runMaybe m) unit
+  ... |  nothing         | [ eq ] = mSuf _ unit wp nothing (sym eq)
+  ... |  just y          | [ eq ] = let wp' = mSuf _ unit wp (just y) (sym eq)
+                                     in fSuf y P unit wp'
+  ASTSufficientPT.opSuf     MaybeSuf Maybe-bail f fSuf P i wp = wp
+
+module MaybeAST where
+  open MaybeBase
+  open MaybeBase using (MaybebindPost) public
+  open import Dijkstra.AST.Core                                      public
+  open import Dijkstra.AST.Branching
+  open ConditionalExtensions MaybePT MaybeOpSem MaybePTMono MaybeSuf public
+
+  MaybeAST = ExtAST
+
+  runMaybeAST = runAST
+
+  -- This property says that predTrans really is the *weakest* precondition for a
+  -- postcondition to hold after running a MaybeAST.
+  Post⇒wp : ∀ {A} → MaybeAST A → Input → Set₁
+  Post⇒wp {A} m i =
+    (P : Post A)
+    → P (runMaybeAST m i)
+    → predTrans m P i
+
+  predTrans-is-weakest : ∀ {A} → (m : MaybeAST A) → Post⇒wp {A} m unit
+  predTrans-is-weakest (ASTreturn _) _ = id
+  predTrans-is-weakest (ASTbind m f) _ Pr
+     with predTrans-is-weakest m
+  ...| rec
+    with runMaybeAST m unit
+  ... | nothing = rec _ λ where _ refl → Pr
+  ... | just x  = rec _ λ where r refl → predTrans-is-weakest (f x) _ Pr
+  predTrans-is-weakest (ASTop (Left Maybe-bail) f)    Pr = id
+  predTrans-is-weakest (ASTop (Right (BCif b)) f) Pr
+     with predTrans-is-weakest (f (Level.lift b))
+  ...| rec = λ x → (λ where refl → rec Pr x) , (λ where refl → rec Pr x)
+  predTrans-is-weakest (ASTop (Right (BCeither b)) f) Pr
+     with predTrans-is-weakest (f (Level.lift b))
+  ...| rec = λ x → (λ where r refl → rec Pr x) , (λ where r refl → rec Pr x)
+  predTrans-is-weakest (ASTop (Right (BCmaybe mb)) f) Pr
+     with predTrans-is-weakest (f (Level.lift mb))
+  ...| rec = λ x → (λ where refl → rec Pr x) , λ where j refl → rec Pr x
+
+  maybePTApp
+      : ∀ {A} {P₁ P₂ : Post A} (m : MaybeAST A) i
+        → predTrans m (λ o → P₁ o → P₂ o) i
+        → predTrans m P₁ i
+        → predTrans m P₂ i
+  maybePTApp {_} {P₁} {P₂} m unit imp pt1 =
+    predTrans-is-weakest m P₂
+      (sufficient m (λ o → P₁ o → P₂ o) unit imp
+        (sufficient m P₁ unit pt1))
+
+  module MaybeBindProps {A B : Set} {m : MaybeAST A} {f : A → MaybeAST B}
+                        (prog : MaybeAST B)
+                        (prog≡ : prog ≡ ASTbind m f) where
+    justProp : ∀ x
+               → runMaybeAST m unit ≡ just x
+               → runMaybeAST prog unit ≡ runMaybeAST (f x) unit
+    justProp x runm≡justx rewrite prog≡ | runm≡justx = refl
+
+  -- TODO : generalise, does not need to be specific to Maybe
+  bindCont : ∀ {A}{B}{m : MaybeAST A}{f : A → MaybeAST B}
+             (prog : MaybeAST B)
            → prog ≡ AST.ASTbind m f
            → (A → MaybeAST B)
-bindCont {f = f} _ refl = f
+  bindCont {m = m} {f} prog refl = f
+
+  maybePTBindLemma : ∀ {A B : Set} {m : MaybeAST A} {f : A → MaybeAST B} {P : Post B}{i : Input}
+                     → (prog : MaybeAST B)
+                     → prog ≡ ASTbind m f
+                     → (      runMaybeAST m i ≡ nothing → P nothing)
+                     → (∀ x → runMaybeAST m i ≡ just x  → P (runMaybeAST (f x) i))
+                     → predTrans prog P i
+  maybePTBindLemma {A} {m = m} {f} {P} {unit} prog refl nothingCase justCase
+     with runMaybeAST m unit | inspect (runMaybeAST m) unit
+  ... | nothing | [ R ] = predTrans-is-weakest m _ bindPost
+        where
+        bindPost : _
+        bindPost r refl rewrite R = nothingCase refl
+  ... | just x  | [ R ] = predTrans-is-weakest prog P bindPost
+        where
+        bindPost : _
+        bindPost = subst P (sym (MaybeBindProps.justProp prog refl x R)) (justCase x refl)
+
+  maybeSufficient = ASTSufficientPT.sufficient Suf
+
+  -- TODO: make these apply to MaybeExt, use in Partiality
+  maybeSuffBind
+    : ∀ {A B P} {Q : Post A} {i} (m : MaybeAST A) (f : A → MaybeAST B)
+      → predTrans (m >>= f) P i
+      → (P nothing → Q nothing)
+      → (∀ x → predTrans (f x) P unit → Q (just x))
+      → Q (runMaybeAST m i)
+  maybeSuffBind{P = P}{Q}{i} m f wp n⊆ j⊆ =
+    MaybebindPost⊆ (λ x → predTrans (f x)) P Q n⊆ j⊆
+      (runMaybeAST m i) (maybeSufficient m _ i wp _ refl)
 
 module MaybeSyntax where
-  open import Dijkstra.AST.Syntax public
+  open import Dijkstra.AST.Branching
+  open ASTExtension
+  open MaybeBase
 
-  bail : ∀ {A} → MaybeAST A
-  bail = ASTop Maybe-bail (λ ())
+  bail : ∀ {A} → AST (BranchOps MaybeOps) A
+  bail =  ASTop (Left Maybe-bail) λ ()
 
-private
+open MaybeAST     public
+open MaybeSyntax  public
+
+module MaybeExample where
+  open MaybeBase
+  open MaybeSyntax
+  open MaybeAST
 
   prog₁ : ∀ {A} → A → MaybeAST A
   prog₁ a =
-    ASTbind (ASTop (Maybe-bail {Void}) (λ ()))
+    ASTbind (ASTop (Left (Maybe-bail {Void})) (λ ()))
             (λ _ → ASTreturn  a)
 
-  module prog₁ where
-    open MaybeSyntax
-    prog₁' : ∀ {A} → A → MaybeAST A
-    prog₁' a = do
-      bail {Void}
-      return a
+  prog₁' : ∀ {A} → A → MaybeAST A
+  prog₁' a = do
+    bail {Void}
+    return a
 
-MaybeTypes : ASTTypes
-ASTTypes.Input  MaybeTypes   = Unit
-ASTTypes.Output MaybeTypes A = Maybe A
-
-open ASTTypes MaybeTypes
-
-MaybeOpSem : ASTOpSem MaybeOps MaybeTypes
-ASTOpSem.runAST MaybeOpSem (ASTreturn x) _ = just x
-ASTOpSem.runAST MaybeOpSem (ASTbind m f) i
-  with ASTOpSem.runAST MaybeOpSem m i
-...| nothing = nothing
-...| just x  = ASTOpSem.runAST MaybeOpSem (f x) i
-ASTOpSem.runAST MaybeOpSem (ASTop Maybe-bail f) i = nothing
-
-runMaybeAST = ASTOpSem.runAST MaybeOpSem
-
-MaybebindPost : ∀ {A B} → (A → PredTrans B) → Post B → Post A
-MaybebindPost _ P nothing  = P nothing
-MaybebindPost f P (just y) = f y P unit
-
-MaybebindPost⊆
-  : ∀ {A B} (f : A → PredTrans B) (P₁ : Post B) (P₂ : Post A)
-    → (P₁ nothing → P₂ nothing)
-    → (∀ x → f x P₁ unit → P₂ (just x))
-    → MaybebindPost f P₁ ⊆ₒ P₂
-MaybebindPost⊆ f P₁ P₂ n⊆ j⊆ nothing wp = n⊆ wp
-MaybebindPost⊆ f P₁ P₂ n⊆ j⊆ (just x) wp = j⊆ x wp
-
-MaybePT : ASTPredTrans MaybeOps MaybeTypes
-ASTPredTrans.returnPT MaybePT x P i               = P (just x)
--- Note that it is important *not* to pattern match the input as 'unit'.  Even though this is the
--- only constructor for Unit, Agda does not figure out that this case applies to a general Input
--- (because Input is of type Unit), and therefore does not expand this case when encountering
--- bindPT.
-ASTPredTrans.bindPT   MaybePT f i Post x          = ∀ r → r ≡ x → MaybebindPost f Post r
-ASTPredTrans.opPT     MaybePT Maybe-bail f Post i = Post nothing
--- This open is important because, without it, Agda does not know how to interpret bindPT and
--- therefore does not refine the goal sufficiently to enable the old λ ._ refl trick to get to the
--- MaybebindPost goal, for example.
-open ASTPredTrans MaybePT
-
-private
   BailWorks : ∀ {A} -> Post A
   BailWorks o = o ≡ nothing
 
-  bailWorks  : ∀ {A} (a : A) i → ASTPredTrans.predTrans MaybePT (prog₁ a) BailWorks i
+  bailWorks  : ∀ {A} (a : A) i → predTrans (prog₁ a) BailWorks i
   bailWorks  a unit r refl = refl
 
   -- "expanded" version for understanding
-  bailWorks' : ∀ {A} (a : A) i → ASTPredTrans.predTrans MaybePT (prog₁ a) BailWorks i
+  bailWorks' : ∀ {A} (a : A) i → predTrans (prog₁ a) BailWorks i
   bailWorks' a unit maybeVoid maybeVoid≡nothing
                              -- MaybebindPost (λ x P i → P (just a)) BailWorks           maybeVoid
     with maybeVoid | maybeVoid≡nothing
@@ -114,124 +237,10 @@ private
     rewrite n≡nothing        -- MaybebindPost (λ x P i → P (just a)) (λ o → o ≡ nothing) nothing
     = refl
 
-MaybePTMono : ASTPredTransMono MaybePT
-ASTPredTransMono.returnPTMono MaybePTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
-  P₁⊆ₒP₂ _ wp
-
-ASTPredTransMono.bindPTMono₁  MaybePTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ nothing  wp .nothing  refl =
-  P₁⊆ₒP₂ nothing (wp nothing refl)
-ASTPredTransMono.bindPTMono₁  MaybePTMono f monoF unit P₁ P₂ P₁⊆ₒP₂ (just y) wp .(just y) refl =
-  monoF y P₁ P₂ P₁⊆ₒP₂ unit (wp (just y) refl)
-
-ASTPredTransMono.bindPTMono₂  MaybePTMono {B1} {B2} f₁ f₂ f₁⊑f₂ unit P nothing wp .nothing refl =
-  wp nothing refl
-ASTPredTransMono.bindPTMono₂  MaybePTMono f₁ f₂ f₁⊑f₂ unit P (just y) wp .(just y) refl =
-  f₁⊑f₂ y _ unit (wp (just y) refl)
-
-ASTPredTransMono.opPTMono₁    MaybePTMono Maybe-bail f monoF P₁ P₂ P₁⊆ₒP₂ unit wp =
-  P₁⊆ₒP₂ nothing wp
-ASTPredTransMono.opPTMono₂    MaybePTMono Maybe-bail f₁ f₂ f₁⊑f₂ P i wp =
-  wp
-
-maybePTMono      = ASTPredTransMono.predTransMono MaybePTMono
-maybePTMonoBind₂ = ASTPredTransMono.bindPTMono₂   MaybePTMono
-
-MaybeSuf : ASTSufficientPT MaybeOpSem MaybePT
-ASTSufficientPT.returnSuf MaybeSuf x P i wp = wp
-ASTSufficientPT.bindSuf   MaybeSuf {A} {B} m f mSuf fSuf P unit wp
-  with runMaybeAST m unit | inspect (runMaybeAST m) unit
-... |  nothing            | [ eq ] = mSuf _ unit wp nothing (sym eq)
-... |  just y             | [ eq ] = let wp' = mSuf _ unit wp (just y) (sym eq)
-                                      in fSuf y P unit wp'
-ASTSufficientPT.opSuf     MaybeSuf Maybe-bail f fSuf P i wp = wp
-
-maybeSufficient = ASTSufficientPT.sufficient MaybeSuf
-
-maybeSuffBind
-  : ∀ {A B P} {Q : Post A} {i} (m : MaybeAST A) (f : A → MaybeAST B)
-    → predTrans (m >>= f) P i
-    → (P nothing → Q nothing)
-    → (∀ x → predTrans (f x) P unit → Q (just x))
-    → Q (runMaybeAST m i)
-maybeSuffBind{P = P}{Q}{i} m f wp n⊆ j⊆ =
-  MaybebindPost⊆ (λ x → predTrans (f x)) P Q n⊆ j⊆
-    (runMaybeAST m i) (maybeSufficient m _ i wp _ refl)
-
--- This property says that predTrans really is the *weakest* precondition for a
--- postcondition to hold after running a MaybeAST.
-Post⇒wp : ∀ {A} → MaybeAST A → Input → Set₁
-Post⇒wp {A} m i =
-  (P : Post A)
-  → P (runMaybeAST m i)
-  → predTrans m P i
-
-predTrans-is-weakest : ∀ {A} → (m : MaybeAST A) → Post⇒wp {A} m unit
-predTrans-is-weakest (ASTreturn _) _ = id
-predTrans-is-weakest (ASTbind m f) _ Pr
-   with predTrans-is-weakest m
-...| rec
-  with runMaybeAST m unit
-... | nothing = rec _ λ where _ refl → Pr
-... | just x  = rec _ λ where r refl → predTrans-is-weakest (f x) _ Pr
-predTrans-is-weakest (ASTop Maybe-bail f) P = id
-
-module MaybeBindProps {A B : Set} {m : MaybeAST A} {f : A → MaybeAST B}
-                      (prog : MaybeAST B)
-                      (prog≡ : prog ≡ ASTbind m f) where
-  justProp : ∀ x
-             → runMaybeAST m unit ≡ just x
-             → runMaybeAST prog unit ≡ runMaybeAST (f x) unit
-  justProp x runm≡justx rewrite prog≡ | runm≡justx = refl
-
-maybePTBindLemma : ∀ {A B : Set} {m : MaybeAST A} {f : A → MaybeAST B} {P : Post B}{i : Input}
-                   → (prog : MaybeAST B)
-                   → prog ≡ ASTbind m f
-                   → (      runMaybeAST m i ≡ nothing → P nothing)
-                   → (∀ x → runMaybeAST m i ≡ just x  → P (runMaybeAST (f x) i))
-                   → predTrans prog P i
-maybePTBindLemma {A} {m = m} {f} {P} {unit} prog refl nothingCase justCase
-   with runMaybeAST m unit | inspect (runMaybeAST m) unit
-... | nothing | [ R ] = predTrans-is-weakest m _ bindPost
-      where
-      bindPost : _
-      bindPost r refl rewrite R = nothingCase refl
-... | just x  | [ R ] = predTrans-is-weakest prog P bindPost
-      where
-      bindPost : _
-      bindPost = subst P (sym (MaybeBindProps.justProp prog refl x R)) (justCase x refl)
-
-maybePTApp
-    : ∀ {A} {P₁ P₂ : Post A} (m : MaybeAST A) i
-      → predTrans m (λ o → P₁ o → P₂ o) i
-      → predTrans m P₁ i
-      → predTrans m P₂ i
-maybePTApp {_} {P₁} {P₂} m unit imp pt1 =
-  predTrans-is-weakest m P₂
-    (ASTSufficientPT.sufficient MaybeSuf m (λ o → P₁ o → P₂ o) unit imp
-      (ASTSufficientPT.sufficient MaybeSuf m P₁ unit pt1))
-
-MaybeExtOps    = BranchOps MaybeOps
-MaybeASTExt    = AST MaybeExtOps
-MaybePTExt     = PredTransExtension.BranchPT MaybePT
-runMaybeASTExt = ASTOpSem.runAST (OpSemExtension.BranchOpSem MaybeOpSem)
-MaybePTMonoExt = PredTransExtensionMono.BranchPTMono MaybePTMono
-MaybeSufExt    = SufficientExtension.BranchSuf MaybePTMono MaybeSuf
-
-module MaybeBranchingSyntax where
-
-  bail : ∀ {A} → AST MaybeExtOps A
-  bail =  ASTop (Left Maybe-bail) λ ()
-
-  instance
-    Monad-Maybe-AST : Monad (AST MaybeExtOps)
-    Monad.return Monad-Maybe-AST = ASTreturn
-    Monad._>>=_  Monad-Maybe-AST = ASTbind
-
-private
   -- an easy example using sufficient
   bailWorksSuf  : ∀ {A : Set} (a : A) i → (runMaybeAST (prog₁ a) i ≡ nothing)
   bailWorksSuf a i =
-    ASTSufficientPT.sufficient MaybeSuf (prog₁ a) BailWorks unit (bailWorks a unit)
+    sufficient (prog₁ a) BailWorks unit (bailWorks a unit)
 
   -- alternate version, showing that it's trivial in this case
   bailWorksSuf' : ∀ {A : Set} (a : A) i → (runMaybeAST (prog₁ a) i ≡ nothing)

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -142,6 +142,7 @@ module MaybeAST where
      with predTrans-is-weakest (f (Level.lift mb))
   ...| rec = λ x → (λ where   refl → rec Pr x) , (λ where j refl → rec Pr x)
 
+  -- TODO: do versions for Either and RWS; generically?
   maybePTApp
       : ∀ {A} {P₁ P₂ : Post A} (m : MaybeAST A) i
         → predTrans m (λ o → P₁ o → P₂ o) i
@@ -186,7 +187,6 @@ module MaybeAST where
 
   maybeSufficient = ASTSufficientPT.sufficient Suf
 
-  -- TODO: make these apply to MaybeExt, use in Partiality
   maybeSuffBind
     : ∀ {A B P} {Q : Post A} {i} (m : MaybeAST A) (f : A → MaybeAST B)
       → predTrans (m >>= f) P i

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -45,7 +45,7 @@ module MaybeBase where
   ...| just x  = ASTOpSem.runAST MaybeOpSem (f x) i
   ASTOpSem.runAST MaybeOpSem (ASTop Maybe-bail f) i = nothing
 
-  runMaybe = ASTOpSem.runAST MaybeOpSem
+  runMaybeBase = ASTOpSem.runAST MaybeOpSem
 
   MaybebindPost : ∀ {A B} → (A → PredTrans B) → Post B → Post A
   MaybebindPost _ P nothing  = P nothing
@@ -97,10 +97,10 @@ module MaybeBase where
   MaybeSuf : ASTSufficientPT MaybeOpSem MaybePT
   ASTSufficientPT.returnSuf MaybeSuf x P i wp = wp
   ASTSufficientPT.bindSuf   MaybeSuf {A} {B} m f mSuf fSuf P unit wp
-    with runMaybe m unit | inspect (runMaybe m) unit
-  ... |  nothing         | [ eq ] = mSuf _ unit wp nothing (sym eq)
-  ... |  just y          | [ eq ] = let wp' = mSuf _ unit wp (just y) (sym eq)
-                                     in fSuf y P unit wp'
+    with runMaybeBase m unit | inspect (runMaybeBase m) unit
+  ... |  nothing             | [ eq ] = mSuf _ unit wp nothing (sym eq)
+  ... |  just y              | [ eq ] = let wp' = mSuf _ unit wp (just y) (sym eq)
+                                         in fSuf y P unit wp'
   ASTSufficientPT.opSuf     MaybeSuf Maybe-bail f fSuf P i wp = wp
 
 module MaybeAST where
@@ -110,7 +110,7 @@ module MaybeAST where
   open import Dijkstra.AST.Branching
   open ConditionalExtensions MaybePT MaybeOpSem MaybePTMono MaybeSuf public
 
-  MaybeAST = ExtAST
+  MaybeAST    = ExtAST
 
   runMaybeAST = runAST
 
@@ -133,13 +133,13 @@ module MaybeAST where
   predTrans-is-weakest (ASTop (Left Maybe-bail) f)    Pr = id
   predTrans-is-weakest (ASTop (Right (BCif b)) f) Pr
      with predTrans-is-weakest (f (Level.lift b))
-  ...| rec = λ x → (λ where refl → rec Pr x) , (λ where refl → rec Pr x)
+  ...| rec = λ x → (λ where   refl → rec Pr x) , (λ where   refl → rec Pr x)
   predTrans-is-weakest (ASTop (Right (BCeither b)) f) Pr
      with predTrans-is-weakest (f (Level.lift b))
   ...| rec = λ x → (λ where r refl → rec Pr x) , (λ where r refl → rec Pr x)
   predTrans-is-weakest (ASTop (Right (BCmaybe mb)) f) Pr
      with predTrans-is-weakest (f (Level.lift mb))
-  ...| rec = λ x → (λ where refl → rec Pr x) , λ where j refl → rec Pr x
+  ...| rec = λ x → (λ where   refl → rec Pr x) , (λ where j refl → rec Pr x)
 
   maybePTApp
       : ∀ {A} {P₁ P₂ : Post A} (m : MaybeAST A) i

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -18,207 +18,259 @@ import      Level.Literals as Level using (#_)
 open import Relation.Binary.PropositionalEquality
   hiding ([_])
 
-data RWSCmd (A : Set) : Set₁ where
-  RWSgets   : (g : St → A)                 → RWSCmd A
-  RWSputs   : (p : St → St) → (A ≡ Unit)   → RWSCmd A
-  RWSask    : (A ≡ Ev)                     → RWSCmd A
-  RWSlocal  : (l : Ev → Ev)                → RWSCmd A
-  RWStell   : (out : List Wr) → (A ≡ Unit) → RWSCmd A
-  RWSlisten : {A' : Set} → (A ≡ (A' × List Wr)) → RWSCmd A
-  RWSpass   :                                RWSCmd A
+module RWSBase where
+
+  data RWSCmd (A : Set) : Set₁ where
+    RWSgets   : (g : St → A)                 → RWSCmd A
+    RWSputs   : (p : St → St) → (A ≡ Unit)   → RWSCmd A
+    RWSask    : (A ≡ Ev)                     → RWSCmd A
+    RWSlocal  : (l : Ev → Ev)                → RWSCmd A
+    RWStell   : (out : List Wr) → (A ≡ Unit) → RWSCmd A
+    RWSlisten : {A' : Set} → (A ≡ (A' × List Wr)) → RWSCmd A
+    RWSpass   :                                RWSCmd A
 
 
-RWSSubArg : {A : Set} (c : RWSCmd A) → Set₁
-RWSSubArg (RWSgets g)          = Level.Lift _ Void
-RWSSubArg (RWSputs p refl)     = Level.Lift _ Void
-RWSSubArg (RWSask refl)        = Level.Lift _ Void
-RWSSubArg (RWSlocal l)         = Level.Lift _ Unit
-RWSSubArg (RWStell out refl)   = Level.Lift _ Void
-RWSSubArg (RWSlisten{A'} refl) = Level.Lift _ Unit
-RWSSubArg  RWSpass             = Level.Lift _ Unit
+  RWSSubArg : {A : Set} (c : RWSCmd A) → Set₁
+  RWSSubArg (RWSgets g)          = Level.Lift _ Void
+  RWSSubArg (RWSputs p refl)     = Level.Lift _ Void
+  RWSSubArg (RWSask refl)        = Level.Lift _ Void
+  RWSSubArg (RWSlocal l)         = Level.Lift _ Unit
+  RWSSubArg (RWStell out refl)   = Level.Lift _ Void
+  RWSSubArg (RWSlisten{A'} refl) = Level.Lift _ Unit
+  RWSSubArg  RWSpass             = Level.Lift _ Unit
 
-RWSSubRet : {A : Set} {c : RWSCmd A} (r : RWSSubArg c) → Set
-RWSSubRet{_} {RWSgets g} _ = Void
-RWSSubRet{_} {RWSputs p x} _ = Void
-RWSSubRet{_} {RWSask x} _ = Void
-RWSSubRet{A} {RWSlocal l} _ = A
-RWSSubRet{_} {RWStell out x} _ = Void
-RWSSubRet {.(_ × List Wr)} {RWSlisten{A'} refl} _ = A'
-RWSSubRet{A} {RWSpass} _ = A × (List Wr → List Wr)
+  RWSSubRet : {A : Set} {c : RWSCmd A} (r : RWSSubArg c) → Set
+  RWSSubRet{_} {RWSgets g} _ = Void
+  RWSSubRet{_} {RWSputs p x} _ = Void
+  RWSSubRet{_} {RWSask x} _ = Void
+  RWSSubRet{A} {RWSlocal l} _ = A
+  RWSSubRet{_} {RWStell out x} _ = Void
+  RWSSubRet {.(_ × List Wr)} {RWSlisten{A'} refl} _ = A'
+  RWSSubRet{A} {RWSpass} _ = A × (List Wr → List Wr)
 
-RWSOps : ASTOps
-ASTOps.Cmd RWSOps     = RWSCmd
-ASTOps.SubArg RWSOps  = RWSSubArg
-ASTOps.SubRet RWSOps  = RWSSubRet
+  RWSOps : ASTOps
+  ASTOps.Cmd RWSOps     = RWSCmd
+  ASTOps.SubArg RWSOps  = RWSSubArg
+  ASTOps.SubRet RWSOps  = RWSSubRet
 
-RWS = AST RWSOps
+  RWSBaseAST = AST RWSOps
 
-module RWSSyntax where
-  open import Dijkstra.AST.Syntax public
+  RWSTypes : ASTTypes
+  ASTTypes.Input  RWSTypes    = Ev × St
+  ASTTypes.Output RWSTypes A  = A × St × List Wr
 
-  gets : ∀ {A} → (St → A) → RWS A
-  gets f = ASTop (RWSgets f) λ ()
+  open ASTTypes RWSTypes
 
-  puts : (St → St) → RWS Unit
-  puts f = ASTop (RWSputs f refl) (λ ())
+  RWSOpSem : ASTOpSem RWSOps RWSTypes
+  ASTOpSem.runAST RWSOpSem (ASTreturn x) (ev , st) = x , st , []
+  ASTOpSem.runAST RWSOpSem (ASTbind m f) (ev , st₀) =
+    let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem m (ev , st₀)
+        (x₂ , st₂ , outs₂) = ASTOpSem.runAST RWSOpSem (f x₁) (ev , st₁)
+    in (x₂ , st₂ , outs₁ ++ outs₂)
+  ASTOpSem.runAST RWSOpSem (ASTop (RWSgets g) f) (ev , st) =
+    g st , st , []
+  ASTOpSem.runAST RWSOpSem (ASTop (RWSputs p refl) f) (ev , st) =
+    unit , p st , []
+  ASTOpSem.runAST RWSOpSem (ASTop (RWSask refl) f) (ev , st) =
+    ev , st , []
+  ASTOpSem.runAST RWSOpSem (ASTop (RWSlocal l) f) (ev , st) =
+    ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (l ev , st)
+  ASTOpSem.runAST RWSOpSem (ASTop (RWStell out refl) f) (ev , st) =
+    unit , st , out
+  ASTOpSem.runAST RWSOpSem (ASTop (RWSlisten refl) f) (ev , st) =
+    let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (ev , st)
+    in (x₁ , outs₁) , st₁ , outs₁
+  ASTOpSem.runAST RWSOpSem (ASTop RWSpass f) (ev , st) =
+    let ((x₁ , wf) , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (ev , st)
+    in x₁ , st₁ , wf outs₁
 
-  ask : RWS Ev
-  ask = ASTop (RWSask refl) (λ ())
+  runRWS = ASTOpSem.runAST RWSOpSem
 
-  local : ∀ {A} → (Ev → Ev) → RWS A → RWS A
-  local f m = ASTop (RWSlocal f) (λ where (Level.lift unit) → m)
+  RWSbindPost : (outs : List Wr) {A : Set} → Post A → Post A
+  RWSbindPost outs P (x , st , outs') = P (x , st , outs ++ outs')
 
-  tell : List Wr → RWS Unit
-  tell outs = ASTop (RWStell outs refl) (λ ())
+  RWSpassPost : ∀ {A} → Post A → Post (A × (List Wr → List Wr))
+  RWSpassPost P ((x , f) , s , o) = ∀ o' → o' ≡ f o → P (x , s , o')
 
-  listen : ∀ {A} → RWS A → RWS (A × List Wr)
-  listen m = ASTop (RWSlisten refl) λ where (Level.lift unit) → m
+  RWSlistenPost : ∀ {A} → Post (A × List Wr) → Post A
+  RWSlistenPost P (x , s , o) = P ((x , o) , s , o)
 
-  pass : ∀ {A} → RWS (A × (List Wr → List Wr)) → RWS A
-  pass m = ASTop RWSpass (λ where (Level.lift unit) → m)
+  RWSPT : ASTPredTrans RWSOps RWSTypes
+  ASTPredTrans.returnPT RWSPT x P (ev , st) =
+    P (x , st , [])
+  ASTPredTrans.bindPT RWSPT f (ev , st) P (x , st' , outs) =
+    ∀ r → r ≡ x → f r (RWSbindPost outs P) (ev , st')
+  ASTPredTrans.opPT RWSPT (RWSgets g) f P (ev , st) =
+    P (g st , st , [])
+  ASTPredTrans.opPT RWSPT (RWSputs p refl) f P (ev , st) =
+    P (unit , p st , [])
+  ASTPredTrans.opPT RWSPT (RWSask refl) f P (ev , st) =
+    P (ev , st , [])
+  ASTPredTrans.opPT RWSPT (RWSlocal l) f P (ev , st) =
+    ∀ ev' → ev' ≡ l ev → f (Level.lift unit) P (ev' , st)
+  ASTPredTrans.opPT RWSPT (RWStell out refl) f P (ev , st) =
+    P (unit , st , out)
+  ASTPredTrans.opPT RWSPT (RWSlisten{A'} refl) f P (ev , st) =
+    f (Level.lift unit) (RWSlistenPost P) (ev , st)
+  ASTPredTrans.opPT RWSPT{A} RWSpass f P (ev , st) =
+    f (Level.lift unit) (RWSpassPost P) (ev , st)
 
-private
-  prog₁ : (St → Wr) → RWS Unit
+  ptsRWS = ASTPredTrans.predTrans RWSPT
+
+  RWSPTMono : ASTPredTransMono RWSPT
+  ASTPredTransMono.returnPTMono RWSPTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
+    P₁⊆ₒP₂ _ wp
+  ASTPredTransMono.bindPTMono₁ RWSPTMono f monoF (ev , st) P₁ P₂ P₁⊆ₒP₂ (x₁ , st₁ , outs₁) wp .x₁ refl =
+    monoF _ _ _ (λ o' pf' → P₁⊆ₒP₂ _ pf') (ev , st₁) (wp _ refl)
+  ASTPredTransMono.bindPTMono₂ RWSPTMono f₁ f₂ f₁⊑f₂ (ev , st) P (x₁ , st₁ , outs₁) wp .x₁ refl =
+    f₁⊑f₂ x₁ (RWSbindPost outs₁ P) (ev , st₁) (wp x₁ refl)
+  ASTPredTransMono.opPTMono₁ RWSPTMono (RWSgets g) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+    P₁⊆ₒP₂ _ wp
+  ASTPredTransMono.opPTMono₁ RWSPTMono (RWSputs p refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+    P₁⊆ₒP₂ _ wp
+  ASTPredTransMono.opPTMono₁ RWSPTMono (RWSask refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+    P₁⊆ₒP₂ _ wp
+  ASTPredTransMono.opPTMono₁ RWSPTMono (RWSlocal l) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp .(l ev) refl =
+    monoF (Level.lift unit) _ _ P₁⊆ₒP₂ (l ev , st) (wp _ refl)
+  ASTPredTransMono.opPTMono₁ RWSPTMono (RWStell out refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+    P₁⊆ₒP₂ _ wp
+  ASTPredTransMono.opPTMono₁ RWSPTMono (RWSlisten refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+    monoF (Level.lift unit) _ _ (λ where (x' , st' , o') → P₁⊆ₒP₂ _) (ev , st) wp
+  ASTPredTransMono.opPTMono₁ RWSPTMono RWSpass f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
+    monoF (Level.lift unit) _ _ (λ where ((x' , w') , st' , o') pf₁ ._ refl → P₁⊆ₒP₂ _ (pf₁ _ refl)) (ev , st) wp
+  ASTPredTransMono.opPTMono₂ RWSPTMono (RWSgets g) f₁ f₂ f₁⊑f₂ P i wp =
+    wp
+  ASTPredTransMono.opPTMono₂ RWSPTMono (RWSputs p refl) f₁ f₂ f₁⊑f₂ P i wp =
+    wp
+  ASTPredTransMono.opPTMono₂ RWSPTMono (RWSask refl) f₁ f₂ f₁⊑f₂ P i wp =
+    wp
+  ASTPredTransMono.opPTMono₂ RWSPTMono (RWSlocal l) f₁ f₂ f₁⊑f₂ P (ev , st) wp .(l ev) refl =
+    f₁⊑f₂ (Level.lift unit) _ _ (wp _ refl)
+  ASTPredTransMono.opPTMono₂ RWSPTMono (RWStell out refl) f₁ f₂ f₁⊑f₂ P i wp =
+    wp
+  ASTPredTransMono.opPTMono₂ RWSPTMono (RWSlisten refl) f₁ f₂ f₁⊑f₂ P i wp =
+    f₁⊑f₂ (Level.lift unit) _ _ wp
+  ASTPredTransMono.opPTMono₂ RWSPTMono RWSpass f₁ f₂ f₁⊑f₂ P i wp =
+    f₁⊑f₂ _ _ _ wp
+
+  RWSSuf : ASTSufficientPT RWSOpSem RWSPT
+  ASTSufficientPT.returnSuf RWSSuf x P i wp = wp
+  ASTSufficientPT.bindSuf RWSSuf m f mSuf fSuf P (e , s₀) wp =
+    let (x₁ , s₁ , o₁) = ASTOpSem.runAST RWSOpSem m (e , s₀)
+        wpₘ = mSuf _ (e , s₀) wp _ refl
+    in fSuf x₁ _ (e , s₁) wpₘ
+  ASTSufficientPT.opSuf RWSSuf (RWSgets g) f fSuf P i wp = wp
+  ASTSufficientPT.opSuf RWSSuf (RWSputs p refl) f fSuf P i wp = wp
+  ASTSufficientPT.opSuf RWSSuf (RWSask refl) f fSuf P i wp = wp
+  ASTSufficientPT.opSuf RWSSuf (RWSlocal l) f fSuf P (e , s) wp =
+    fSuf (Level.lift unit) P (l e , s) (wp (l e) refl)
+  ASTSufficientPT.opSuf RWSSuf (RWStell out refl) f fSuf P i wp = wp
+  ASTSufficientPT.opSuf RWSSuf (RWSlisten refl) f fSuf P i wp =
+    fSuf _ _ _ wp
+  ASTSufficientPT.opSuf RWSSuf RWSpass f fSuf P i wp =
+    let ((x₁ , g) , s₁ , o₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) i
+    in fSuf (Level.lift unit) (RWSpassPost P) i wp (g o₁) refl
+
+  sufRWS = ASTSufficientPT.sufficient RWSSuf
+
+module RWSAST where
+  open RWSBase
+  open RWSBase using (RWSbindPost ; RWSpassPost ; RWSlistenPost) public
+  open import Dijkstra.AST.Branching
+  open ConditionalExtensions RWSPT RWSOpSem RWSPTMono RWSSuf public
+
+  RWSAST    = ExtAST
+
+  runRWSAST = runAST
+
+  -- This property says that predTrans really is the *weakest* precondition for a
+  -- postcondition to hold after running a MaybeAST.
+  Post⇒wp : ∀ {A} → RWSAST A → Input → Set₁
+  Post⇒wp {A} m i =
+    (P : Post A)
+    → P (runRWSAST m i)
+    → predTrans m P i
+
+  predTrans-is-weakest : ∀ {A : Set} → (m : RWSAST A) → (inp : Input) → Post⇒wp {A} m inp
+  predTrans-is-weakest     (ASTreturn _) _ _ = id
+  predTrans-is-weakest {A} (ASTbind m f) (ev , st) Pr
+     with predTrans-is-weakest m (ev , st)
+  ...| rec
+     with runRWSAST m (ev , st)
+  ... | rv , st' , wrs = λ x → rec _ λ where r refl → predTrans-is-weakest (f r) (ev , st') _ x
+  predTrans-is-weakest (ASTop (Left (RWSgets g))        f)  _         _ = id
+  predTrans-is-weakest (ASTop (Left (RWSputs p refl))   f) (ev , st) P Pr = Pr
+  predTrans-is-weakest (ASTop (Left (RWSask refl))      f) (ev , st) P Pr = Pr
+  predTrans-is-weakest (ASTop (Left (RWSlocal l))       f) (ev , st) P Pr =
+    λ where ev' refl → predTrans-is-weakest (f (Level.lift unit)) (l ev , st) _ Pr
+  predTrans-is-weakest (ASTop (Left (RWStell out refl)) f) (ev , st) P Pr = Pr
+  predTrans-is-weakest (ASTop (Left (RWSlisten refl))   f) (ev , st) P Pr =
+    predTrans-is-weakest (f (Level.lift unit)) (ev , st) _ Pr
+  predTrans-is-weakest (ASTop (Left RWSpass)            f) (ev , st) P Pr =
+    predTrans-is-weakest (f (Level.lift unit)) (ev , st) _ λ where o' refl → Pr 
+  predTrans-is-weakest (ASTop (Right (BCif b))          f) _ _ Pr
+     with predTrans-is-weakest (f (Level.lift b))
+  ...| rec = (λ where refl → rec _ _ Pr)
+            , λ where refl → rec _ _ Pr
+  predTrans-is-weakest (ASTop (Right (BCeither b))      f) _ _ Pr
+     with predTrans-is-weakest (f (Level.lift b))
+  ...| rec = (λ where l refl → rec _ _ Pr)
+            , λ where r refl → rec _ _ Pr
+  predTrans-is-weakest (ASTop (Right (BCmaybe mb))      f) _ _ Pr
+     with predTrans-is-weakest (f (Level.lift mb))
+  ...| rec = (λ where refl → rec _ _ Pr)
+            , λ where j refl → rec _ _ Pr
+
+  module RWSSyntax where
+    gets : ∀ {A} → (St → A) → RWSAST A
+    gets f = ASTop (Left (RWSgets f)) λ ()
+
+    puts : (St → St) → RWSAST Unit
+    puts f = ASTop (Left (RWSputs f refl)) (λ ())
+
+    ask : RWSAST Ev
+    ask = ASTop (Left (RWSask refl)) (λ ())
+
+    local : ∀ {A} → (Ev → Ev) → RWSAST A → RWSAST A
+    local f m = ASTop (Left (RWSlocal f)) (λ where (Level.lift unit) → m)
+
+    tell : List Wr → RWSAST Unit
+    tell outs = ASTop (Left (RWStell outs refl)) (λ ())
+
+    listen : ∀ {A} → RWSAST A → RWSAST (A × List Wr)
+    listen m = ASTop (Left (RWSlisten refl)) λ where (Level.lift unit) → m
+
+    pass : ∀ {A} → RWSAST (A × (List Wr → List Wr)) → RWSAST A
+    pass m = ASTop (Left RWSpass) (λ where (Level.lift unit) → m)
+
+open RWSAST    public
+open RWSSyntax public
+
+module RWSExample where
+  open RWSAST
+  open RWSBase
+  open RWSSyntax
+
+  prog₁ : (St → Wr) → RWSAST Unit
   prog₁ f =
-    ASTop RWSpass λ _ →
-      ASTbind (ASTop (RWSgets f) λ ()) λ w →
-      ASTbind (ASTop (RWStell (w ∷ []) refl) λ ()) λ _ →
+    ASTop (Left RWSpass) λ _ →
+      ASTbind (ASTop (Left (RWSgets f)) λ ()) λ w →
+      ASTbind (ASTop (Left (RWStell (w ∷ []) refl)) λ ()) λ _ →
       ASTreturn (unit , λ o → o ++ o)
 
-  module prog₁ where
-    open RWSSyntax
-    prog₁' : (St → Wr) → RWS Unit
-    prog₁' f =
-      pass $ do
-        w ← gets f
-        tell (w ∷ [])
-        return (unit , λ o → o ++ o)
+  prog₁' : (St → Wr) → RWSAST Unit
+  prog₁' f =
+    pass $ do
+      w ← gets f
+      tell (w ∷ [])
+      return (unit , λ o → o ++ o)
 
-RWSTypes : ASTTypes
-ASTTypes.Input  RWSTypes    = Ev × St
-ASTTypes.Output RWSTypes A  = A × St × List Wr
-
-open ASTTypes RWSTypes
-
-RWSOpSem : ASTOpSem RWSOps RWSTypes
-ASTOpSem.runAST RWSOpSem (ASTreturn x) (ev , st) = x , st , []
-ASTOpSem.runAST RWSOpSem (ASTbind m f) (ev , st₀) =
-  let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem m (ev , st₀)
-      (x₂ , st₂ , outs₂) = ASTOpSem.runAST RWSOpSem (f x₁) (ev , st₁)
-  in (x₂ , st₂ , outs₁ ++ outs₂)
-ASTOpSem.runAST RWSOpSem (ASTop (RWSgets g) f) (ev , st) =
-  g st , st , []
-ASTOpSem.runAST RWSOpSem (ASTop (RWSputs p refl) f) (ev , st) =
-  unit , p st , []
-ASTOpSem.runAST RWSOpSem (ASTop (RWSask refl) f) (ev , st) =
-  ev , st , []
-ASTOpSem.runAST RWSOpSem (ASTop (RWSlocal l) f) (ev , st) =
-  ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (l ev , st)
-ASTOpSem.runAST RWSOpSem (ASTop (RWStell out refl) f) (ev , st) =
-  unit , st , out
-ASTOpSem.runAST RWSOpSem (ASTop (RWSlisten refl) f) (ev , st) =
-  let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (ev , st)
-  in (x₁ , outs₁) , st₁ , outs₁
-ASTOpSem.runAST RWSOpSem (ASTop RWSpass f) (ev , st) =
-  let ((x₁ , wf) , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (ev , st)
-  in x₁ , st₁ , wf outs₁
-
-runRWS = ASTOpSem.runAST RWSOpSem
-
-RWSbindPost : (outs : List Wr) {A : Set} → Post A → Post A
-RWSbindPost outs P (x , st , outs') = P (x , st , outs ++ outs')
-
-RWSpassPost : ∀ {A} → Post A → Post (A × (List Wr → List Wr))
-RWSpassPost P ((x , f) , s , o) = ∀ o' → o' ≡ f o → P (x , s , o')
-
-RWSlistenPost : ∀ {A} → Post (A × List Wr) → Post A
-RWSlistenPost P (x , s , o) = P ((x , o) , s , o)
-
-RWSPT : ASTPredTrans RWSOps RWSTypes
-ASTPredTrans.returnPT RWSPT x P (ev , st) =
-  P (x , st , [])
-ASTPredTrans.bindPT RWSPT f (ev , st) P (x , st' , outs) =
-  ∀ r → r ≡ x → f r (RWSbindPost outs P) (ev , st')
-ASTPredTrans.opPT RWSPT (RWSgets g) f P (ev , st) =
-  P (g st , st , [])
-ASTPredTrans.opPT RWSPT (RWSputs p refl) f P (ev , st) =
-  P (unit , p st , [])
-ASTPredTrans.opPT RWSPT (RWSask refl) f P (ev , st) =
-  P (ev , st , [])
-ASTPredTrans.opPT RWSPT (RWSlocal l) f P (ev , st) =
-  ∀ ev' → ev' ≡ l ev → f (Level.lift unit) P (ev' , st)
-ASTPredTrans.opPT RWSPT (RWStell out refl) f P (ev , st) =
-  P (unit , st , out)
-ASTPredTrans.opPT RWSPT (RWSlisten{A'} refl) f P (ev , st) =
-  f (Level.lift unit) (RWSlistenPost P) (ev , st)
-ASTPredTrans.opPT RWSPT{A} RWSpass f P (ev , st) =
-  f (Level.lift unit) (RWSpassPost P) (ev , st)
-
-ptsRWS = ASTPredTrans.predTrans RWSPT
-
-private
   TwoOuts : Post Unit
   TwoOuts (_ , _ , o) = length o ≡ 2
 
-  wpTwoOuts : ∀ f i → ASTPredTrans.predTrans RWSPT (prog₁ f) TwoOuts i
+  wpTwoOuts : ∀ f i → predTrans (prog₁ f) TwoOuts i
   wpTwoOuts f (e , s) w w= unit refl .(w ∷ w ∷ []) refl = refl
 
-RWSPTMono : ASTPredTransMono RWSPT
-ASTPredTransMono.returnPTMono RWSPTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
-  P₁⊆ₒP₂ _ wp
-ASTPredTransMono.bindPTMono₁ RWSPTMono f monoF (ev , st) P₁ P₂ P₁⊆ₒP₂ (x₁ , st₁ , outs₁) wp .x₁ refl =
-  monoF _ _ _ (λ o' pf' → P₁⊆ₒP₂ _ pf') (ev , st₁) (wp _ refl)
-ASTPredTransMono.bindPTMono₂ RWSPTMono f₁ f₂ f₁⊑f₂ (ev , st) P (x₁ , st₁ , outs₁) wp .x₁ refl =
-  f₁⊑f₂ x₁ (RWSbindPost outs₁ P) (ev , st₁) (wp x₁ refl)
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWSgets g) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  P₁⊆ₒP₂ _ wp
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWSputs p refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  P₁⊆ₒP₂ _ wp
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWSask refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  P₁⊆ₒP₂ _ wp
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWSlocal l) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp .(l ev) refl =
-  monoF (Level.lift unit) _ _ P₁⊆ₒP₂ (l ev , st) (wp _ refl)
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWStell out refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  P₁⊆ₒP₂ _ wp
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWSlisten refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  monoF (Level.lift unit) _ _ (λ where (x' , st' , o') → P₁⊆ₒP₂ _) (ev , st) wp
-ASTPredTransMono.opPTMono₁ RWSPTMono RWSpass f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  monoF (Level.lift unit) _ _ (λ where ((x' , w') , st' , o') pf₁ ._ refl → P₁⊆ₒP₂ _ (pf₁ _ refl)) (ev , st) wp
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWSgets g) f₁ f₂ f₁⊑f₂ P i wp =
-  wp
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWSputs p refl) f₁ f₂ f₁⊑f₂ P i wp =
-  wp
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWSask refl) f₁ f₂ f₁⊑f₂ P i wp =
-  wp
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWSlocal l) f₁ f₂ f₁⊑f₂ P (ev , st) wp .(l ev) refl =
-  f₁⊑f₂ (Level.lift unit) _ _ (wp _ refl)
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWStell out refl) f₁ f₂ f₁⊑f₂ P i wp =
-  wp
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWSlisten refl) f₁ f₂ f₁⊑f₂ P i wp =
-  f₁⊑f₂ (Level.lift unit) _ _ wp
-ASTPredTransMono.opPTMono₂ RWSPTMono RWSpass f₁ f₂ f₁⊑f₂ P i wp =
-  f₁⊑f₂ _ _ _ wp
+  twoOuts : ∀ f i → TwoOuts (runRWSAST (prog₁ f) i)
+  twoOuts f i = sufficient (prog₁ f) TwoOuts i (wpTwoOuts f i)
 
-RWSSuf : ASTSufficientPT RWSOpSem RWSPT
-ASTSufficientPT.returnSuf RWSSuf x P i wp = wp
-ASTSufficientPT.bindSuf RWSSuf m f mSuf fSuf P (e , s₀) wp =
-  let (x₁ , s₁ , o₁) = ASTOpSem.runAST RWSOpSem m (e , s₀)
-      wpₘ = mSuf _ (e , s₀) wp _ refl
-  in fSuf x₁ _ (e , s₁) wpₘ
-ASTSufficientPT.opSuf RWSSuf (RWSgets g) f fSuf P i wp = wp
-ASTSufficientPT.opSuf RWSSuf (RWSputs p refl) f fSuf P i wp = wp
-ASTSufficientPT.opSuf RWSSuf (RWSask refl) f fSuf P i wp = wp
-ASTSufficientPT.opSuf RWSSuf (RWSlocal l) f fSuf P (e , s) wp =
-  fSuf (Level.lift unit) P (l e , s) (wp (l e) refl)
-ASTSufficientPT.opSuf RWSSuf (RWStell out refl) f fSuf P i wp = wp
-ASTSufficientPT.opSuf RWSSuf (RWSlisten refl) f fSuf P i wp =
-  fSuf _ _ _ wp
-ASTSufficientPT.opSuf RWSSuf RWSpass f fSuf P i wp =
-  let ((x₁ , g) , s₁ , o₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) i
-  in fSuf (Level.lift unit) (RWSpassPost P) i wp (g o₁) refl
-
-sufRWS = ASTSufficientPT.sufficient RWSSuf
-
-private
-  twoOuts : ∀ f i → TwoOuts (runRWS (prog₁ f) i)
-  twoOuts f i = ASTSufficientPT.sufficient RWSSuf (prog₁ f) TwoOuts i (wpTwoOuts f i)

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -115,8 +115,6 @@ module RWSBase where
   ASTPredTrans.opPT RWSPT{A} RWSpass f P (ev , st) =
     f (Level.lift unit) (RWSpassPost P) (ev , st)
 
-  ptsRWS = ASTPredTrans.predTrans RWSPT
-
   RWSPTMono : ASTPredTransMono RWSPT
   ASTPredTransMono.returnPTMono RWSPTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
     P₁⊆ₒP₂ _ wp
@@ -170,8 +168,6 @@ module RWSBase where
   ASTSufficientPT.opSuf RWSSuf RWSpass f fSuf P i wp =
     let ((x₁ , g) , s₁ , o₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) i
     in fSuf (Level.lift unit) (RWSpassPost P) i wp (g o₁) refl
-
-  sufRWS = ASTSufficientPT.sufficient RWSSuf
 
 module RWSAST where
   open RWSBase

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -10,7 +10,6 @@ open import Data.Empty
 open import Data.Fin
 open import Data.Product using (_×_ ; _,_ ; proj₁ ; proj₂)
 open import Data.Unit
-open import Dijkstra.AST.Core
 open import Function
 open import Haskell.Prelude
 import      Level
@@ -19,6 +18,8 @@ open import Relation.Binary.PropositionalEquality
   hiding ([_])
 
 module RWSBase where
+
+  open import Dijkstra.AST.Core
 
   data RWSCmd (A : Set) : Set₁ where
     RWSgets   : (g : St → A)                 → RWSCmd A
@@ -173,6 +174,7 @@ module RWSAST where
   open RWSBase
   open RWSBase using (RWSbindPost ; RWSpassPost ; RWSlistenPost) public
   open import Dijkstra.AST.Branching
+  open import Dijkstra.AST.Core
   open ConditionalExtensions RWSPT RWSOpSem RWSPTMono RWSSuf public
 
   RWSAST    = ExtAST
@@ -244,15 +246,18 @@ open RWSSyntax public
 
 module RWSExample where
   open RWSAST
-  open RWSBase
   open RWSSyntax
 
-  prog₁ : (St → Wr) → RWSAST Unit
-  prog₁ f =
-    ASTop (Left RWSpass) λ _ →
-      ASTbind (ASTop (Left (RWSgets f)) λ ()) λ w →
-      ASTbind (ASTop (Left (RWStell (w ∷ []) refl)) λ ()) λ _ →
-      ASTreturn (unit , λ o → o ++ o)
+  module _ where
+    open import Dijkstra.AST.Core
+    open        RWSBase
+
+    prog₁ : (St → Wr) → RWSAST Unit
+    prog₁ f =
+      ASTop (Left RWSpass) λ _ →
+        ASTbind (ASTop (Left (RWSgets f)) λ ()) λ w →
+        ASTbind (ASTop (Left (RWStell (w ∷ []) refl)) λ ()) λ _ →
+        ASTreturn (unit , λ o → o ++ o)
 
   prog₁' : (St → Wr) → RWSAST Unit
   prog₁' f =

--- a/src/Dijkstra/AST/Syntax.agda
+++ b/src/Dijkstra/AST/Syntax.agda
@@ -9,13 +9,12 @@ module Dijkstra.AST.Syntax where
 open import Data.Empty
 open import Data.Product using (_×_ ; _,_ ; proj₁ ; proj₂)
 open import Data.Unit
-open import Dijkstra.AST.Core
 open import Function
 open import Haskell.Prelude
-import      Level
-import      Level.Literals as Level using (#_)
 
 instance
+  open import Dijkstra.AST.Core
+
   MonadAST : ∀ {OP : ASTOps} → Monad (AST OP)
   Monad.return MonadAST = ASTreturn
   Monad._>>=_  MonadAST = ASTbind

--- a/src/Dijkstra/AST/Syntax.agda
+++ b/src/Dijkstra/AST/Syntax.agda
@@ -18,4 +18,4 @@ import      Level.Literals as Level using (#_)
 instance
   MonadAST : ∀ {OP : ASTOps} → Monad (AST OP)
   Monad.return MonadAST = ASTreturn
-  Monad._>>=_ MonadAST = ASTbind
+  Monad._>>=_  MonadAST = ASTbind

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -14,18 +14,15 @@ open import LibraBFT.ImplShared.Base.Types
 open import LibraBFT.ImplShared.Consensus.Types
 open import LibraBFT.ImplShared.Interface.Output
 open import LibraBFT.ImplShared.Util.Crypto
-open import LibraBFT.ImplShared.Util.Dijkstra.All
+open import LibraBFT.ImplShared.Util.Dijkstra.All hiding (bail)
 open import Level
 open import Optics.All
 open import Util.ByteString
 open import Util.Hash
 import      Util.KVMap                                           as Map
 open import Util.PKCS
-open import Util.Prelude
-open import Dijkstra.AST.Branching
-open import Dijkstra.AST.Core
-import      Dijkstra.AST.Either as EitherAST
-open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; return; Unit; unit; Void)
+open import Util.Prelude hiding (bail ; return)
+open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; Unit; unit; Void)
 
 ------------------------------------------------------------------------------
 open import Data.String                                          using (String)
@@ -50,8 +47,9 @@ module addChild (lb : LinkableBlock) (hv : HashValue) where
   E : VariantFor Either
   E = toEither step₀
 
+  open import Dijkstra.AST.Either
   postulate -- TODO: implement it
-    addChild-AST : EitherAST.EitherAST ErrLog LinkableBlock
+    addChild-AST : EitherAST ErrLog LinkableBlock
 
 abstract
   addChild   = addChild.step₀
@@ -129,18 +127,19 @@ insertBlockE-original block bt = do
              , block))
 
 module insertBlockE-AST (block : ExecutedBlock) (bt : BlockTree) where
-  open import Dijkstra.AST.Either ErrLog
-  open import Dijkstra.AST.Core
-  open EitherAST.EitherSyntax ErrLog renaming (bail to bail-AST; return to return-AST)
+  -- We hide EitherAST so that we can explicitly state the ErrLog type in
+  -- function signatures to maintain consistency with the Haskell code
+  open import Dijkstra.AST.Either ErrLog hiding (EitherAST)
+  open import Dijkstra.AST.Either         using (EitherAST)
   open addChild
 
-  insertBlockE-AST : EitherAST (BlockTree × ExecutedBlock)
+  insertBlockE-AST : EitherAST ErrLog (BlockTree × ExecutedBlock)
   insertBlockE-AST = do
     let blockId = block ^∙ ebId
     case btGetBlock blockId bt of λ where
       (just existingBlock) → pure (bt , existingBlock)
       nothing → case btGetLinkableBlock (block ^∙ ebParentId) bt of λ where
-        nothing → bail-AST fakeErr
+        nothing → bail fakeErr
         (just parentBlock) → (do
           parentBlock' ← addChild-AST parentBlock blockId
           let bt' = bt & btIdToBlock ∙~ Map.kvm-insert-Haskell (block ^∙ ebParentId) parentBlock' (bt ^∙ btIdToBlock)
@@ -263,9 +262,10 @@ abstract
   insertQuorumCertE-Either-≡ = refl
 
 module insertQuorumCertE-AST (qc : QuorumCert) (bt0 : BlockTree) where
-  open EitherAST ErrLog
-  open SyntaxExt renaming (bail to bail-AST; return to return-AST)
-  open BranchingSyntax EitherOps
+  -- We hide EitherAST so that we can explicitly state the ErrLog type in
+  -- function signatures to maintain consistency with the Haskell code
+  open import Dijkstra.AST.Either ErrLog hiding (EitherAST)
+  open import Dijkstra.AST.Either         using (EitherAST)
 
   here' : List String → List String
   here' t = "BlockTree" ∷ "insertQuorumCert" ∷ t
@@ -282,20 +282,20 @@ module insertQuorumCertE-AST (qc : QuorumCert) (bt0 : BlockTree) where
   continue1 : BlockTree → HashValue → ExecutedBlock → List InfoLog → (BlockTree × List InfoLog)
   continue2 : BlockTree → List InfoLog → (BlockTree × List InfoLog)
 
-  insertQuorumCertE-AST : EitherDExt (BlockTree × List InfoLog)
+  insertQuorumCertE-AST : EitherAST ErrLog (BlockTree × List InfoLog)
   insertQuorumCertE-AST =
     case safetyInvariant of λ where
-      (Left  e)    → bail-AST e
-      (Right unit) → maybeSD (btGetBlock blockId bt0) (bail-AST fakeErr) λ block →
-                     maybeSD (bt0 ^∙ btHighestCertifiedBlock) (bail-AST fakeErr) λ hcb →
+      (Left  e)    → bail e
+      (Right unit) → maybeSD (btGetBlock blockId bt0) (bail fakeErr) λ block →
+                     maybeSD (bt0 ^∙ btHighestCertifiedBlock) (bail fakeErr) λ hcb →
                      ifAST ⌊ (block ^∙ ebRound) >? (hcb ^∙ ebRound) ⌋
                      then
                        (let bt   = bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId
                                        & btHighestQuorumCert       ∙~ qc
                             info = (fakeInfo ∷ [])
-                        in return-AST (continue1 bt  blockId block info))
+                        in return (continue1 bt  blockId block info))
                      else
-                          (return-AST (continue1 bt0 blockId block []))
+                          (return (continue1 bt0 blockId block []))
 
   continue1 bt blockId block info =
     continue2 ( bt & btIdToQuorumCert ∙~ lookupOrInsert blockId qc (bt ^∙ btIdToQuorumCert))

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/BlockTree.agda
@@ -22,7 +22,6 @@ open import Util.Hash
 import      Util.KVMap                                           as Map
 open import Util.PKCS
 open import Util.Prelude hiding (bail ; return)
-open import Haskell.Prelude using (_>>_; _>>=_; just; Maybe; nothing; Unit; unit; Void)
 
 ------------------------------------------------------------------------------
 open import Data.String                                          using (String)
@@ -266,6 +265,7 @@ module insertQuorumCertE-AST (qc : QuorumCert) (bt0 : BlockTree) where
   -- function signatures to maintain consistency with the Haskell code
   open import Dijkstra.AST.Either ErrLog hiding (EitherAST)
   open import Dijkstra.AST.Either         using (EitherAST)
+  open import Haskell.Prelude using (return)
 
   here' : List String → List String
   here' t = "BlockTree" ∷ "insertQuorumCert" ∷ t
@@ -281,6 +281,7 @@ module insertQuorumCertE-AST (qc : QuorumCert) (bt0 : BlockTree) where
 
   continue1 : BlockTree → HashValue → ExecutedBlock → List InfoLog → (BlockTree × List InfoLog)
   continue2 : BlockTree → List InfoLog → (BlockTree × List InfoLog)
+
 
   insertQuorumCertE-AST : EitherAST ErrLog (BlockTree × List InfoLog)
   insertQuorumCertE-AST =


### PR DESCRIPTION
The purpose of this PR is to make it easier to use the framework, including branching operations.
Rather than considering the branching operations as "extensions" to an underlying ("base") AST, we
consider the version extended with branching operation as the first target, even for programs that
don't use branching operations (initially).  We then streamline the importing and opening of the
extended AST and associated properties, as demonstrated in the updated examples.  Finally, the
BlockTree definitions and proofs are updated to use the new style, demonstrating the simpler
importing/opening facilitated by this PR.
