### PR TITLE
Formatting, comments, naming for consistency with paper. 

### DIFF
--- a/src/Dijkstra/AST/Branching.agda
+++ b/src/Dijkstra/AST/Branching.agda
@@ -27,22 +27,22 @@ module ASTExtension (O : ASTOps) where
   open ASTOps
 
   BranchOps : ASTOps
-  Cmd  BranchOps A = Either (Cmd O A) (BranchCmd A)
-  SubArg BranchOps{_} (Left x)    = SubArg O x
-  SubArg BranchOps{_} (Right y)   = BranchSubArg y
-  SubRet BranchOps{_} {Left x}  r = SubRet O r
-  SubRet BranchOps{_} {Right y} r = BranchSubRet r
+  Cmd    BranchOps A              = Either (Cmd O A) (BranchCmd A)
+  SubArg BranchOps{_} (left x)    = SubArg O x
+  SubArg BranchOps{_} (right y)   = BranchSubArg y
+  SubRet BranchOps{_} {left x}  r = SubRet O r
+  SubRet BranchOps{_} {right y} r = BranchSubRet r
 
   unextend : ∀ {A} → AST BranchOps A → AST O A
   unextend (ASTreturn x)                          = ASTreturn x
   unextend (ASTbind m f)                          = ASTbind (unextend m) (unextend ∘ f)
-  unextend (ASTop (Left c) f)                     = ASTop c (unextend ∘ f)
-  unextend (ASTop (Right (BCif false))         f) = unextend (f (lift false))
-  unextend (ASTop (Right (BCif true))          f) = unextend (f (lift true))
-  unextend (ASTop (Right (BCeither (Left x)))  f) = unextend (f (lift (Left x)))
-  unextend (ASTop (Right (BCeither (Right y))) f) = unextend (f (lift (Right y)))
-  unextend (ASTop (Right (BCmaybe nothing))    f) = unextend (f (lift nothing))
-  unextend (ASTop (Right (BCmaybe (just x)))   f) = unextend (f (lift (just x)))
+  unextend (ASTop (left c) f)                     = ASTop c (unextend ∘ f)
+  unextend (ASTop (right (BCif false))         f) = unextend (f (lift false))
+  unextend (ASTop (right (BCif true))          f) = unextend (f (lift true))
+  unextend (ASTop (right (BCeither (left x)))  f) = unextend (f (lift (left x)))
+  unextend (ASTop (right (BCeither (right y))) f) = unextend (f (lift (right y)))
+  unextend (ASTop (right (BCmaybe nothing))    f) = unextend (f (lift nothing))
+  unextend (ASTop (right (BCmaybe (just x)))   f) = unextend (f (lift (just x)))
 
 module OpSemExtension {O : ASTOps} {T : ASTTypes} (OpSem : ASTOpSem O T) where
   open ASTExtension O
@@ -58,15 +58,14 @@ module PredTransExtension {O : ASTOps} {T : ASTTypes} (PT : ASTPredTrans O T) wh
   BranchPT : ASTPredTrans BranchOps T
   returnPT BranchPT          = returnPT PT
   bindPT   BranchPT          = bindPT   PT
-  opPT     BranchPT (Left x) =
-    opPT PT x
-  opPT     BranchPT (Right (BCif c))     f P i =
+  opPT     BranchPT (left x) = opPT     PT x
+  opPT     BranchPT (right (BCif c))     f P i =
       (       c ≡ true    → f (lift true)      P i)
     × (       c ≡ false   → f (lift false)     P i)
-  opPT     BranchPT (Right (BCeither e)) f P i =
-      (∀ l →  e ≡ Left  l → f (lift (Left l))  P i)
-    × (∀ r →  e ≡ Right r → f (lift (Right r)) P i)
-  opPT     BranchPT (Right (BCmaybe mb)) f P i =
+  opPT     BranchPT (right (BCeither e)) f P i =
+      (∀ l →  e ≡ left  l → f (lift (left l))  P i)
+    × (∀ r →  e ≡ right r → f (lift (right r)) P i)
+  opPT     BranchPT (right (BCmaybe mb)) f P i =
       (∀ j → mb ≡ just j  → f (lift (just j))  P i)
     × (      mb ≡ nothing → f (lift nothing)   P i)
   open ASTPredTrans BranchPT
