### PR TITLE
Enable extending "predTrans is weakest" proof from base to extended version

### DIFF
--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -251,3 +251,25 @@ module ConditionalExtensions
   open ASTPredTransMono PTMono    public
   open BranchingSyntax BaseOps    public
   open import Dijkstra.AST.Syntax public
+
+  Post⇒wp-base : ∀ {A} → AST BaseOps A → Input → Set₁
+  Post⇒wp-base {A} m i =
+        (P : Post A)
+      → P (ASTOpSem.runAST BaseOpSem m i)
+      → ASTPredTrans.predTrans BasePT m P i
+
+  module WithPTIWBase (predTrans-is-weakest-base : ∀ {A i} → (m : AST BaseOps A) → Post⇒wp-base m i) where
+
+    Post⇒wp : ∀ {A} → ExtAST A → Input → Set₁
+    Post⇒wp {A} m i =
+      (P : Post A)
+      → P (runAST m i)
+      → predTrans m P i
+
+    open ASTExtension BaseOps
+    open PredTransExtensionMono BasePTMono
+
+    predTrans-is-weakest : ∀ {A i} → (m : ExtAST A) → Post⇒wp m i
+    predTrans-is-weakest {i = i} m P Pr =
+      extendPT m P i (predTrans-is-weakest-base (unextend m) P Pr)
+

--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -85,78 +85,78 @@ module PredTransExtensionMono
   open PredTransExtension PT
 
   BranchPTMono : ASTPredTransMono BranchPT
-  ASTPredTransMono.returnPTMono BranchPTMono = ASTPredTransMono.returnPTMono M
-  ASTPredTransMono.bindPTMono₁ BranchPTMono = ASTPredTransMono.bindPTMono₁ M
-  ASTPredTransMono.bindPTMono₂ BranchPTMono = ASTPredTransMono.bindPTMono₂ M
-  ASTPredTransMono.opPTMono₁ BranchPTMono (Left x) = ASTPredTransMono.opPTMono₁ M x
-  proj₁ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCif x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) refl =
+  ASTPredTransMono.returnPTMono     BranchPTMono = ASTPredTransMono.returnPTMono M
+  ASTPredTransMono.bindPTMono₁      BranchPTMono = ASTPredTransMono.bindPTMono₁  M
+  ASTPredTransMono.bindPTMono₂      BranchPTMono = ASTPredTransMono.bindPTMono₂  M
+  ASTPredTransMono.opPTMono₁        BranchPTMono (Left x) = ASTPredTransMono.opPTMono₁ M x
+  proj₁ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCif x))     f monoF P₁ P₂ P₁⊆ₒP₂ i wp)   refl =
     monoF (Level.lift true) _ _ P₁⊆ₒP₂ i (proj₁ wp refl)
-  proj₂ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCif x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) refl =
+  proj₂ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCif x))     f monoF P₁ P₂ P₁⊆ₒP₂ i wp)   refl =
     monoF (Level.lift false) _ _ P₁⊆ₒP₂ i (proj₂ wp refl)
   proj₁ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCeither x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) l refl =
     monoF (Level.lift (Left l)) _ _ P₁⊆ₒP₂ i (proj₁ wp _ refl)
   proj₂ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCeither x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) r refl =
     monoF (Level.lift (Right r)) _ _ P₁⊆ₒP₂ i (proj₂ wp _ refl)
-  proj₁ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCmaybe x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) refl =
+  proj₁ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCmaybe x))  f monoF P₁ P₂ P₁⊆ₒP₂ i wp)   refl =
     monoF (Level.lift nothing) _ _ P₁⊆ₒP₂ i (proj₁ wp refl)
-  proj₂ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCmaybe x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) j refl =
+  proj₂ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCmaybe x))  f monoF P₁ P₂ P₁⊆ₒP₂ i wp) j refl =
     monoF (Level.lift (just j)) _ _ P₁⊆ₒP₂ i (proj₂ wp _ refl)
