### PR TITLE
 Consolidate monotonicity requirements

### DIFF
--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -38,8 +38,8 @@ module ASTExtension (O : ASTOps) where
   ASTOps.Cmd  BranchOps A = Either (ASTOps.Cmd O A) (BranchCmd A)
   ASTOps.SubArg BranchOps{_} (Left x)   = ASTOps.SubArg O x
   ASTOps.SubArg BranchOps{_} (Right y)  = BranchSubArg y
-  ASTOps.SubRet BranchOps{_} {(Left x)} r  = ASTOps.SubRet O r
-  ASTOps.SubRet BranchOps{_} {(Right y)} r = BranchSubRet r
+  ASTOps.SubRet BranchOps{_} {Left x} r  = ASTOps.SubRet O r
+  ASTOps.SubRet BranchOps{_} {Right y} r = BranchSubRet r
 
   unextend : ∀ {A} → AST BranchOps A → AST O A
   unextend (ASTreturn x)      = ASTreturn x
@@ -107,50 +107,45 @@ module PredTransExtension {O : ASTOps} {T : ASTTypes} (PT : ASTPredTrans O T) wh
 module PredTransExtensionMono
   {O : ASTOps} {T : ASTTypes} {PT : ASTPredTrans O T}
   (M : ASTPredTransMono PT) where
-  open ASTTypes T hiding (M)
+  open ASTTypes T hiding (Exec)
   open ASTExtension O
   open PredTransExtension PT
 
+  module M where
+    open ASTPredTransMono M public
+
   BranchPTMono : ASTPredTransMono BranchPT
-  ASTPredTransMono.returnPTMono BranchPTMono = ASTPredTransMono.returnPTMono M
-  ASTPredTransMono.bindPTMono₁ BranchPTMono = ASTPredTransMono.bindPTMono₁ M
-  ASTPredTransMono.bindPTMono₂ BranchPTMono = ASTPredTransMono.bindPTMono₂ M
-  ASTPredTransMono.opPTMono₁ BranchPTMono (Left x) = ASTPredTransMono.opPTMono₁ M x
-  proj₁ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCif x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) refl =
-    monoF (Level.lift true) _ _ P₁⊆ₒP₂ i (proj₁ wp refl)
-  proj₂ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCif x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) refl =
-    monoF (Level.lift false) _ _ P₁⊆ₒP₂ i (proj₂ wp refl)
-  proj₁ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCeither x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) l refl =
-    monoF (Level.lift (Left l)) _ _ P₁⊆ₒP₂ i (proj₁ wp _ refl)
-  proj₂ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCeither x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) r refl =
-    monoF (Level.lift (Right r)) _ _ P₁⊆ₒP₂ i (proj₂ wp _ refl)
-  proj₁ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCmaybe x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) refl =
-    monoF (Level.lift nothing) _ _ P₁⊆ₒP₂ i (proj₁ wp refl)
-  proj₂ (ASTPredTransMono.opPTMono₁ BranchPTMono (Right (BCmaybe x)) f monoF P₁ P₂ P₁⊆ₒP₂ i wp) j refl =
-    monoF (Level.lift (just j)) _ _ P₁⊆ₒP₂ i (proj₂ wp _ refl)
-  ASTPredTransMono.opPTMono₂ BranchPTMono (Left x) = ASTPredTransMono.opPTMono₂ M x
-  proj₁ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCif x)) f₁ f₂ f₁⊑f₂ P i wp) refl =
-    f₁⊑f₂ (Level.lift true) _ i (proj₁ wp refl)
-  proj₂ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCif x)) f₁ f₂ f₁⊑f₂ P i wp) refl =
-    f₁⊑f₂ (Level.lift false) _ i (proj₂ wp refl)
-  proj₁ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCeither x)) f₁ f₂ f₁⊑f₂ P i wp) l refl =
-    f₁⊑f₂ (Level.lift (Left l)) _ i (proj₁ wp _ refl)
-  proj₂ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCeither x)) f₁ f₂ f₁⊑f₂ P i wp) r refl =
-    f₁⊑f₂ (Level.lift (Right r)) _ i (proj₂ wp _ refl)
-  proj₁ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCmaybe x)) f₁ f₂ f₁⊑f₂ P i wp) refl =
-    f₁⊑f₂ (Level.lift nothing) _ i (proj₁ wp refl)
-  proj₂ (ASTPredTransMono.opPTMono₂ BranchPTMono (Right (BCmaybe x)) f₁ f₂ f₁⊑f₂ P i wp) j refl =
-    f₁⊑f₂ (Level.lift (just j)) _ i (proj₂ wp _ refl)
+  ASTPredTransMono.returnPTMono BranchPTMono = M.returnPTMono
+  ASTPredTransMono.bindPTMono BranchPTMono   = M.bindPTMono
+  ASTPredTransMono.opPTMono BranchPTMono (Left x) = M.opPTMono x
+  proj₁ (ASTPredTransMono.opPTMono BranchPTMono (Right (BCif x)) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) refl =
+    f₁⊑f₂ (Level.lift true) _ i (mono₁ (Level.lift true) _ _ P₁⊆P₂ i (proj₁ p refl))
+  proj₂ (ASTPredTransMono.opPTMono BranchPTMono (Right (BCif x)) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) refl =
+    f₁⊑f₂ (Level.lift false) _ i (mono₁ (Level.lift false) _ _ P₁⊆P₂ i (proj₂ p refl))
+  proj₁ (ASTPredTransMono.opPTMono BranchPTMono (Right (BCeither x)) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) l refl =
+    f₁⊑f₂ (Level.lift (Left l)) _ i (mono₁ (Level.lift (Left l)) _ _ P₁⊆P₂ i (proj₁ p l refl))
+  proj₂ (ASTPredTransMono.opPTMono BranchPTMono (Right (BCeither x)) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) r refl =
+    f₁⊑f₂ (Level.lift (Right r)) _ i (mono₁ (Level.lift (Right r)) _ _ P₁⊆P₂ i (proj₂ p r refl))
+  proj₁ (ASTPredTransMono.opPTMono BranchPTMono (Right (BCmaybe x)) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) refl =
+    f₁⊑f₂ (Level.lift nothing) _ i (mono₁ (Level.lift nothing) _ _ P₁⊆P₂ i (proj₁ p refl))
+  proj₂ (ASTPredTransMono.opPTMono BranchPTMono (Right (BCmaybe x)) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) j refl =
+    f₁⊑f₂ (Level.lift (just j)) _ i (mono₁ (Level.lift (just j)) _ _ P₁⊆P₂ i (proj₂ p j refl))
 
   unextendPT : ∀ {A} (m : AST BranchOps A)
                → ASTPredTrans.predTrans BranchPT m ⊑ ASTPredTrans.predTrans PT (unextend m)
   unextendPT (ASTreturn x) P i wp = wp
   unextendPT (ASTbind m f) P i wp =
     ASTPredTransMono.predTransMono M (unextend m) _ _ 