@@ -86,18 +85,18 @@ module PredTransExtensionMono
   BranchPTMono : ASTPredTransMono BranchPT
   returnPTMono BranchPTMono          = M.returnPTMono
   bindPTMono   BranchPTMono          = M.bindPTMono
-  opPTMono     BranchPTMono (Left x) = M.opPTMono x
-  proj₁ (opPTMono BranchPTMono (Right (BCif x))       f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p)   refl =
+  opPTMono     BranchPTMono (left x) = M.opPTMono x
+  proj₁ (opPTMono BranchPTMono (right (BCif x))       f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p)   refl =
     f₁⊑f₂ (lift true)      _ i (mono₁ (lift true)      _ _ P₁⊆P₂ i (proj₁ p refl))
-  proj₂ (opPTMono BranchPTMono (Right (BCif x))       f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p)   refl =
+  proj₂ (opPTMono BranchPTMono (right (BCif x))       f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p)   refl =
     f₁⊑f₂ (lift false)     _ i (mono₁ (lift false)     _ _ P₁⊆P₂ i (proj₂ p refl))
-  proj₁ (opPTMono BranchPTMono (Right (BCeither x))   f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) l refl =
-    f₁⊑f₂ (lift (Left l))  _ i (mono₁ (lift (Left l))  _ _ P₁⊆P₂ i (proj₁ p l refl))
-  proj₂ (opPTMono BranchPTMono (Right (BCeither x))   f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) r refl =
-    f₁⊑f₂ (lift (Right r)) _ i (mono₁ (lift (Right r)) _ _ P₁⊆P₂ i (proj₂ p r refl))
-  proj₁ (opPTMono BranchPTMono (Right (BCmaybe x))    f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) j refl =
+  proj₁ (opPTMono BranchPTMono (right (BCeither x))   f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) l refl =
+    f₁⊑f₂ (lift (left l))  _ i (mono₁ (lift (left l))  _ _ P₁⊆P₂ i (proj₁ p l refl))
+  proj₂ (opPTMono BranchPTMono (right (BCeither x))   f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) r refl =
+    f₁⊑f₂ (lift (right r)) _ i (mono₁ (lift (right r)) _ _ P₁⊆P₂ i (proj₂ p r refl))
+  proj₁ (opPTMono BranchPTMono (right (BCmaybe x))    f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p) j refl =
     f₁⊑f₂ (lift (just j))  _ i (mono₁ (lift (just j))  _ _ P₁⊆P₂ i (proj₁ p j refl))
-  proj₂ (opPTMono BranchPTMono (Right (BCmaybe x))    f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p)   refl =
+  proj₂ (opPTMono BranchPTMono (right (BCmaybe x))    f₁ f₂ mono₁ mono₂ f₁⊑f₂ P₁ P₂ i P₁⊆P₂ p)   refl =
     f₁⊑f₂ (lift nothing)   _ i (mono₁ (lift nothing)   _ _ P₁⊆P₂ i (proj₂ p refl))
 
   unextendPT : ∀ {A} (m : AST BranchOps A)
@@ -110,22 +109,22 @@ module PredTransExtensionMono
         (unextendPT ∘ f)
         i _ _ (λ _ x → x))
       i (unextendPT m _ _ wp)
-  unextendPT (ASTop (Left x)                     f) P i   wp =
+  unextendPT (ASTop (left x)                     f) P i   wp =
     M.opPTMono x _ _
       (predTransMono BranchPTMono ∘ f)
       (M.predTransMono ∘ unextend ∘ f)
       (unextendPT ∘ f) _ _ i (λ _ x → x) wp
-  unextendPT (ASTop (Right (BCif false))         f) P i   wp =
+  unextendPT (ASTop (right (BCif false))         f) P i   wp =
     unextendPT (f (lift false))     P i (proj₂ wp refl)
-  unextendPT (ASTop (Right (BCif true))          f) P i   wp =
+  unextendPT (ASTop (right (BCif true))          f) P i   wp =
     unextendPT (f (lift true))      _ _ (proj₁ wp refl)