-  ASTPredTransMono.opPTMono₂ BranchPTMono (Left x) = ASTPredTransMono.opPTMono₂ M x
-  proj₁ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCif x)) f₁ f₂ f₁⊑f₂ P i wp) refl =
-    f₁⊑f₂ (Level.lift true) _ i (proj₁ wp refl)
-  proj₂ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCif x)) f₁ f₂ f₁⊑f₂ P i wp) refl =
-    f₁⊑f₂ (Level.lift false) _ i (proj₂ wp refl)
+  ASTPredTransMono.opPTMono₂        BranchPTMono (Left x) = ASTPredTransMono.opPTMono₂ M x
+  proj₁ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCif x))     f₁ f₂ f₁⊑f₂ P i wp)   refl =
+    f₁⊑f₂ (Level.lift true)      _ i (proj₁ wp refl)
+  proj₂ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCif x))     f₁ f₂ f₁⊑f₂ P i wp)   refl =
+    f₁⊑f₂ (Level.lift false)     _ i (proj₂ wp refl)
   proj₁ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCeither x)) f₁ f₂ f₁⊑f₂ P i wp) l refl =
-    f₁⊑f₂ (Level.lift (Left l)) _ i (proj₁ wp _ refl)
+    f₁⊑f₂ (Level.lift (Left l))  _ i (proj₁ wp _ refl)
   proj₂ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCeither x)) f₁ f₂ f₁⊑f₂ P i wp) r refl =
     f₁⊑f₂ (Level.lift (Right r)) _ i (proj₂ wp _ refl)
-  proj₁ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCmaybe x)) f₁ f₂ f₁⊑f₂ P i wp) refl =
-    f₁⊑f₂ (Level.lift nothing) _ i (proj₁ wp refl)
-  proj₂ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCmaybe x)) f₁ f₂ f₁⊑f₂ P i wp) j refl =
-    f₁⊑f₂ (Level.lift (just j)) _ i (proj₂ wp _ refl)
+  proj₁ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCmaybe x))  f₁ f₂ f₁⊑f₂ P i wp)   refl =
+    f₁⊑f₂ (Level.lift nothing)   _ i (proj₁ wp refl)
+  proj₂ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCmaybe x))  f₁ f₂ f₁⊑f₂ P i wp) j refl =
+    f₁⊑f₂ (Level.lift (just j))  _ i (proj₂ wp _ refl)
 
   unextendPT : ∀ {A} (m : AST BranchOps A)
                → ASTPredTrans.predTrans BranchPT m ⊑ ASTPredTrans.predTrans PT (unextend m)
-  unextendPT (ASTreturn x) P i wp = wp
-  unextendPT (ASTbind m f) P i wp =
+  unextendPT (ASTreturn x)                              P i wp = wp
+  unextendPT (ASTbind m f)                              P i wp =
     ASTPredTransMono.predTransMono M (unextend m) _ _ 
       (ASTPredTransMono.bindPTMono₂ M _ _ (unextendPT ∘ f) i P)
       i (unextendPT m _ _ wp)
-  unextendPT (ASTop (Left x) f) P i wp =
+  unextendPT (ASTop (Left x)                     f) P i wp =
     ASTPredTransMono.opPTMono₂ M x _ _ (unextendPT ∘ f) P i wp
-  unextendPT (ASTop (Right (BCif false)) f) P i wp =
+  unextendPT (ASTop (Right (BCif false))         f) P i wp =
     unextendPT (f (Level.lift false)) P i (proj₂ wp refl)
-  unextendPT (ASTop (Right (BCif true)) f) P i wp =
+  unextendPT (ASTop (Right (BCif true))          f) P i wp =
     unextendPT (f (Level.lift true)) _ _ (proj₁ wp refl)
-  unextendPT (ASTop (Right (BCeither (Left x))) f) P i wp =
+  unextendPT (ASTop (Right (BCeither (Left x)))  f) P i wp =
     unextendPT (f (Level.lift (Left x))) _ _ (proj₁ wp _ refl)
   unextendPT (ASTop (Right (BCeither (Right y))) f) P i wp =
     unextendPT (f (Level.lift (Right y))) _ _ (proj₂ wp _ refl)
-  unextendPT (ASTop (Right (BCmaybe nothing)) f) P i wp =
+  unextendPT (ASTop (Right (BCmaybe nothing))    f) P i wp =
     unextendPT (f (Level.lift nothing)) _ _ (proj₁ wp refl)