-      (ASTPredTransMono.bindPTMono₂ M _ _ (unextendPT ∘ f) i P)
+      (M.bindPTMono _ _
+        (ASTPredTransMono.predTransMono BranchPTMono ∘ f) (M.predTransMono ∘ unextend ∘ f)
+        (unextendPT ∘ f)
+        i _ _ (λ _ x → x))
       i (unextendPT m _ _ wp)
   unextendPT (ASTop (Left x) f) P i wp =
-    ASTPredTransMono.opPTMono₂ M x _ _ (unextendPT ∘ f) P i wp
+    M.opPTMono x _ _
+      (ASTPredTransMono.predTransMono BranchPTMono ∘ f)
+      (M.predTransMono ∘ unextend ∘ f)
+      (unextendPT ∘ f) _ _ i (λ _ x → x) wp
   unextendPT (ASTop (Right (BCif false)) f) P i wp =
     unextendPT (f (Level.lift false)) P i (proj₂ wp refl)
   unextendPT (ASTop (Right (BCif true)) f) P i wp =
@@ -169,10 +164,15 @@ module PredTransExtensionMono
   extendPT (ASTreturn x) P i wp = wp
   extendPT (ASTbind m f) P i wp =
     ASTPredTransMono.predTransMono BranchPTMono m _ _
-      (ASTPredTransMono.bindPTMono₂ BranchPTMono _ _ (extendPT ∘ f) _ _) _
+    (ASTPredTransMono.bindPTMono BranchPTMono _ _
+      (M.predTransMono ∘ unextend ∘ f) (ASTPredTransMono.predTransMono BranchPTMono ∘ f) (extendPT ∘ f)
+      i _ _ (λ _ x → x))
+      _
       (extendPT m _ _ wp)
   extendPT (ASTop (Left x) f) P i wp =