-  unextendPT (ASTop (Right (BCeither (Left x)))  f) P i   wp =
-    unextendPT (f (lift (Left x)))  _ _ (proj₁ wp _ refl)
-  unextendPT (ASTop (Right (BCeither (Right y))) f) P i wp =
-    unextendPT (f (lift (Right y))) _ _ (proj₂ wp _ refl)
-  unextendPT (ASTop (Right (BCmaybe (just j)))   f) P i wp =
+  unextendPT (ASTop (right (BCeither (left x)))  f) P i   wp =
+    unextendPT (f (lift (left x)))  _ _ (proj₁ wp _ refl)
+  unextendPT (ASTop (right (BCeither (right y))) f) P i wp =
+    unextendPT (f (lift (right y))) _ _ (proj₂ wp _ refl)
+  unextendPT (ASTop (right (BCmaybe (just j)))   f) P i wp =
     unextendPT (f (lift (just j)))  _ _ (proj₁ wp _ refl)
-  unextendPT (ASTop (Right (BCmaybe nothing))    f) P i wp =
+  unextendPT (ASTop (right (BCmaybe nothing))    f) P i wp =
     unextendPT (f (lift nothing))   _ _ (proj₂ wp   refl)
 
   extendPT : ∀ {A} (m : AST BranchOps A)
@@ -138,21 +137,21 @@ module PredTransExtensionMono
       i _ _ (λ _ x → x))
       _
       (extendPT m _ _ wp)
-  extendPT (ASTop (Left x) f) P i wp =
-    opPTMono BranchPTMono (Left x) _ _
+  extendPT (ASTop (left x) f) P i wp =
+    opPTMono BranchPTMono (left x) _ _
       (M.predTransMono ∘ unextend ∘ f) (predTransMono BranchPTMono ∘ f) (extendPT ∘ f)
       _ _ i (λ _ x → x) wp
-  proj₁ (extendPT (ASTop (Right (BCif x))     f) P i wp)   refl =
+  proj₁ (extendPT (ASTop (right (BCif x))     f) P i wp)   refl =
     extendPT (f (lift true))      _ _ wp
-  proj₂ (extendPT (ASTop (Right (BCif x))     f) P i wp)   refl =
+  proj₂ (extendPT (ASTop (right (BCif x))     f) P i wp)   refl =
     extendPT (f (lift false))     _ _ wp
-  proj₁ (extendPT (ASTop (Right (BCeither x)) f) P i wp) l refl =
-    extendPT (f (lift (Left l)))  _ _ wp
-  proj₂ (extendPT (ASTop (Right (BCeither x)) f) P i wp) r refl =
-    extendPT (f (lift (Right r))) _ _ wp
-  proj₁ (extendPT (ASTop (Right (BCmaybe x))  f) P i wp) j refl =
+  proj₁ (extendPT (ASTop (right (BCeither x)) f) P i wp) l refl =
+    extendPT (f (lift (left l)))  _ _ wp
+  proj₂ (extendPT (ASTop (right (BCeither x)) f) P i wp) r refl =
+    extendPT (f (lift (right r))) _ _ wp
+  proj₁ (extendPT (ASTop (right (BCmaybe x))  f) P i wp) j refl =
     extendPT (f (lift (just j)))  _ _ wp
-  proj₂ (extendPT (ASTop (Right (BCmaybe x))  f) P i wp)   refl =
+  proj₂ (extendPT (ASTop (right (BCmaybe x))  f) P i wp)   refl =
     extendPT (f (lift nothing))   _ _ wp
 
 module SufficientExtension
@@ -167,7 +166,7 @@ module SufficientExtension
   open PredTransExtension PT
   open PredTransExtensionMono M
 
-  -- NOTE: to save space in the paper, we list extendPT and unextendPT as if they were here.  They
+  -- NOTE: to save space in the paper, we list BranchPTMono, extendPT and unextendPT as if they were here.  They
   -- are actually in module PredTransExtensionMono, just above.
 
   BranchSuf : ASTSufficientPT BranchOpSem BranchPT
@@ -183,25 +182,25 @@ module SufficientExtension
 
     wp' : predTrans PT (ASTbind (unextend m) (unextend ∘ f)) P i
     wp' = unextendPT (ASTbind m f) _ _ wp
-  opSuf BranchSuf (Left x)                     f fSuf P i wp =
+  opSuf BranchSuf (left x)                     f fSuf P i wp =
     opSuf S x (unextend ∘ f) fSuf' _ _ wp'
     where
     fSuf' : ∀ r → Sufficient S _ (unextend (f r))
     fSuf' r P i wp = fSuf r _ _ (extendPT (f r) _ _ wp)
 
     wp' : predTrans PT (ASTop x (unextend ∘ f)) _ _