-  unextendPT (ASTop (Right (BCmaybe (just j))) f) P i wp =
+  unextendPT (ASTop (Right (BCmaybe (just j)))   f) P i wp =
     unextendPT (f (Level.lift (just j))) _ _ (proj₂ wp _ refl)
 
   extendPT : ∀ {A} (m : AST BranchOps A)
              → ASTPredTrans.predTrans PT (unextend m) ⊑ ASTPredTrans.predTrans BranchPT m
-  extendPT (ASTreturn x) P i wp = wp
-  extendPT (ASTbind m f) P i wp =
-    ASTPredTransMono.predTransMono BranchPTMono m _ _
+  extendPT        (ASTreturn x)                  P i wp = wp
+  extendPT        (ASTbind m f)                  P i wp =
+    ASTPredTransMono.predTransMono  BranchPTMono m _ _
       (ASTPredTransMono.bindPTMono₂ BranchPTMono _ _ (extendPT ∘ f) _ _) _
       (extendPT m _ _ wp)
-  extendPT (ASTop (Left x) f) P i wp =
+  extendPT        (ASTop (Left x)             f) P i wp =
     ASTPredTransMono.opPTMono₂ BranchPTMono (Left x) _ _ (extendPT ∘ f) _ _ wp
-  proj₁ (extendPT (ASTop (Right (BCif x)) f) P i wp) refl =
+  proj₁ (extendPT (ASTop (Right (BCif x))     f) P i wp)   refl =
     extendPT (f (Level.lift true)) _ _ wp
-  proj₂ (extendPT (ASTop (Right (BCif x)) f) P i wp) refl =
+  proj₂ (extendPT (ASTop (Right (BCif x))     f) P i wp)   refl =
     extendPT (f (Level.lift false)) _ _ wp
   proj₁ (extendPT (ASTop (Right (BCeither x)) f) P i wp) l refl =
     extendPT (f (Level.lift (Left l))) _ _ wp
   proj₂ (extendPT (ASTop (Right (BCeither x)) f) P i wp) r refl =
     extendPT (f (Level.lift (Right r))) _ _ wp
-  proj₁ (extendPT (ASTop (Right (BCmaybe x)) f) P i wp) refl =
+  proj₁ (extendPT (ASTop (Right (BCmaybe x))  f) P i wp)   refl =
     extendPT (f (Level.lift nothing)) _ _ wp
-  proj₂ (extendPT (ASTop (Right (BCmaybe x)) f) P i wp) j refl =
+  proj₂ (extendPT (ASTop (Right (BCmaybe x))  f) P i wp) j refl =
     extendPT (f (Level.lift (just j))) _ _ wp
 
 module SufficientExtension

--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -252,11 +252,7 @@ module ConditionalExtensions
   open BranchingSyntax BaseOps    public
   open import Dijkstra.AST.Syntax public
 
-  Post⇒wp-base : ∀ {A} → AST BaseOps A → Input → Set₁
-  Post⇒wp-base {A} m i =
-        (P : Post A)
-      → P (ASTOpSem.runAST BaseOpSem m i)
-      → ASTPredTrans.predTrans BasePT m P i
+  open ASTPTIWeakest BaseOpSem BasePT
 
   module WithPTIWBase (predTrans-is-weakest-base : ∀ {A i} → (m : AST BaseOps A) → Post⇒wp-base m i) where
 
@@ -269,6 +265,9 @@ module ConditionalExtensions
     open ASTExtension BaseOps
     open PredTransExtensionMono BasePTMono
 
+    -- We use unextend to get an equivalent AST without branching operations, use the provided proof
+    -- that predTrans is weakest for the underlying AST, and then use extendPT to extend that
+    -- property to the AST with branching operatiions.
     predTrans-is-weakest : ∀ {A i} → (m : ExtAST A) → Post⇒wp m i
     predTrans-is-weakest {i = i} m P Pr =
       extendPT m P i (predTrans-is-weakest-base (unextend m) P Pr)

--- a/src/Dijkstra/AST/Core.agda
+++ b/src/Dijkstra/AST/Core.agda
@@ -106,7 +106,7 @@ record ASTPredTransMono {OP} {Ty} (PT : ASTPredTrans OP Ty) : Set₂ where
     opPTMono c (predTrans ∘ f) (predTrans ∘ f) (predTransMono ∘ f) (predTransMono ∘ f)
       (λ _ _ _ x → x) _ _ i P₁⊆P₂ p
 