-    ASTPredTransMono.opPTMono₂ BranchPTMono (Left x) _ _ (extendPT ∘ f) _ _ wp
+    ASTPredTransMono.opPTMono BranchPTMono (Left x) _ _
+      (M.predTransMono ∘ unextend ∘ f) (ASTPredTransMono.predTransMono BranchPTMono ∘ f) (extendPT ∘ f)
+      _ _ i (λ _ x → x) wp
   proj₁ (extendPT (ASTop (Right (BCif x)) f) P i wp) refl =
     extendPT (f (Level.lift true)) _ _ wp
   proj₂ (extendPT (ASTop (Right (BCif x)) f) P i wp) refl =
@@ -187,9 +187,9 @@ module PredTransExtensionMono
     extendPT (f (Level.lift (just j))) _ _ wp
 
 module SufficientExtension
-  {O : ASTOps} {T : ASTTypes} {OS : ASTOpSem O T} {PT : ASTPredTrans O T}
+  {O} {T} {OS : ASTOpSem O T} {PT : ASTPredTrans O T}
   (M : ASTPredTransMono PT) (S : ASTSufficientPT OS PT) where
-  open ASTTypes T hiding (M)
+  open ASTTypes T
   open ASTExtension O
   open OpSemExtension OS
   open PredTransExtension PT

--- a/src/Dijkstra/AST/Core.agda
+++ b/src/Dijkstra/AST/Core.agda
@@ -35,8 +35,8 @@ record ASTTypes : Set₁ where
     Input  : Set
     Output : (A : Set) → Set
 
-  M : Set → Set
-  M A = (i : Input) → Output A
+  Exec : Set → Set
+  Exec A = (i : Input) → Output A
 
   Pre : Set₁
   Pre = (i : Input) → Set
@@ -63,7 +63,7 @@ record ASTOpSem (OP : ASTOps) (Ty : ASTTypes) : Set₁ where
   constructor mkASTOpSem
   open ASTTypes Ty
   field
-    runAST : ∀ {A} → (m : AST OP A) → M A
+    runAST : ∀ {A} → (m : AST OP A) → Exec A
 
 record ASTPredTrans (OP : ASTOps) (Ty : ASTTypes) : Set₂ where
   constructor mkASTPredTrans
@@ -82,33 +82,29 @@ record ASTPredTrans (OP : ASTOps) (Ty : ASTTypes) : Set₂ where
   predTrans (ASTop c f) P i =
     opPT c (predTrans ∘ f) P i
 
-record ASTPredTransMono {OP : ASTOps} {Ty : ASTTypes} (PT : ASTPredTrans OP Ty) : Set₂ where
+record ASTPredTransMono {OP} {Ty} (PT : ASTPredTrans OP Ty) : Set₂ where
   open ASTTypes Ty
   open ASTPredTrans PT
   field
-    returnPTMono : ∀ {A} → (x : A) → MonoPredTrans (returnPT x)
-    bindPTMono₁  : ∀ {A B} → (f : A → PredTrans B)
-                   → (∀ x → MonoPredTrans (f x))
-                   → ∀ i P₁ P₂ → P₁ ⊆ₒ P₂ → bindPT f i P₁ ⊆ₒ bindPT f i P₂
-    bindPTMono₂  : ∀ {A B} → (f₁ f₂ : A → PredTrans B)
-                   → (f₁⊑f₂ : ∀ x → f₁ x ⊑ f₂ x)
-                   → ∀ i P → bindPT f₁ i  P ⊆ₒ bindPT f₂ i P
-    opPTMono₁    : ∀ {A} (c : Cmd OP A) (f : (r : SubArg OP c) → PredTrans (SubRet OP r))
-                   → (∀ r → MonoPredTrans (f r))
-                   → ∀ P₁ P₂ → P₁ ⊆ₒ P₂ → opPT c f P₁ ⊆ᵢ opPT c f P₂
-    opPTMono₂    : ∀ {A} (c : Cmd OP A) (f₁ f₂ : (r : SubArg OP c) → PredTrans (SubRet OP r))
-                   → (f₁⊑f₂ : ∀ r → f₁ r ⊑ f₂ r)
-                   → opPT c f₁ ⊑ opPT c f₂
+    returnPTMono :  ∀ {A} → (x : A) → MonoPredTrans (returnPT x)
+    bindPTMono :    ∀ {A B} → (f₁ f₂ : A → PredTrans B)
+                    → (∀ x → MonoPredTrans (f₁ x)) → (∀ x → MonoPredTrans (f₂ x)) → (∀ x → f₁ x ⊑ f₂ x)
+                    → ∀ i P₁ P₂ → P₁ ⊆ₒ P₂ → bindPT f₁ i P₁ ⊆ₒ bindPT f₂ i P₂
+    opPTMono :      ∀ {A} (c : Cmd OP A) (f₁ f₂ : (r : SubArg OP c) → PredTrans (SubRet OP r))
+                    → (∀ r → MonoPredTrans (f₁ r)) → (∀ x → MonoPredTrans (f₂ x)) → (∀ r → f₁ r ⊑ f₂ r)
+                    → ∀ P₁ P₂ i → P₁ ⊆ₒ P₂ → opPT c f₁ P₁ i → opPT c f₂ P₂ i
 