-    wp' = unextendPT (ASTop (Left x) f) _ _ wp
-  opSuf BranchSuf (Right (BCif false))         f fSuf P i wp =
+    wp' = unextendPT (ASTop (left x) f) _ _ wp
+  opSuf BranchSuf (right (BCif false))         f fSuf P i wp =
     fSuf (lift false)     _ _ (proj₂ wp   refl)
-  opSuf BranchSuf (Right (BCif true))          f fSuf P i wp =
+  opSuf BranchSuf (right (BCif true))          f fSuf P i wp =
     fSuf (lift true)      _ _ (proj₁ wp   refl)
-  opSuf BranchSuf (Right (BCeither (Left x)))  f fSuf P i wp =
-    fSuf (lift (Left x))  _ _ (proj₁ wp _ refl)
-  opSuf BranchSuf (Right (BCeither (Right y))) f fSuf P i wp =
-    fSuf (lift (Right y)) _ _ (proj₂ wp _ refl)
-  opSuf BranchSuf (Right (BCmaybe (just j)))   f fSuf P i wp =
+  opSuf BranchSuf (right (BCeither (left x)))  f fSuf P i wp =
+    fSuf (lift (left x))  _ _ (proj₁ wp _ refl)
+  opSuf BranchSuf (right (BCeither (right y))) f fSuf P i wp =
+    fSuf (lift (right y)) _ _ (proj₂ wp _ refl)
+  opSuf BranchSuf (right (BCmaybe (just j)))   f fSuf P i wp =
     fSuf (lift (just j))  _ _ (proj₁ wp _ refl)
-  opSuf BranchSuf (Right (BCmaybe nothing))    f fSuf P i wp =
+  opSuf BranchSuf (right (BCmaybe nothing))    f fSuf P i wp =
     fSuf (lift nothing)   _ _ (proj₂ wp   refl)
 
 module NecessaryExtension
@@ -235,36 +234,36 @@ module NecessaryExtension
 
        nec : predTrans PT (unextend (ASTbind m f)) P i
        nec = bindNec S (unextend m) (unextend ∘ f) mNec' fxNec P i pre
-  opNec BranchNec {A} (Left x)                     f fNec P i pre =
-    extendPT (ASTop (Left x) f) _ i baseNec
+  opNec BranchNec {A} (left x)                     f fNec P i pre =
+    extendPT (ASTop (left x) f) _ i baseNec
       where
       subNec : (a : SubArg x) (P₁ : Post (SubRet a)) (i₁ : Input)
                → (P₁post : P₁ (runAST (unextend (f a)) i₁))
                → predTrans PT (unextend (f a)) P₁ i₁
       subNec a P₁ i₁ = unextendPT (f a) P₁ i₁ ∘ fNec a P₁ i₁
 
-      baseNec : predTrans PT (unextend (ASTop (Left x) f)) P i
+      baseNec : predTrans PT (unextend (ASTop (left x) f)) P i
       baseNec = opNec S x _ subNec _ i pre
-  proj₁ (opNec BranchNec (Right (BCif      false))    f fNec P i pre) = λ ()
-  proj₂ (opNec BranchNec (Right (BCif      false))    f fNec P i pre) =
+  proj₁ (opNec BranchNec (right (BCif      false))    f fNec P i pre) = λ ()
+  proj₂ (opNec BranchNec (right (BCif      false))    f fNec P i pre) =
     λ _            → fNec (lift false)     _ _ pre