-module ASTPTWeakest
+module ASTPTIWeakest
   {OP : ASTOps} {Ty : ASTTypes}
   (OpSem : ASTOpSem OP Ty) (PT : ASTPredTrans OP Ty) where
   open ASTTypes     Ty

--- a/src/Dijkstra/AST/Core.agda
+++ b/src/Dijkstra/AST/Core.agda
@@ -110,6 +110,19 @@ record ASTPredTransMono {OP : ASTOps} {Ty : ASTTypes} (PT : ASTPredTrans OP Ty) 
   predTransMono (ASTop c f) P₁ P₂ P₁⊆P₂ i wp =
     opPTMono₁ c (predTrans ∘ f) (predTransMono ∘ f) _ _ P₁⊆P₂ i wp
 
+module ASTPTWeakest
+  {OP : ASTOps} {Ty : ASTTypes}
+  (OpSem : ASTOpSem OP Ty) (PT : ASTPredTrans OP Ty) where
+  open ASTTypes     Ty
+  open ASTOpSem     OpSem
+  open ASTPredTrans PT
+
+  Post⇒wp-base : ∀ {A} → AST OP A → Input → Set₁
+  Post⇒wp-base {A} m i =
+    (P : Post A)
+    → P (runAST m i)
+    → predTrans m P i
+
 record ASTSufficientPT
   {OP : ASTOps} {Ty : ASTTypes}
   (OpSem : ASTOpSem OP Ty) (PT : ASTPredTrans OP Ty) : Set₁ where

--- a/src/Dijkstra/AST/Either.agda
+++ b/src/Dijkstra/AST/Either.agda
@@ -62,8 +62,9 @@ module EitherBase where
   ASTPredTrans.bindPT EitherPT {A} {B} f i Post x =
     ∀ r → r ≡ x → EitherbindPost f Post r
   ASTPredTrans.opPT EitherPT (Either-bail a) f Post i = Post (Left a)
-  open ASTPredTrans EitherPT
-  open ASTPTWeakest EitherOpSem EitherPT
+
+  open ASTPredTrans  EitherPT
+  open ASTPTIWeakest EitherOpSem EitherPT
 
   predTrans-is-weakest-base' : ∀ {A} → (m : EitherBaseAST A) → Post⇒wp-base {A} m unit
   predTrans-is-weakest-base' (ASTreturn _) _ = id

--- a/src/Dijkstra/AST/Either.agda
+++ b/src/Dijkstra/AST/Either.agda
@@ -74,7 +74,7 @@ module EitherBase where
     with runEitherBase m unit
   ... | Left  x = rec _ λ where _ refl → Pr
   ... | Right x = rec _ λ where r refl → predTrans-is-weakest-base' (f x) _ Pr
-  predTrans-is-weakest-base' (ASTop (Either-bail e) f) Pr = id
+  predTrans-is-weakest-base' (ASTop (Either-bail _) _) _ = id
 
   predTrans-is-weakest-base : ∀ {A} → {i : Unit} → (m : EitherBaseAST A) → Post⇒wp-base {A} m i
   predTrans-is-weakest-base {A} {unit} m = predTrans-is-weakest-base' m
@@ -82,7 +82,7 @@ module EitherBase where
   ------------------------------------------------------------------------------
   EitherPTMono : ASTPredTransMono EitherPT
 
-  ASTPredTransMono.returnPTMono EitherPTMono                 x                            _  _       P₁⊆ₒP₂ _         wp =
+  ASTPredTransMono.returnPTMono EitherPTMono                 _                            _  _       P₁⊆ₒP₂ _         wp =
     P₁⊆ₒP₂ _ wp
   ASTPredTransMono.bindPTMono   EitherPTMono                 f₁ f₂ mono₁ mono₂ f₁⊑f₂ unit P₁ P₂      P₁⊆ₒP₂ (Left  x) wp .(Left  x) refl =
     P₁⊆ₒP₂ (Left x) (wp (Left x) refl)

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -68,11 +68,12 @@ module MaybeBase where
   -- bindPT.
   ASTPredTrans.bindPT   MaybePT f i Post x          = ∀ r → r ≡ x → MaybebindPost f Post r
   ASTPredTrans.opPT     MaybePT Maybe-bail f Post i = Post nothing