-  predTransMono : ∀ {A} (m : AST OP A)
-                  → MonoPredTrans (predTrans m)
-  predTransMono (ASTreturn x) =
-    returnPTMono x
-  predTransMono (ASTbind m f) P₁ P₂ P₁⊆P₂ i x₁ =
-    predTransMono  m _ _
-      (bindPTMono₁ (predTrans ∘ f) (predTransMono ∘ f) i _ _ P₁⊆P₂) i x₁
-  predTransMono (ASTop c f) P₁ P₂ P₁⊆P₂ i wp =
-    opPTMono₁ c (predTrans ∘ f) (predTransMono ∘ f) _ _ P₁⊆P₂ i wp
+  predTransMono : ∀ {A} (m : AST OP A) → MonoPredTrans (predTrans m)
+  predTransMono (ASTreturn x) P₁ P₂ P₁⊆P₂ i p = returnPTMono x _ _ P₁⊆P₂ i p
+  predTransMono (ASTbind m f) P₁ P₂ P₁⊆P₂ i p =
+    predTransMono m _ _
+      (bindPTMono p' p' mono mono (λ _ _ _ x → x) i _ _ P₁⊆P₂) i p
+    where
+    p' = predTrans ∘ f
+    mono = predTransMono ∘ f
+  predTransMono (ASTop c f) P₁ P₂ P₁⊆P₂ i p =
+    opPTMono c (predTrans ∘ f) (predTrans ∘ f) (predTransMono ∘ f) (predTransMono ∘ f)
+      (λ _ _ _ x → x) _ _ i P₁⊆P₂ p
 
 record ASTSufficientPT
   {OP : ASTOps} {Ty : ASTTypes}

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -164,40 +164,20 @@ private
   wpTwoOuts f (e , s) w w= unit refl .(w ∷ w ∷ []) refl = refl
 
 RWSPTMono : ASTPredTransMono RWSPT