-  proj₁ (opNec BranchNec (Right (BCif      true))     f fNec P i pre) = λ _            → fNec (lift true)      _ _ pre
-  proj₂ (opNec BranchNec (Right (BCif      true))     f fNec P i pre) = λ ()
-  proj₁ (opNec BranchNec (Right (BCeither (Left x)))  f fNec P i pre) = λ where _ refl → fNec (lift (Left x))  _ _ pre
-  proj₂ (opNec BranchNec (Right (BCeither (Left x)))  f fNec P i pre) = λ _ ()
-  proj₁ (opNec BranchNec (Right (BCeither (Right y))) f fNec P i pre) = λ _ ()
-  proj₂ (opNec BranchNec (Right (BCeither (Right y))) f fNec P i pre) = λ where _ refl → fNec (lift (Right y)) _ _ pre
-  proj₁ (opNec BranchNec (Right (BCmaybe  (just j)))  f fNec P i pre) = λ where _ refl → fNec (lift (just j) ) _ _ pre
-  proj₂ (opNec BranchNec (Right (BCmaybe  (just j)))  f fNec P i pre) = λ   ()
-  proj₁ (opNec BranchNec (Right (BCmaybe   nothing))  f fNec P i pre) = λ _ ()
-  proj₂ (opNec BranchNec (Right (BCmaybe   nothing))  f fNec P i pre) = λ _            → fNec (lift nothing)   _ _ pre
+  proj₁ (opNec BranchNec (right (BCif      true))     f fNec P i pre) = λ _            → fNec (lift true)      _ _ pre
+  proj₂ (opNec BranchNec (right (BCif      true))     f fNec P i pre) = λ ()
+  proj₁ (opNec BranchNec (right (BCeither (left x)))  f fNec P i pre) = λ where _ refl → fNec (lift (left x))  _ _ pre
+  proj₂ (opNec BranchNec (right (BCeither (left x)))  f fNec P i pre) = λ _ ()
+  proj₁ (opNec BranchNec (right (BCeither (right y))) f fNec P i pre) = λ _ ()
+  proj₂ (opNec BranchNec (right (BCeither (right y))) f fNec P i pre) = λ where _ refl → fNec (lift (right y)) _ _ pre
+  proj₁ (opNec BranchNec (right (BCmaybe  (just j)))  f fNec P i pre) = λ where _ refl → fNec (lift (just j) ) _ _ pre
+  proj₂ (opNec BranchNec (right (BCmaybe  (just j)))  f fNec P i pre) = λ   ()
+  proj₁ (opNec BranchNec (right (BCmaybe   nothing))  f fNec P i pre) = λ _ ()
+  proj₂ (opNec BranchNec (right (BCmaybe   nothing))  f fNec P i pre) = λ _            → fNec (lift nothing)   _ _ pre
 
 module BranchingSyntax (BaseOps : ASTOps) where
 
   Ops = ASTExtension.BranchOps BaseOps
 
   ifAST_then_else : ∀ {A} → Bool → (t e : AST Ops A) → AST Ops A
-  ifAST b then t else e = ASTop (Right (BCif b))
+  ifAST b then t else e = ASTop (right (BCif b))
                                 λ { (lift true)  → t
                                   ; (lift false) → e
                                   }
@@ -277,7 +276,7 @@ module BranchingSyntax (BaseOps : ASTOps) where
              → AST Ops B
              → Maybe A
              → AST Ops B
-  maybeAST fA B mA = ASTop (Right (BCmaybe mA))
+  maybeAST fA B mA = ASTop (right (BCmaybe mA))
                            λ { (lift nothing)  → B
                              ; (lift (just a)) → fA a
                              }
@@ -295,9 +294,9 @@ module BranchingSyntax (BaseOps : ASTOps) where
               → (B → AST Ops C)
               → Either A B
               → AST Ops C
