### PR TITLE
Rework paper intro example, simpler and more detail; reorder proof obligations for `maybe` to match arguments to `maybe`

### DIFF
--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -76,8 +76,8 @@ module PredTransExtension {O : ASTOps} {T : ASTTypes} (PT : ASTPredTrans O T) wh
       (∀ l →  e ≡ Left  l → f (Level.lift (Left l))  P i)
     × (∀ r →  e ≡ Right r → f (Level.lift (Right r)) P i)
   opPT     BranchPT (Right (BCmaybe mb)) f P i =
-      (      mb ≡ nothing → f (Level.lift nothing)   P i)
-    × (∀ j → mb ≡ just j  → f (Level.lift (just j))  P i)
+      (∀ j → mb ≡ just j  → f (Level.lift (just j))  P i)
+    × (      mb ≡ nothing → f (Level.lift nothing)   P i)
   open ASTPredTrans BranchPT
 
 module PredTransExtensionMono
@@ -104,10 +104,10 @@ module PredTransExtensionMono
     f₁⊑f₂ (Level.lift (Left l))  _ i (mono₁ (Level.lift (Left l))  _ _ P₁⊆P₂ i (proj₁ p l refl))
   proj₂ (opPTMono BranchPTMono (Right (BCeither x))   f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) r refl =
     f₁⊑f₂ (Level.lift (Right r)) _ i (mono₁ (Level.lift (Right r)) _ _ P₁⊆P₂ i (proj₂ p r refl))
-  proj₁ (opPTMono BranchPTMono (Right (BCmaybe x))    f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p)   refl =
-    f₁⊑f₂ (Level.lift nothing)   _ i (mono₁ (Level.lift nothing)   _ _ P₁⊆P₂ i (proj₁ p refl))
-  proj₂ (opPTMono BranchPTMono (Right (BCmaybe x))    f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) j refl =
-    f₁⊑f₂ (Level.lift (just j))  _ i (mono₁ (Level.lift (just j))  _ _ P₁⊆P₂ i (proj₂ p j refl))
+  proj₁ (opPTMono BranchPTMono (Right (BCmaybe x))    f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) j refl =
+    f₁⊑f₂ (Level.lift (just j))  _ i (mono₁ (Level.lift (just j))  _ _ P₁⊆P₂ i (proj₁ p j refl))
+  proj₂ (opPTMono BranchPTMono (Right (BCmaybe x))    f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p)   refl =
+    f₁⊑f₂ (Level.lift nothing)   _ i (mono₁ (Level.lift nothing)   _ _ P₁⊆P₂ i (proj₂ p refl))
 
   unextendPT : ∀ {A} (m : AST BranchOps A)
                → predTrans BranchPT m ⊑ predTrans PT (unextend m)
@@ -132,10 +132,10 @@ module PredTransExtensionMono
     unextendPT (f (Level.lift (Left x)))  _ _ (proj₁ wp _ refl)
   unextendPT (ASTop (Right (BCeither (Right y))) f) P i wp =
     unextendPT (f (Level.lift (Right y))) _ _ (proj₂ wp _ refl)
-  unextendPT (ASTop (Right (BCmaybe nothing))    f) P i wp =
-    unextendPT (f (Level.lift nothing))   _ _ (proj₁ wp   refl)
   unextendPT (ASTop (Right (BCmaybe (just j)))   f) P i wp =
-    unextendPT (f (Level.lift (just j)))  _ _ (proj₂ wp _ refl)
+    unextendPT (f (Level.lift (just j)))  _ _ (proj₁ wp _ refl)
+  unextendPT (ASTop (Right (BCmaybe nothing))    f) P i wp =
+    unextendPT (f (Level.lift nothing))   _ _ (proj₂ wp   refl)
 
   extendPT : ∀ {A} (m : AST BranchOps A)
              → predTrans PT (unextend m) ⊑ predTrans BranchPT m
@@ -159,10 +159,10 @@ module PredTransExtensionMono
     extendPT (f (Level.lift (Left l)))  _ _ wp
   proj₂ (extendPT (ASTop (Right (BCeither x)) f) P i wp) r refl =
     extendPT (f (Level.lift (Right r))) _ _ wp