-ASTPredTransMono.returnPTMono RWSPTMono x P₁ P₂ P₁⊆ₒP₂ i wp =
-  P₁⊆ₒP₂ _ wp
-ASTPredTransMono.bindPTMono₁ RWSPTMono f monoF (ev , st) P₁ P₂ P₁⊆ₒP₂ (x₁ , st₁ , outs₁) wp .x₁ refl =
-  monoF _ _ _ (λ o' pf' → P₁⊆ₒP₂ _ pf') (ev , st₁) (wp _ refl)
-ASTPredTransMono.bindPTMono₂ RWSPTMono f₁ f₂ f₁⊑f₂ (ev , st) P (x₁ , st₁ , outs₁) wp .x₁ refl =
-  f₁⊑f₂ x₁ (RWSbindPost outs₁ P) (ev , st₁) (wp x₁ refl)
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWSgets g) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  P₁⊆ₒP₂ _ wp
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWSputs p refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  P₁⊆ₒP₂ _ wp
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWSask refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  P₁⊆ₒP₂ _ wp
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWSlocal l) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp .(l ev) refl =
-  monoF (Level.lift unit) _ _ P₁⊆ₒP₂ (l ev , st) (wp _ refl)
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWStell out refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  P₁⊆ₒP₂ _ wp
-ASTPredTransMono.opPTMono₁ RWSPTMono (RWSlisten refl) f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  monoF (Level.lift unit) _ _ (λ where (x' , st' , o') → P₁⊆ₒP₂ _) (ev , st) wp
-ASTPredTransMono.opPTMono₁ RWSPTMono RWSpass f monoF P₁ P₂ P₁⊆ₒP₂ (ev , st) wp =
-  monoF (Level.lift unit) _ _ (λ where ((x' , w') , st' , o') pf₁ ._ refl → P₁⊆ₒP₂ _ (pf₁ _ refl)) (ev , st) wp
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWSgets g) f₁ f₂ f₁⊑f₂ P i wp =
-  wp
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWSputs p refl) f₁ f₂ f₁⊑f₂ P i wp =
-  wp
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWSask refl) f₁ f₂ f₁⊑f₂ P i wp =
-  wp
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWSlocal l) f₁ f₂ f₁⊑f₂ P (ev , st) wp .(l ev) refl =
-  f₁⊑f₂ (Level.lift unit) _ _ (wp _ refl)
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWStell out refl) f₁ f₂ f₁⊑f₂ P i wp =
-  wp
-ASTPredTransMono.opPTMono₂ RWSPTMono (RWSlisten refl) f₁ f₂ f₁⊑f₂ P i wp =
-  f₁⊑f₂ (Level.lift unit) _ _ wp
-ASTPredTransMono.opPTMono₂ RWSPTMono RWSpass f₁ f₂ f₁⊑f₂ P i wp =
-  f₁⊑f₂ _ _ _ wp
+ASTPredTransMono.returnPTMono RWSPTMono x Post₁ Post₂ P₁⊆P₂ i wp =
+  P₁⊆P₂ _ wp
+ASTPredTransMono.bindPTMono RWSPTMono f₁ f₂ mono₁ mono₂ f₁⊑f₂ (ev , st) P₁ P₂ P₁⊆P₂ (x₁ , st₁ , outs₁) wp r refl =
+  f₁⊑f₂ x₁ _ (ev , st₁) (mono₁ x₁ _ _ (λ o' → P₁⊆P₂ _) (ev , st₁) (wp _ refl))
+ASTPredTransMono.opPTMono RWSPTMono (RWSgets g) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ (ev , st) P₁⊆P₂ wp = P₁⊆P₂ _ wp
+ASTPredTransMono.opPTMono RWSPTMono (RWSputs p refl) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ (ev , st) P₁⊆P₂ wp = P₁⊆P₂ _ wp
+ASTPredTransMono.opPTMono RWSPTMono (RWSask refl) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ (ev , st) P₁⊆P₂ wp = P₁⊆P₂ _ wp
+ASTPredTransMono.opPTMono RWSPTMono (RWSlocal l) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ (ev , st) P₁⊆P₂ wp ev' refl =
+  f₁⊑f₂ (Level.lift unit) _ _ (mono₁ (Level.lift unit) _ _ P₁⊆P₂ _ (wp _ refl))
+ASTPredTransMono.opPTMono RWSPTMono (RWStell out refl) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ (ev , st) P₁⊆P₂ wp = P₁⊆P₂ _ wp
+ASTPredTransMono.opPTMono RWSPTMono (RWSlisten refl) f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ (ev , st) P₁⊆P₂ wp =
+  f₁⊑f₂ (Level.lift unit) _ _ (mono₁ (Level.lift unit) _ _ (λ where (x' , st' , o') → P₁⊆P₂ _) _ wp)
+ASTPredTransMono.opPTMono RWSPTMono RWSpass f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ (ev , st) P₁⊆P₂ wp =
+  f₁⊑f₂ (Level.lift unit) _ _ (mono₁ (Level.lift unit) _ _ (λ where ((x' , w') , st' , o') pf₁ _ refl → P₁⊆P₂ _ (pf₁ _ refl)) _ wp)
 
 RWSSuf : ASTSufficientPT RWSOpSem RWSPT
 ASTSufficientPT.returnSuf RWSSuf x P i wp = wp


### PR DESCRIPTION
NOTE: This branch does not compile, as the changes have not been propagated to the AST versions of Either or Maybe. Feel free to mark it as a draft for now.

This PR reduces the number of monotonicity lemmas required from 5 to 3, by merging the two lemmas for bind into one and merging the two for operations into one. The purpose of this is to reduce the burden of proving these properties (and shrink the number of lines needed to list the record `ASTPredTransMono`)