-  eitherAST fA fB eAB = ASTop (Right (BCeither eAB))
-                              λ { (lift (Left  a)) → fA a
-                                ; (lift (Right b)) → fB b
+  eitherAST fA fB eAB = ASTop (right (BCeither eAB))
+                              λ { (lift (left  a)) → fA a
+                                ; (lift (right b)) → fB b
                                 }
 
   -- Same but with arguments in more "natural" order

--- a/src/Dijkstra/AST/Core.agda
+++ b/src/Dijkstra/AST/Core.agda
@@ -97,7 +97,7 @@ record ASTPredTransMono {OP} {Ty} (PT : ASTPredTrans OP Ty) : Set₂ where
                    → ∀ i P₁ P₂ → P₁ ⊆ₒ P₂ → bindPT f₁ i P₁ ⊆ₒ bindPT f₂ i P₂
     opPTMono     : ∀ {A} (c : Cmd OP A)
                      (f₁ f₂ : (r : SubArg OP c) → PredTrans (SubRet OP r))
-                   → (∀ r → MonoPT (f₁ r)) → (∀ x → MonoPT (f₂ x))
+                   → (∀ r → MonoPT (f₁ r)) → (∀ r → MonoPT (f₂ r))
                    → (∀ r → f₁ r ⊑ f₂ r)
                    → ∀ P₁ P₂ i → P₁ ⊆ₒ P₂ → opPT c f₁ P₁ i → opPT c f₂ P₂ i
 

--- a/src/Dijkstra/AST/Examples/Either/Bind.agda
+++ b/src/Dijkstra/AST/Examples/Either/Bind.agda
@@ -16,8 +16,8 @@ module TwoEitherBindsExample where
       return (n1 ∷ n2 ∷ [])
 
     ProgPost : Unit → Either ⊤ (List ℕ) → Set
-    ProgPost _ (Left  l) =        l ≡ tt
-    ProgPost _ (Right r) = length r ≡ 2
+    ProgPost _ (left  l) =        l ≡ tt
+    ProgPost _ (right r) = length r ≡ 2
 
     progPostWP : predTrans prog (ProgPost unit) unit
     progPostWP = predTransMono prog runPost _ ⊆ₒProgPost unit PT1
@@ -26,10 +26,10 @@ module TwoEitherBindsExample where
       runPost = runEitherAST prog unit ≡_
 
       ⊆ₒProgPost : runPost ⊆ₒ ProgPost unit
-      ⊆ₒProgPost (Left  _) _                                               = refl
-      ⊆ₒProgPost (Right r) Right_n1∷n2∷[]≡Right_r with runEitherAST en1 unit
-      ... | (Right n1)                            with runEitherAST en2 unit
-      ... | (Right n2) rewrite inj₂-injective (sym Right_n1∷n2∷[]≡Right_r) = refl
+      ⊆ₒProgPost (left  _) _                                               = refl
+      ⊆ₒProgPost (right r) Right_n1∷n2∷[]≡Right_r with runEitherAST en1 unit
+      ... | (right n1)                            with runEitherAST en2 unit
+      ... | (right n2) rewrite inj₂-injective (sym Right_n1∷n2∷[]≡Right_r) = refl
 
       PT1 : predTrans prog runPost unit
       PT1 = necessary prog _ unit refl

--- a/src/Dijkstra/AST/Examples/Maybe/Branching.agda
+++ b/src/Dijkstra/AST/Examples/Maybe/Branching.agda
@@ -32,7 +32,7 @@ module Example-if (n : ℕ) where
     open MaybeBase
 
     branchingProg : MaybeAST ℕ
-    branchingProg = ASTop (Right (BCif (toBool (n ≟ℕ 0) )))
+    branchingProg = ASTop (right (BCif (toBool (n ≟ℕ 0) )))
                           (λ { (lift false) → ASTreturn (2 * n)
                              ; (lift true)  → ASTop (Left Maybe-bail) λ () })
 
@@ -53,7 +53,7 @@ module Example-if (n : ℕ) where
     Using C-c C-, (without the C-u prefix), tells us a bit more
     detail about the goal:
 
-      ASTPredTrans.opPT MaybePTExt (Right (BCif ⌊ n ≟ℕ 0 ⌋))
+      ASTPredTrans.opPT MaybePTExt (right (BCif ⌊ n ≟ℕ 0 ⌋))
         (λ x →
            ASTPredTrans.predTrans MaybePTExt
            ((λ { (lift false) → ASTreturn (2 * n)
@@ -81,7 +81,7 @@ module Example-if (n : ℕ) where
     evaluates to the relevant boolean value (true for the first, false for the second).  This is
     because
 
-      ASTPredTrans.opPT BranchPT (Right (BCif c)) f P i
+      ASTPredTrans.opPT BranchPT (right (BCif c)) f P i
 
     requires two proofs, one for when the condition c is true and one for when it's false; each case
     gets evidence that the condition evaluates to the relevant boolean.
@@ -166,15 +166,15 @@ module Example-either (n : ℕ) where
     open import Dijkstra.AST.Maybe public
 
     _monus1 : ℕ → Either Unit ℕ
-    _monus1 0        = Left unit
-    _monus1 (suc n') = Right n'
+    _monus1 0        = left unit
+    _monus1 (suc n') = right n'
 
-    monus1lemma1 : ∀ {n'} → n ≡ n' → ∀ {l} → n' monus1 ≡ Left l → n ≡ 0
+    monus1lemma1 : ∀ {n'} → n ≡ n' → ∀ {l} → n' monus1 ≡ left l → n ≡ 0
     monus1lemma1 {n'} n≡n' _
        with n'
     ...| 0 = n≡n'
 
-    monus1lemma2 : ∀ {nalias} → n ≡ nalias → ∀ {n'} → nalias monus1 ≡ Right n' → n ≡ suc n'
+    monus1lemma2 : ∀ {nalias} → n ≡ nalias → ∀ {n'} → nalias monus1 ≡ right n' → n ≡ suc n'
     monus1lemma2 {nalias} n≡nalias isrgt
        with nalias
     ...| suc x rewrite n≡nalias | inj₂-injective isrgt = refl
@@ -192,12 +192,12 @@ module Example-either (n : ℕ) where
     open        BranchCmd using (BCif ; BCeither)
     open        MaybeBase using (Maybe-bail)
 
-    -- A branching program that bails if n monus1 is Left _
-    -- and returns b if n monus1 is Right b
+    -- A branching program that bails if n monus1 is left _
+    -- and returns b if n monus1 is right b
     branchingProg : MaybeAST ℕ
-    branchingProg = ASTop (Right (BCeither (n monus1)))
-                          λ { (lift (Left  a)) → ASTop (Left Maybe-bail) λ ()
-                            ; (lift (Right b)) → return b
+    branchingProg = ASTop (right (BCeither (n monus1)))
+                          λ { (lift (left  a)) → ASTop (left Maybe-bail) λ ()
+                            ; (lift (right b)) → return b
                             }
 
     branchingProgWP : (i : Input)

--- a/src/Dijkstra/AST/Maybe.agda
+++ b/src/Dijkstra/AST/Maybe.agda
@@ -187,7 +187,7 @@ module MaybeSyntax where
   open MaybeBase
 
   bail : ∀ {A} → AST (BranchOps MaybeOps) A
-  bail =  ASTop (Left Maybe-bail) λ ()
+  bail =  ASTop (left Maybe-bail) λ ()
 
 open MaybeSyntax public
 
@@ -200,7 +200,7 @@ module MaybeExample where
 
     prog₁ : ∀ {A} → A → MaybeAST A
     prog₁ a =
-      ASTbind (ASTop (Left (Maybe-bail {Void})) (λ ()))
+      ASTbind (ASTop (left (Maybe-bail {Void})) (λ ()))
               (λ _ → ASTreturn  a)
 
   -- Now we present an equivalent program using the MaybeSyntax, so we don't need to open MaybeBase,

--- a/src/Dijkstra/AST/Prelude.agda
+++ b/src/Dijkstra/AST/Prelude.agda
@@ -46,5 +46,5 @@ absurd A case x of f = ⊥-elim (f x)
 
 Either : ∀ {a b} → Set a → Set b → Set (a ℓ⊔ b)
 Either A B = A ⊎ B
-pattern Left  x = inj₁ x
-pattern Right x = inj₂ x
+pattern left  x = inj₁ x
+pattern right x = inj₂ x

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -94,24 +94,24 @@ module RWSBase where
 
   open ASTPredTrans
   RWSPT : ASTPredTrans RWSOps RWSTypes
-  returnPT RWSPT x P (ev , st) =
-    P (x , st , [])
-  bindPT   RWSPT f (ev , st) P (x , st' , outs) =
-    ∀ r → r ≡ x → f r (RWSbindPost outs P) (ev , st')
-  opPT     RWSPT (RWSgets g)          f P (ev , st) =
-    P (g st , st , [])
-  opPT     RWSPT (RWSputs p refl)     f P (ev , st) =
-    P (unit , p st , [])
-  opPT     RWSPT (RWSask refl)        f P (ev , st) =
-    P (ev , st , [])
-  opPT     RWSPT (RWSlocal l)         f P (ev , st) =
-    ∀ ev' → ev' ≡ l ev → f (lift unit) P (ev' , st)
-  opPT     RWSPT (RWStell out refl)   f P (ev , st) =
-    P (unit , st , out)
-  opPT     RWSPT (RWSlisten{A'} refl) f P (ev , st) =
-    f (lift unit) (RWSlistenPost P) (ev , st)
-  opPT     RWSPT{A} RWSpass           f P (ev , st) =
-    f (lift unit) (RWSpassPost P) (ev , st)
+  returnPT RWSPT x P (e , s) =
+    P (x , s , [])
+  bindPT   RWSPT f (e , s0) P (x , s1 , outs) =
+    ∀ r → r ≡ x → f r (RWSbindPost outs P) (e , s1)
+  opPT     RWSPT (RWSgets g)          f P (e , s) =
+    P (g s  ,   s , [])
+  opPT     RWSPT (RWSputs p refl)     f P (e , s) =
+    P (unit , p s , [])
+  opPT     RWSPT (RWSask refl)        f P (e , s) =
+    P (e    ,   s , [])
+  opPT     RWSPT (RWSlocal l)         f P (e , s) =
+    ∀ e' → e' ≡ l e → f (lift unit) P (e' , s)
+  opPT     RWSPT (RWStell out refl)   f P (e , s) =
+    P (unit ,   s , out)
+  opPT     RWSPT (RWSlisten{A'} refl) f P (e , s) =
+    f (lift unit) (RWSlistenPost P) (e , s)
+  opPT     RWSPT{A} RWSpass           f P (e , s) =
+    f (lift unit) (RWSpassPost P)   (e , s)
 
   ------------------------------------------------------------------------------
   open ASTPredTransMono
@@ -195,25 +195,25 @@ module RWSSyntax where
   open RWSBase
 
   gets : ∀ {A} → (St → A) → RWSAST A
-  gets g = ASTop (Left (RWSgets g)) λ ()
+  gets g = ASTop (left (RWSgets g)) λ ()
 
   puts : (St → St) → RWSAST Unit
-  puts p = ASTop (Left (RWSputs p refl)) (λ ())
+  puts p = ASTop (left (RWSputs p refl)) (λ ())
 
   ask : RWSAST Ev
-  ask = ASTop (Left (RWSask refl)) (λ ())
+  ask = ASTop (left (RWSask refl)) (λ ())
 
   local : ∀ {A} → (Ev → Ev) → RWSAST A → RWSAST A
-  local l m = ASTop (Left (RWSlocal l)) (λ where (lift unit) → m)
+  local l m = ASTop (left (RWSlocal l)) (λ where (lift unit) → m)
 
   tell : List Wr → RWSAST Unit
-  tell outs = ASTop (Left (RWStell outs refl)) (λ ())
+  tell outs = ASTop (left (RWStell outs refl)) (λ ())
 
   listen : ∀ {A} → RWSAST A → RWSAST (A × List Wr)
-  listen m = ASTop (Left (RWSlisten refl)) λ where (lift unit) → m
+  listen m = ASTop (left (RWSlisten refl)) λ where (lift unit) → m
 
   pass : ∀ {A} → RWSAST (A × (List Wr → List Wr)) → RWSAST A
-  pass m = ASTop (Left RWSpass) (λ where (lift unit) → m)
+  pass m = ASTop (left RWSpass) (λ where (lift unit) → m)
 
 open RWSSyntax public
 
@@ -225,9 +225,9 @@ module RWSExample where
 
     prog₁ : (St → Wr) → RWSAST Unit
     prog₁ g =
-      ASTop (Left RWSpass) λ _ →
-        ASTbind (ASTop (Left (RWSgets g)) λ ()) λ w →
-        ASTbind (ASTop (Left (RWStell (w ∷ []) refl)) λ ()) λ _ →
+      ASTop (left RWSpass) λ _ →
+        ASTbind (ASTop (left (RWSgets g)) λ ()) λ w →
+        ASTbind (ASTop (left (RWStell (w ∷ []) refl)) λ ()) λ _ →
         ASTreturn (unit , λ o → o ++ o)
 
   prog₁' : (St → Wr) → RWSAST Unit

--- a/src/Dijkstra/AST/RWS.agda
+++ b/src/Dijkstra/AST/RWS.agda
@@ -95,7 +95,7 @@ module RWSBase where
   open ASTPredTrans
   RWSPT : ASTPredTrans RWSOps RWSTypes
   returnPT RWSPT x P (e , s) =
-    P (x , s , [])
+    P (x    ,   s , [])
   bindPT   RWSPT f (e , s0) P (x , s1 , outs) =
     ∀ r → r ≡ x → f r (RWSbindPost outs P) (e , s1)
   opPT     RWSPT (RWSgets g)          f P (e , s) =

--- a/src/Haskell/Modules/Either.agda
+++ b/src/Haskell/Modules/Either.agda
@@ -15,8 +15,6 @@ Either : ∀ {a b} → Set a → Set b → Set (a ℓ⊔ b)
 Either A B = A DS.⊎ B
 pattern Left  x = DS.inj₁ x
 pattern Right x = DS.inj₂ x
-pattern left  x = DS.inj₁ x
-pattern right x = DS.inj₂ x
 
 either = DS.either
 


### PR DESCRIPTION
This PR contains no functional change, just formatting, naming, etc. for consistency with the paper (some changes made in the paper as well).

I'm creating the PR against branch `mark-make-ast-independent-of-haskell` so it's easy to review before #245 is merged, but it should be retargeted to `main-ast` after #245 is merged.