-  proj₁ (extendPT (ASTop (Right (BCmaybe x))  f) P i wp)   refl =
-    extendPT (f (Level.lift nothing))   _ _ wp
-  proj₂ (extendPT (ASTop (Right (BCmaybe x))  f) P i wp) j refl =
+  proj₁ (extendPT (ASTop (Right (BCmaybe x))  f) P i wp) j refl =
     extendPT (f (Level.lift (just j)))  _ _ wp
+  proj₂ (extendPT (ASTop (Right (BCmaybe x))  f) P i wp)   refl =
+    extendPT (f (Level.lift nothing))   _ _ wp
 
 module SufficientExtension
   {O} {T} {OS : ASTOpSem O T} {PT : ASTPredTrans O T}
@@ -175,6 +175,9 @@ module SufficientExtension
   open OpSemExtension OS
   open PredTransExtension PT
   open PredTransExtensionMono M
+
+  -- NOTE: to save space in the paper, we list extendPT and unextendPT as if they were here.  They
+  -- are actually in module PredTransExtensionMono, just above.
 
   BranchSuf : ASTSufficientPT BranchOpSem BranchPT
   returnSuf BranchSuf = returnSuf S
@@ -205,10 +208,10 @@ module SufficientExtension
     fSuf (Level.lift (Left x))  _ _ (proj₁ wp _ refl)
   opSuf BranchSuf (Right (BCeither (Right y))) f fSuf P i wp =
     fSuf (Level.lift (Right y)) _ _ (proj₂ wp _ refl)
-  opSuf BranchSuf (Right (BCmaybe nothing))    f fSuf P i wp =
-    fSuf (Level.lift nothing)   _ _ (proj₁ wp   refl)
   opSuf BranchSuf (Right (BCmaybe (just j)))   f fSuf P i wp =
-    fSuf (Level.lift (just j))  _ _ (proj₂ wp _ refl)
+    fSuf (Level.lift (just j))  _ _ (proj₁ wp _ refl)
+  opSuf BranchSuf (Right (BCmaybe nothing))    f fSuf P i wp =
+    fSuf (Level.lift nothing)   _ _ (proj₂ wp   refl)
 
 module BranchingSyntax (BaseOps : ASTOps) where
 

--- a/src/Dijkstra/AST/Examples/PaperIntro.agda
+++ b/src/Dijkstra/AST/Examples/PaperIntro.agda
@@ -106,7 +106,8 @@ progPost g (_ , s) with g s
 
 -}
 
--- See below for step-by-step development and explanation of this proof
+-- Here is an alternative proof, which uses our framework to guide the proof development.
+-- See below for a step-by-step explanation.
 progPostWP : ∀ g i → predTrans (prog g) (ProgPost i) i
 proj₁ (progPostWP g i r x) _ _ _ _ _ refl = refl , refl
 proj₂ (progPostWP _ _ _ _)   _     _ refl = refl , refl

--- a/src/Dijkstra/AST/Examples/PaperIntro.agda
+++ b/src/Dijkstra/AST/Examples/PaperIntro.agda
@@ -119,6 +119,10 @@ proj₂ (progPostWP _ _ _ _)   _     _ refl = refl , refl
   progPostWP : ∀ g i → predTrans (prog g) (ProgPost i) i
   progPostWP g i = {!!}
 
+  -- Note that, in the paper, we pattern match i as (e , s).  In the direct proof above, the
+  -- user has to access s in order to do "with g s".  In the following proof, however, the user
+  -- need refer to s at all, so we don't bother pattern matching on the structure of i here.
+
   -- In the following, each time we take a step, the goal in each hole is much more manageable and
   -- understandable than the unwieldy one shown above for the direct approach.
 

--- a/src/Dijkstra/AST/Examples/PaperIntro.agda
+++ b/src/Dijkstra/AST/Examples/PaperIntro.agda
@@ -17,10 +17,10 @@ open import Relation.Binary.PropositionalEquality
 
 -- The example in the paper
 prog : (St → Maybe Wr) → RWSAST Unit
-prog f = pass inner
+prog g = pass inner
   where inner : RWSAST (Unit × (List Wr → List Wr))
         inner = do