+
   -- This open is important because, without it, Agda does not know how to interpret bindPT and
   -- therefore does not refine the goal sufficiently to enable the old λ ._ refl trick to get to the
   -- MaybebindPost goal, for example.
-  open ASTPredTrans MaybePT
-  open ASTPTWeakest MaybeOpSem MaybePT
+  open ASTPredTrans  MaybePT
+  open ASTPTIWeakest MaybeOpSem MaybePT
 
   predTrans-is-weakest-base' : ∀ {A} → (m : MaybeBaseAST A) → Post⇒wp-base {A} m unit
   predTrans-is-weakest-base' (ASTreturn _) _ = id

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -116,8 +116,8 @@ module RWSBase where
   ASTPredTrans.opPT RWSPT{A} RWSpass f P (ev , st) =
     f (Level.lift unit) (RWSpassPost P) (ev , st)
 
-  open ASTPredTrans RWSPT
-  open ASTPTWeakest RWSOpSem RWSPT
+  open ASTPredTrans  RWSPT
+  open ASTPTIWeakest RWSOpSem RWSPT
 
   predTrans-is-weakest-base : ∀ {ev : Ev}{st : St}{A} → (m : RWSBaseAST A) → Post⇒wp-base {A} m (ev , st)
   predTrans-is-weakest-base           (ASTreturn _) _ = id

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -22,13 +22,13 @@ module RWSBase where
   open import Dijkstra.AST.Core
 
   data RWSCmd (A : Set) : Set₁ where
-    RWSgets   : (g : St → A)                 → RWSCmd A
-    RWSputs   : (p : St → St) → (A ≡ Unit)   → RWSCmd A
-    RWSask    : (A ≡ Ev)                     → RWSCmd A
-    RWSlocal  : (l : Ev → Ev)                → RWSCmd A
-    RWStell   : (out : List Wr) → (A ≡ Unit) → RWSCmd A
+    RWSgets   : (g : St → A)                      → RWSCmd A
+    RWSputs   : (p : St → St) → (A ≡ Unit)        → RWSCmd A
+    RWSask    : (A ≡ Ev)                          → RWSCmd A
+    RWSlocal  : (l : Ev → Ev)                     → RWSCmd A
+    RWStell   : (out : List Wr) → (A ≡ Unit)      → RWSCmd A
     RWSlisten : {A' : Set} → (A ≡ (A' × List Wr)) → RWSCmd A
-    RWSpass   :                                RWSCmd A
+    RWSpass   :                                     RWSCmd A
 
 
   RWSSubArg : {A : Set} (c : RWSCmd A) → Set₁
@@ -41,13 +41,13 @@ module RWSBase where
   RWSSubArg  RWSpass             = Level.Lift _ Unit
 
   RWSSubRet : {A : Set} {c : RWSCmd A} (r : RWSSubArg c) → Set