-          m ← gets f
+          m ← gets g
           maybeAST (λ w → do tell (w ∷ [])
                              return (unit , λ _ → []))
                    (return (unit , (λ x → x ++ x)))
@@ -29,19 +29,20 @@ prog f = pass inner
 ProgPost : (Ev × St) → (Unit × St × List Wr) → Set
 ProgPost (_ , s1) (_ , s2 , o) = s1 ≡ s2 × 0 ≡ length o
 
--- Here we prove that, for any f and i, the postcondition holds of the result of running (prog f)
--- on i.  The proof is deceptively simple, as explained after the proof.
-progPost : ∀ f i → ProgPost i (runRWSAST (prog f) i)
-progPost f (_ , s) with f s
+-- Here we prove directly (i.e., *without* using our framework) that, for any f and i, the
+-- postcondition holds of the result of running (prog f) on i.  The proof is deceptively simple, as
+-- explained after the proof.
+progPost : ∀ g i → ProgPost i (runRWSAST (prog g) i)
+progPost g (_ , s) with g s
 ... | nothing = refl , refl
 ... | just _  = refl , refl
 
 {- We start with:
 
-  progPost : ∀ f i → ProgPost i (runRWSAST (prog f) i)
-  progPost f i = ?
+  progPost : ∀ g i → ProgPost i (runRWSAST (prog g) i)
+  progPost g i = ?
 
-  -- The goal, of course, is: ProgPost i (runRWSAST (prog f) i)
+  -- The goal, of course, is: ProgPost i (runRWSAST (prog g) i)
   -- But if we expand this (C-u C-u C-c C-,), we see:
 
   Goal: Data.Product.Σ
@@ -51,7 +52,7 @@ progPost f (_ , s) with f s
           (Dijkstra.AST.Core.ASTOpSem.runAST RWSBase.RWSOpSem
            (Dijkstra.AST.Branching.ASTExtension.unextend RWSBase.RWSOps
             (Dijkstra.AST.Core.AST.ASTop
-             (Right (Dijkstra.AST.Branching.BranchCmd.BCmaybe (f (proj₂ i))))
+             (Right (Dijkstra.AST.Branching.BranchCmd.BCmaybe (g (proj₂ i))))
              (λ { (Level.lift nothing)
                     → Dijkstra.AST.Core.AST.ASTreturn (unit , (λ x → x ++ x))
                 ; (Level.lift (just a))
@@ -69,7 +70,7 @@ progPost f (_ , s) with f s
              (Dijkstra.AST.Core.ASTOpSem.runAST RWSBase.RWSOpSem
               (Dijkstra.AST.Branching.ASTExtension.unextend RWSBase.RWSOps
                (Dijkstra.AST.Core.AST.ASTop
-                (Right (Dijkstra.AST.Branching.BranchCmd.BCmaybe (f (proj₂ i))))
+                (Right (Dijkstra.AST.Branching.BranchCmd.BCmaybe (g (proj₂ i))))
                 (λ { (Level.lift nothing)
                        → Dijkstra.AST.Core.AST.ASTreturn (unit , (λ x₁ → x₁ ++ x₁))
                    ; (Level.lift (just a))
@@ -84,7 +85,7 @@ progPost f (_ , s) with f s
               (Dijkstra.AST.Core.ASTOpSem.runAST RWSBase.RWSOpSem
                (Dijkstra.AST.Branching.ASTExtension.unextend RWSBase.RWSOps
                 (Dijkstra.AST.Core.AST.ASTop
-                 (Right (Dijkstra.AST.Branching.BranchCmd.BCmaybe (f (proj₂ i))))
+                 (Right (Dijkstra.AST.Branching.BranchCmd.BCmaybe (g (proj₂ i))))
                  (λ { (Level.lift nothing)
                         → Dijkstra.AST.Core.AST.ASTreturn (unit , (λ x₁ → x₁ ++ x₁))
                     ; (Level.lift (just a))
@@ -96,7 +97,7 @@ progPost f (_ , s) with f s
                (proj₁ i , proj₂ i))))))
 
   -- This is quite unwieldy, and it's very challenging to look at this and determine that
-  -- we need to do 'with f s' (after refining the input i to (_ , s)), to get the two cases to
+  -- we need to do 'with g s' (after refining the input i to (_ , s)), to get the two cases to
   -- prove.  And this is for a small, relatively simple program that is all in scope, so we have
   -- no need to prove and invoke properties about functions called within the program.
 
@@ -106,60 +107,97 @@ progPost f (_ , s) with f s
 -}
 
 -- See below for step-by-step development and explanation of this proof
-progPostWP : ∀ f i → predTrans (prog f) (ProgPost i) i
-proj₁ (progPostWP _ _ _ refl) _ = λ where          _ refl → refl , refl
-proj₂ (progPostWP _ _ _ refl) j = λ where _ _ refl _ refl → refl , refl
+progPostWP : ∀ g i → predTrans (prog g) (ProgPost i) i
+proj₁ (progPostWP g i r x) _ _ _ _ _ refl = refl , refl
+proj₂ (progPostWP _ _ _ _)   _     _ refl = refl , refl
 
-{-
+{- TUTORIAL: Here we explain step-by-step how the framework facilitates the above proof.
+
   -- We start with:
 
-  progPostWP : ∀ f i → predTrans (prog f) (ProgPost i) i
-  progPostWP f i = {!!}
+  progPostWP : ∀ g i → predTrans (prog g) (ProgPost i) i
+  progPostWP g i = {!!}
 
-  -- In the following, each time we make a step, the goal in each hole is much more manageable and
+  -- In the following, each time we take a step, the goal in each hole is much more manageable and
   -- understandable than the unwieldy one shown above for the direct approach.
 
-  -- C-c C-c in *empty* hole, press enter to split on result
+  -- C-c C-c in the *empty* hole, press enter to split on result
 
-  progPostWP f i r x = {!!}
+  progPostWP g i r x = {!!}
 
-  -- C-c C-c with x in the hole
+  -- r and x are introduced by the bindPT field of RWSPT; r is a return value from the gets call in
+  -- inner, and x is evidence that r is the result of applying function g to the state (second
+  -- component of the input for RWS), so now our goal is reduced to proving that the predicate
+  -- transformer for the continuation with respect to RWSbindPost holds (note that gets produces no
+  -- outputs).
 
-  progPostWP f i .(f (proj₂ i)) refl = {!!}
+  -- C-c C-c in the *empty* hole again, press enter to split on result
 
-  -- C-c C-c in *empty* hole, press enter to split on result
+  proj₁ (progPostWP g i r x) = {!!}
+  proj₂ (progPostWP g i r x) = {!!}
 
-  proj₁ (progPostWP f i .(f (proj₂ i)) refl) = {!!}
-  proj₂ (progPostWP f i .(f (proj₂ i)) refl) = {!!}
+  -- Because the continuation is a maybeAST, the proof goal is determined by opPT ... (Right
+  -- (BCmaybe mb)) ... in Dijkstra.AST.Branching.PredTransExtension.  Therefore, we have two
+  -- obligations, one for the case in which the value returned by gets (which x tells us is the same
+  -- as r) is a just, and one for when it is nothing.
 
   -- C-c C-r in *each* hole
 
-  proj₁ (progPostWP f i .(f (proj₂ i)) refl) = λ        x o' x₁ → {!!}
-  proj₂ (progPostWP f i .(f (proj₂ i)) refl) = λ j x r x₁ o' x₂ → {!!}
+  proj₁ (progPostWP g i r x) j x₁ r₁ x₂ o' x₃ = {!!}
+  proj₂ (progPostWP g i r x)   x₁       o' x₂ = {!!}
 
-  -- x₁ : o' ≡  ([] ++ []) ++ [] ++ [], change to λ where ... refl to rewrite it,
-  -- and similarly for x₂ : o' ≡ []
+  -- For the just case, Agda has introduced j : Wr and evidence x₁ that r is just j, as determined
+  -- by the first conjunct of opPT ... (Right (BCmaybe mb)).  Similarly, for the nothing case,
+  -- Agda has introduced evidence x₁ that r is nothing.
 
-  proj₁ (progPostWP f i .(f (proj₂ i)) refl) = λ where       x  o' refl → {!!}
-  proj₂ (progPostWP f i .(f (proj₂ i)) refl) = λ where j x r x₁ o' refl → {!!}
+  -- For each case, Agda has further unrolled the respective proof obligations.  In the just case,
+  -- we have another bind (tell and then return), so Agda unrolls our proof obligations using bindPT
+  -- RWSPT again, providing a return value r₁ for the tell (which is simply Unit, as tell does not
+  -- return anything interesting) and evidence x₂ that it is the value returned by the tell, which
+  -- is unit.
 
-  C-c C-r in each hole splits each goal into a product
+  -- Finally, prog g calls pass (syntactic sugar for the RWSpass command) with the result of the
+  -- continuation.  Therefore the respective proof goals are further expanded (via opPT ... RWSpass and
+  -- RWSpassPost), introducing a variable o' : List Wr and evidence (x₃ in the just case, x₂ in the
+  -- nothing case) that o' is the result of running the respective branches.  In each case, o' is
+  -- equivalent to [].  In the just case, this is because pass receives a function that deletes all
+  -- the outputs produced, and in the nothing case, no outputs have been produced, so
+  -- doubling the list of outputs still results in an empty list.  Thus, we have x₃ : o' ≡ ([] ++
+  -- []) ++ [] ++ [] in the just case and x₂ : o' ≡ [] for the nothing case.
 
-  proj₁ (progPostWP f i .(f (proj₂ i)) refl) = λ where        x o' refl → {!!} , {!!}
-  proj₂ (progPostWP f i .(f (proj₂ i)) refl) = λ where j x r x₁ o' refl → {!!} , {!!}
+  -- Next, we use C-c C-c again, this time providing x₃ in the just case and x₂ in the nothing case.
 
-  C-c C-r in each hole completes the proof
+  proj₁ (progPostWP g i r x) j x₁ r₁ x₂ .[] refl = {!!}
+  proj₂ (progPostWP g i r x)         x₁ .[] refl = {!!}
 
-  proj₁ (progPostWP f i .(f (proj₂ i)) refl) = λ where        x o' refl → refl , refl
-  proj₂ (progPostWP f i .(f (proj₂ i)) refl) = λ where j x r x₁ o' refl → refl , refl
+  -- Agda has figured out that the output lists are [] in each case.
 
-  -- The version above is the same thing, hiding things that don't need to be
-  -- exposed.
+  -- C-c C-r in each hole splits each goal into a product for the two conjuncts of ProgPost i
+
+  proj₁ (progPostWP g i r x) j x₁ r₁ x₂ .[] refl = {!!} , {!!}
+  proj₂ (progPostWP g i r x)         x₁ .[] refl = {!!} , {!!}
+
+  -- C-c C-r in each hole completes the proof because Agda has sufficient information (that the
+  -- state is unchanged for the first conjunct and that the length of the list of Wrs produced
+  -- is zero) to easily discharge the proof obligations.
+
+  proj₁ (progPostWP g i r x) j x₁ r₁ x₂ .[] refl = refl , refl
+  proj₂ (progPostWP g i r x)         x₁ .[] refl = refl , refl
+
+  -- The final proof:
+
+  proj₂ (progPostWP _ _ _ _) _ _ _ _ _ refl = refl , refl
+  proj₂ (progPostWP _ _ _ _) _       _ refl = refl , refl
+
+  -- is the same thing, hiding things that don't need to be exposed.  We don't need to name or
+  -- pattern match on anything other than the evidence that the list of outputs produced is
+  -- equivalent to the empty list, enabling proof that its length is zero, as required by the second
+  -- conjunct of the postcondition.
 
 -}
 
 -- As we have proved that the precondition determined by predTrans (prog f) (ProgPost i) holds for
 -- all i, we can use sufficiency to prove that the postcondition holds after running the program
 -- for any input
-progPost' : ∀ f i → ProgPost i (runRWSAST (prog f) i)
-progPost' f i = sufficient (prog f) (ProgPost i) i (progPostWP f i) 
+progPost' : ∀ g i → ProgPost i (runRWSAST (prog g) i)
+progPost' g i = sufficient (prog g) (ProgPost i) i (progPostWP g i)

--- a/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
+++ b/src/LibraBFT/Impl/Consensus/BlockStorage/Properties/BlockTree.agda
@@ -290,36 +290,33 @@ module insertQuorumCertE-ASTSpec
       -- here.  To understand why, see the definition of maybeSD, which is in terms of the maybeD
       -- field of the relevant MonadMaybeD instance (EitherDASTExt-MonadMaybeD), which translates to
       -- ASTop (Right (BCmaybe mb)).  The opPT field of BranchPT establishes that we require two
-      -- proofs, one for the nothing case and one for the just case; each receives evidence that mb
-      -- is the relevant case (nothing or just something), and determines the relevant proof
+      -- proofs, one for the just case and one for the nothing case; each receives evidence that mb
+      -- is the relevant case (just something or nothing), and determines the relevant proof
       -- obligation.
-
-      const tt , λ block _ →
-
-      -- Similarly, another use of maybeSD in the code results in automatically introducing two
-      -- proof obligations using C-c C-r
-
-      const tt ,
-
-      -- The "Right" goal in this case is determined by the use of ifAST in the code, which
-      -- translates to ASTop (Right (BCif b)) ... (see BranchingSyntax).  Therefore, in this case,
-      -- the proof obligation is determined in PredTransExtension to have two proof obligations, one
-      -- for the case in which b is true and one for b is false.  Each gets evidence of the value of
-      -- b (not used in this example) and the predicate transformer resulting from passing the value
-      -- of b to the function in the definition of ASTPredTrans.opPT yields the proof obligation.
-      -- The proofs for each case here are more or less copied from the insertQuorumcertESpec proof,
-      -- but because the framework guided us to the goals, we did not need to state their types
-      -- explicitly, which in turn means that we did not need to break the code into explicit steps.
-
-      λ _ _ →
-        (const $ let bt' = bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId
-                               & btHighestQuorumCert       ∙~ qc
-                in ContractOk-trans
-                     (mkContractOk (∈BlockTree-upd-hqc refl refl))
-                     (contract-cont1' block bt' (fakeInfo ∷ [])))
-      , (const $ ContractOk-trans
-                   (mkContractOk (∈Post⇒∈PreOr'-refl _∈BlockTree_ _))
-                   (contract-cont1' block bt0 []))
+      (λ block _ →
+         -- Similarly, another use of maybeSD in the code results in automatically introducing two
+         -- proof obligations using C-c C-r
+         (λ _ _ →
+            -- The goal in this case is determined by the use of ifAST in the code, which translates
+            -- to ASTop (Right (BCif b)) ... (see BranchingSyntax).  Therefore, in this case, the
+            -- proof obligation is determined in PredTransExtension to have two proof obligations,
+            -- one for the case in which b is true and one for b is false.  Each gets evidence of
+            -- the value of b (not used in this example) and the predicate transformer resulting
+            -- from passing the value of b to the function in the definition of ASTPredTrans.opPT
+            -- yields the proof obligation.  The proofs for each case here are more or less copied
+            -- from the insertQuorumcertESpec proof, but because the framework guided us to the
+            -- goals, we did not need to state their types explicitly, which in turn means that we
+            -- did not need to break the code into explicit steps.
+            (const $ let bt' = bt0 & btHighestCertifiedBlockId ∙~ block ^∙ ebId
+                                   & btHighestQuorumCert       ∙~ qc
+                    in ContractOk-trans
+                         (mkContractOk (∈BlockTree-upd-hqc refl refl))
+                         (contract-cont1' block bt' (fakeInfo ∷ [])))
+          , (const $ ContractOk-trans
+                       (mkContractOk (∈Post⇒∈PreOr'-refl _∈BlockTree_ _))
+                       (contract-cont1' block bt0 [])))
+         , (const tt))
+      , const tt
       where
       -- The following proofs are just about pure code, and are copied verbatim from
       -- insertQuorumCertESpec above


### PR DESCRIPTION
The main purpose of this PR is to simplify the steps to generate the proof of the example in the paper, and to present it in  more detail, explaining how the framework generates the proof obligations.

While doing this, I noticed that the proof obligations for `opPT` for `BCmaybe` were in a different order (nothing then just) than `maybe` (just then nothing), so I reversed them and made relevant fixes.  Some will argue these should be two separate pull requests.  They would be right, but I don't want to send a breaking PR, nor spend time to tease them apart.