-  RWSSubRet{_} {RWSgets g} _ = Void
-  RWSSubRet{_} {RWSputs p x} _ = Void
-  RWSSubRet{_} {RWSask x} _ = Void
-  RWSSubRet{A} {RWSlocal l} _ = A
-  RWSSubRet{_} {RWStell out x} _ = Void
+  RWSSubRet {_}              {RWSgets g} _          = Void
+  RWSSubRet {_}              {RWSputs p x} _        = Void
+  RWSSubRet {_}              {RWSask x} _           = Void
+  RWSSubRet {A}              {RWSlocal l} _         = A
+  RWSSubRet {_}              {RWStell out x} _      = Void
   RWSSubRet {.(_ × List Wr)} {RWSlisten{A'} refl} _ = A'
-  RWSSubRet{A} {RWSpass} _ = A × (List Wr → List Wr)
+  RWSSubRet {A}              {RWSpass} _            = A × (List Wr → List Wr)
 
   RWSOps : ASTOps
   ASTOps.Cmd RWSOps     = RWSCmd
@@ -68,20 +68,20 @@ module RWSBase where
     let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem m (ev , st₀)
         (x₂ , st₂ , outs₂) = ASTOpSem.runAST RWSOpSem (f x₁) (ev , st₁)
     in (x₂ , st₂ , outs₁ ++ outs₂)
-  ASTOpSem.runAST RWSOpSem (ASTop (RWSgets g) f) (ev , st) =
+  ASTOpSem.runAST RWSOpSem (ASTop (RWSgets g)        f) (ev , st) =
     g st , st , []
-  ASTOpSem.runAST RWSOpSem (ASTop (RWSputs p refl) f) (ev , st) =
+  ASTOpSem.runAST RWSOpSem (ASTop (RWSputs p refl)   f) (ev , st) =
     unit , p st , []
-  ASTOpSem.runAST RWSOpSem (ASTop (RWSask refl) f) (ev , st) =
+  ASTOpSem.runAST RWSOpSem (ASTop (RWSask refl)      f) (ev , st) =
     ev , st , []
-  ASTOpSem.runAST RWSOpSem (ASTop (RWSlocal l) f) (ev , st) =
+  ASTOpSem.runAST RWSOpSem (ASTop (RWSlocal l)       f) (ev , st) =
     ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (l ev , st)
   ASTOpSem.runAST RWSOpSem (ASTop (RWStell out refl) f) (ev , st) =
     unit , st , out
-  ASTOpSem.runAST RWSOpSem (ASTop (RWSlisten refl) f) (ev , st) =
+  ASTOpSem.runAST RWSOpSem (ASTop (RWSlisten refl)   f) (ev , st) =
     let (x₁ , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (ev , st)
     in (x₁ , outs₁) , st₁ , outs₁
-  ASTOpSem.runAST RWSOpSem (ASTop RWSpass f) (ev , st) =
+  ASTOpSem.runAST RWSOpSem (ASTop RWSpass            f) (ev , st) =
     let ((x₁ , wf) , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (ev , st)
     in x₁ , st₁ , wf outs₁
 

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -85,7 +85,7 @@ module RWSBase where
     let ((x₁ , wf) , st₁ , outs₁) = ASTOpSem.runAST RWSOpSem (f (Level.lift unit)) (ev , st)
     in x₁ , st₁ , wf outs₁
 
-  runRWS = ASTOpSem.runAST RWSOpSem
+  runRWSBase = ASTOpSem.runAST RWSOpSem
 
   RWSbindPost : (outs : List Wr) {A : Set} → Post A → Post A
   RWSbindPost outs P (x , st , outs') = P (x , st , outs ++ outs')
@@ -115,6 +115,27 @@ module RWSBase where
     f (Level.lift unit) (RWSlistenPost P) (ev , st)
   ASTPredTrans.opPT RWSPT{A} RWSpass f P (ev , st) =
     f (Level.lift unit) (RWSpassPost P) (ev , st)
+
+  open ASTPredTrans RWSPT
+  open ASTPTWeakest RWSOpSem RWSPT
+
+  predTrans-is-weakest-base : ∀ {ev : Ev}{st : St}{A} → (m : RWSBaseAST A) → Post⇒wp-base {A} m (ev , st)
+  predTrans-is-weakest-base           (ASTreturn _) _ = id
+  predTrans-is-weakest-base {ev} {st} (ASTbind m f) _ Pr
+     with predTrans-is-weakest-base {ev} {st} m
+  ...| rec
+    with runRWSBase m (ev , st)
+  ... | r , st' , wr = rec _ λ where _ refl → predTrans-is-weakest-base (f r) _ Pr
+  predTrans-is-weakest-base              (ASTop (RWSgets g)                      f) P    = id
+  predTrans-is-weakest-base              (ASTop (RWSputs p refl)                 f) P    = id
+  predTrans-is-weakest-base              (ASTop (RWSask    refl)                 f) P    = id
+  predTrans-is-weakest-base {ev} {st}    (ASTop (RWSlocal l)                     f) P Pr =
+    λ where _ refl → predTrans-is-weakest-base {l ev} {st} (f (Level.lift unit)) _ Pr
+  predTrans-is-weakest-base              (ASTop (RWStell out refl)               f) P    = id
+  predTrans-is-weakest-base {ev} {st}    (ASTop (RWSlisten {A'} refl)            f) P Pr =
+    predTrans-is-weakest-base {ev} {st} {A'} (f (Level.lift unit)) _ Pr
+  predTrans-is-weakest-base {ev} {st} {A} (ASTop RWSpass                         f) P Pr =
+    predTrans-is-weakest-base {ev} {st}      (f (Level.lift unit)) _ λ where _ refl → Pr
 
   RWSPTMono : ASTPredTransMono RWSPT
   ASTPredTransMono.returnPTMono RWSPTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
@@ -175,49 +196,13 @@ module RWSAST where
   open RWSBase using (RWSbindPost ; RWSpassPost ; RWSlistenPost) public
   open import Dijkstra.AST.Branching
   open import Dijkstra.AST.Core
-  open ConditionalExtensions RWSPT RWSOpSem RWSPTMono RWSSuf public
+  open ConditionalExtensions RWSPT RWSOpSem RWSPTMono RWSSuf     public
+  open WithPTIWBase predTrans-is-weakest-base                    public
 
   RWSAST    = ExtAST
 
   runRWSAST = runAST
 
-  -- This property says that predTrans really is the *weakest* precondition for a
-  -- postcondition to hold after running a MaybeAST.
-  Post⇒wp : ∀ {A} → RWSAST A → Input → Set₁
-  Post⇒wp {A} m i =
-    (P : Post A)
-    → P (runRWSAST m i)
-    → predTrans m P i
-
-  predTrans-is-weakest : ∀ {A : Set} → (m : RWSAST A) → (inp : Input) → Post⇒wp {A} m inp
-  predTrans-is-weakest     (ASTreturn _) _ _ = id
-  predTrans-is-weakest {A} (ASTbind m f) (ev , st) Pr
-     with predTrans-is-weakest m (ev , st)
-  ...| rec
-     with runRWSAST m (ev , st)
-  ... | rv , st' , wrs = λ x → rec _ λ where r refl → predTrans-is-weakest (f r) (ev , st') _ x
-  predTrans-is-weakest (ASTop (Left (RWSgets g))        f)  _         _ = id
-  predTrans-is-weakest (ASTop (Left (RWSputs p refl))   f) (ev , st) P Pr = Pr
-  predTrans-is-weakest (ASTop (Left (RWSask refl))      f) (ev , st) P Pr = Pr
-  predTrans-is-weakest (ASTop (Left (RWSlocal l))       f) (ev , st) P Pr =
-    λ where ev' refl → predTrans-is-weakest (f (Level.lift unit)) (l ev , st) _ Pr
-  predTrans-is-weakest (ASTop (Left (RWStell out refl)) f) (ev , st) P Pr = Pr
-  predTrans-is-weakest (ASTop (Left (RWSlisten refl))   f) (ev , st) P Pr =
-    predTrans-is-weakest (f (Level.lift unit)) (ev , st) _ Pr
-  predTrans-is-weakest (ASTop (Left RWSpass)            f) (ev , st) P Pr =
-    predTrans-is-weakest (f (Level.lift unit)) (ev , st) _ λ where o' refl → Pr 
-  predTrans-is-weakest (ASTop (Right (BCif b))          f) _ _ Pr
-     with predTrans-is-weakest (f (Level.lift b))
-  ...| rec = (λ where refl → rec _ _ Pr)
-            , λ where refl → rec _ _ Pr
-  predTrans-is-weakest (ASTop (Right (BCeither b))      f) _ _ Pr
-     with predTrans-is-weakest (f (Level.lift b))
-  ...| rec = (λ where l refl → rec _ _ Pr)
-            , λ where r refl → rec _ _ Pr
-  predTrans-is-weakest (ASTop (Right (BCmaybe mb))      f) _ _ Pr
-     with predTrans-is-weakest (f (Level.lift mb))
-  ...| rec = (λ where refl → rec _ _ Pr)
-            , λ where j refl → rec _ _ Pr
 
   module RWSSyntax where
     gets : ∀ {A} → (St → A) → RWSAST A


### PR DESCRIPTION
The main purpose of this PR is to provide general support for extending a "predTrans is weakest" proof for the base operations to one for the operations extended to support branching.  This eliminates the need to replicate the proofs for branching for each new monad supported.  There is also some formatting/alignment that should be easy to identify as such.